### PR TITLE
WIP: Print round events with some sanity checking

### DIFF
--- a/packet_handlers.go
+++ b/packet_handlers.go
@@ -84,6 +84,28 @@ func (p *Parser) handleGameEventList(gel *msg.CSVCMsg_GameEventList) {
 	}
 }
 
+type RoundEvents struct {
+	BeginNewMatch           int
+	CSWinPanelMatch         int
+	RoundAnnounceMatchStart int
+	RoundEnd                int
+	RoundFreezeEnd          int
+	RoundOfficiallyEnded    int
+	RoundStart              int
+}
+
+var round int
+var Rounds map[int]*RoundEvents
+
+func ensureExists(round int) {
+	if Rounds == nil {
+		Rounds = make(map[int]*RoundEvents)
+	}
+	if _, ok := Rounds[round]; !ok {
+		Rounds[round] = &RoundEvents{}
+	}
+}
+
 func (p *Parser) handleGameEvent(ge *msg.CSVCMsg_GameEvent) {
 	// TODO: Do we really need to do this check?
 	if p.gehDescriptors == nil {
@@ -99,8 +121,19 @@ func (p *Parser) handleGameEvent(ge *msg.CSVCMsg_GameEvent) {
 
 	var data map[string]*msg.CSVCMsg_GameEventKeyT
 
+	currRound := p.CTState().Score() + p.TState().Score() + 1
+	if round != currRound {
+		round = currRound
+		ensureExists(round)
+	}
+
 	switch d.Name {
+	case "round_announce_match_start": // Special round/match start announcement
+		Rounds[round].RoundAnnounceMatchStart++
+		p.eventDispatcher.Dispatch(events.MatchStartedEvent{})
+
 	case "round_start": // Round started
+		Rounds[round].RoundStart++
 		data = mapGameEventData(d, ge)
 		p.eventDispatcher.Dispatch(events.RoundStartedEvent{
 			TimeLimit: int(data["timelimit"].GetValLong()),
@@ -109,6 +142,7 @@ func (p *Parser) handleGameEvent(ge *msg.CSVCMsg_GameEvent) {
 		})
 
 	case "cs_win_panel_match": // Not sure, maybe match end event???
+		Rounds[round].CSWinPanelMatch++
 		p.eventDispatcher.Dispatch(events.WinPanelMatchEvent{})
 
 	case "round_announce_final": // 30th round for normal de_, not necessarily matchpoint
@@ -118,6 +152,7 @@ func (p *Parser) handleGameEvent(ge *msg.CSVCMsg_GameEvent) {
 		p.eventDispatcher.Dispatch(events.LastRoundHalfEvent{})
 
 	case "round_end": // Round ended and the winner was announced
+		Rounds[round].RoundEnd++
 		data = mapGameEventData(d, ge)
 
 		t := common.Team_Spectators
@@ -136,6 +171,8 @@ func (p *Parser) handleGameEvent(ge *msg.CSVCMsg_GameEvent) {
 		})
 
 	case "round_officially_ended": // Round ended. . . probably the event where you get teleported to the spawn (=> You can still walk around between round_end and this?)
+		Rounds[round-1].RoundOfficiallyEnded++
+		data = mapGameEventData(d, ge)
 		p.eventDispatcher.Dispatch(events.RoundOfficialyEndedEvent{})
 
 	case "round_mvp": // Round MVP was announced
@@ -152,9 +189,11 @@ func (p *Parser) handleGameEvent(ge *msg.CSVCMsg_GameEvent) {
 		p.eventDispatcher.Dispatch(events.BotTakenOverEvent{Taker: p.connectedPlayers[int(data["userid"].GetValShort())]})
 
 	case "begin_new_match": // Match started
+		Rounds[round].BeginNewMatch++
 		p.eventDispatcher.Dispatch(events.MatchStartedEvent{})
 
 	case "round_freeze_end": // Round start freeze ended
+		Rounds[round].RoundFreezeEnd++
 		p.eventDispatcher.Dispatch(events.FreezetimeEndedEvent{})
 
 	case "player_footstep": // Footstep sound
@@ -399,7 +438,6 @@ func (p *Parser) handleGameEvent(ge *msg.CSVCMsg_GameEvent) {
 
 	// Probably not that interesting:
 	case "buytime_ended": // Not actually end of buy time, seems to only be sent once per game at the start
-	case "round_announce_match_start": // Special match start announcement
 	case "bomb_beep": // Bomb beep
 	case "player_spawn": // Player spawn
 	case "hltv_status": // Don't know

--- a/parsing.go
+++ b/parsing.go
@@ -8,6 +8,7 @@ import (
 	"github.com/markus-wa/demoinfocs-golang/events"
 	st "github.com/markus-wa/demoinfocs-golang/sendtables"
 	"os"
+	"sort"
 	"strconv"
 	"strings"
 )
@@ -62,6 +63,46 @@ func (p *Parser) ParseToEnd() error {
 
 		default:
 			if !p.ParseNextFrame() {
+				fmt.Printf("%s %s\n", p.header.ServerName, p.header.MapName)
+				roundNumbers := make([]int, 0)
+				for roundNumber, _ := range Rounds {
+					roundNumbers = append(roundNumbers, roundNumber)
+				}
+				sort.Ints(roundNumbers)
+				for _, roundNumber := range roundNumbers {
+					if roundNumber == roundNumbers[len(roundNumbers)-1] {
+						continue
+					}
+					messages := make([]string, 0)
+					round := Rounds[roundNumber]
+					messages = append(messages, fmt.Sprintf("Round %d\n", roundNumber))
+					if (roundNumber == 1) && (round.BeginNewMatch != 1) {
+						messages = append(messages, fmt.Sprintf("Expected 1 begin_new_match event, got %d\n", round.BeginNewMatch))
+					}
+					if (roundNumber == 1) && (round.RoundAnnounceMatchStart != 1) {
+						messages = append(messages, fmt.Sprintf("Expected 1 round_announce_match_start event, got %d\n", round.RoundAnnounceMatchStart))
+					}
+					if (roundNumber+1 == len(Rounds)) && (round.CSWinPanelMatch != 1) {
+						messages = append(messages, fmt.Sprintf("Expected 1 cs_win_panel_match event, got %d\n", round.CSWinPanelMatch))
+					}
+					if round.RoundEnd != 1 {
+						messages = append(messages, fmt.Sprintf("Expected 1 round_end event, got %d\n", round.RoundEnd))
+					}
+					if round.RoundFreezeEnd != 1 {
+						messages = append(messages, fmt.Sprintf("Expected 1 round_freeze_end event, got %d\n", round.RoundFreezeEnd))
+					}
+					if round.RoundOfficiallyEnded != 1 {
+						messages = append(messages, fmt.Sprintf("Expected 1 round_officially_ended_event event, got %d\n", round.RoundOfficiallyEnded))
+					}
+					if round.RoundStart != 1 {
+						messages = append(messages, fmt.Sprintf("Expected 1 round_start event, got %d\n", round.RoundStart))
+					}
+					if len(messages) > 1 {
+						for _, message := range messages {
+							fmt.Print(message)
+						}
+					}
+				}
 				return nil
 			}
 		}


### PR DESCRIPTION
Experiment for seeing how often certain events happen per match and round, some seem to differ on older demos, but a bunch are pretty consistent for modern demos, depending on which plugin is used to record the server demos.

Some demos start at the end of the first freeze time and some start at map change and some start at the beginning of the first freeze time of the actual match.