### PR TITLE
Revert to use entity id instead of entity

### DIFF
--- a/events/events.go
+++ b/events/events.go
@@ -112,10 +112,10 @@ type NadeEventIf interface {
 // NadeEvent contains the common attributes of nade events. Dont register
 // handlers on this tho, you want NadeEventIf for that
 type NadeEvent struct {
-	NadeType common.EquipmentElement
-	Position r3.Vector
-	Thrower  *common.Player
-	EntityID int
+	NadeType     common.EquipmentElement
+	Position     r3.Vector
+	Thrower      *common.Player
+	NadeEntityID int
 }
 
 // Make NadeEvents implement NadeEventIf

--- a/events/events.go
+++ b/events/events.go
@@ -6,6 +6,7 @@ import (
 
 	common "github.com/markus-wa/demoinfocs-golang/common"
 	msg "github.com/markus-wa/demoinfocs-golang/msg"
+	st "github.com/markus-wa/demoinfocs-golang/sendtables"
 )
 
 // HeaderParsedEvent signals that the header has been parsed.
@@ -112,9 +113,10 @@ type NadeEventIf interface {
 // NadeEvent contains the common attributes of nade events. Dont register
 // handlers on this tho, you want NadeEventIf for that
 type NadeEvent struct {
-	NadeType common.EquipmentElement
-	Position r3.Vector
-	Thrower  *common.Player
+	NadeType   common.EquipmentElement
+	Position   r3.Vector
+	Thrower    *common.Player
+	NadeEntity *st.Entity
 }
 
 // Make NadeEvents implement NadeEventIf

--- a/events/events.go
+++ b/events/events.go
@@ -6,7 +6,6 @@ import (
 
 	common "github.com/markus-wa/demoinfocs-golang/common"
 	msg "github.com/markus-wa/demoinfocs-golang/msg"
-	st "github.com/markus-wa/demoinfocs-golang/sendtables"
 )
 
 // HeaderParsedEvent signals that the header has been parsed.
@@ -113,10 +112,10 @@ type NadeEventIf interface {
 // NadeEvent contains the common attributes of nade events. Dont register
 // handlers on this tho, you want NadeEventIf for that
 type NadeEvent struct {
-	NadeType   common.EquipmentElement
-	Position   r3.Vector
-	Thrower    *common.Player
-	NadeEntity *st.Entity
+	NadeType common.EquipmentElement
+	Position r3.Vector
+	Thrower  *common.Player
+	EntityID int
 }
 
 // Make NadeEvents implement NadeEventIf

--- a/game_events.go
+++ b/game_events.go
@@ -181,32 +181,32 @@ func (p *Parser) handleGameEvent(ge *msg.CSVCMsg_GameEvent) {
 			Y: float64(data["y"].ValFloat),
 			Z: float64(data["z"].ValFloat),
 		}
-		entityID := int(data["entityid"].GetValShort())
+		nadeEntityID := int(data["entityid"].GetValShort())
 
 		switch d.Name {
 		case "flashbang_detonate": // Flash exploded
-			p.eventDispatcher.Dispatch(events.FlashExplodedEvent{NadeEvent: buildNadeEvent(common.EqFlash, thrower, position, entityID)})
+			p.eventDispatcher.Dispatch(events.FlashExplodedEvent{NadeEvent: buildNadeEvent(common.EqFlash, thrower, position, nadeEntityID)})
 
 		case "hegrenade_detonate": // HE exploded
-			p.eventDispatcher.Dispatch(events.HeExplodedEvent{NadeEvent: buildNadeEvent(common.EqHE, thrower, position, entityID)})
+			p.eventDispatcher.Dispatch(events.HeExplodedEvent{NadeEvent: buildNadeEvent(common.EqHE, thrower, position, nadeEntityID)})
 
 		case "decoy_started": // Decoy started
-			p.eventDispatcher.Dispatch(events.DecoyStartEvent{NadeEvent: buildNadeEvent(common.EqDecoy, thrower, position, entityID)})
+			p.eventDispatcher.Dispatch(events.DecoyStartEvent{NadeEvent: buildNadeEvent(common.EqDecoy, thrower, position, nadeEntityID)})
 
 		case "decoy_detonate": // Decoy exploded/expired
-			p.eventDispatcher.Dispatch(events.DecoyEndEvent{NadeEvent: buildNadeEvent(common.EqDecoy, thrower, position, entityID)})
+			p.eventDispatcher.Dispatch(events.DecoyEndEvent{NadeEvent: buildNadeEvent(common.EqDecoy, thrower, position, nadeEntityID)})
 
 		case "smokegrenade_detonate": // Smoke popped
-			p.eventDispatcher.Dispatch(events.SmokeStartEvent{NadeEvent: buildNadeEvent(common.EqSmoke, thrower, position, entityID)})
+			p.eventDispatcher.Dispatch(events.SmokeStartEvent{NadeEvent: buildNadeEvent(common.EqSmoke, thrower, position, nadeEntityID)})
 
 		case "smokegrenade_expired": // Smoke expired
-			p.eventDispatcher.Dispatch(events.SmokeEndEvent{NadeEvent: buildNadeEvent(common.EqSmoke, thrower, position, entityID)})
+			p.eventDispatcher.Dispatch(events.SmokeEndEvent{NadeEvent: buildNadeEvent(common.EqSmoke, thrower, position, nadeEntityID)})
 
 		case "inferno_startburn": // Incendiary exploded/started
-			p.eventDispatcher.Dispatch(events.FireNadeStartEvent{NadeEvent: buildNadeEvent(common.EqIncendiary, thrower, position, entityID)})
+			p.eventDispatcher.Dispatch(events.FireNadeStartEvent{NadeEvent: buildNadeEvent(common.EqIncendiary, thrower, position, nadeEntityID)})
 
 		case "inferno_expire": // Incendiary expired
-			p.eventDispatcher.Dispatch(events.FireNadeEndEvent{NadeEvent: buildNadeEvent(common.EqIncendiary, thrower, position, entityID)})
+			p.eventDispatcher.Dispatch(events.FireNadeEndEvent{NadeEvent: buildNadeEvent(common.EqIncendiary, thrower, position, nadeEntityID)})
 		}
 
 	case "player_connect": // Bot connected or player reconnected, players normally come in via string tables & data tables
@@ -447,12 +447,12 @@ func mapGameEventData(d *msg.CSVCMsg_GameEventListDescriptorT, e *msg.CSVCMsg_Ga
 }
 
 // Just so we can nicely create NadeEvents in one line
-func buildNadeEvent(nadeType common.EquipmentElement, thrower *common.Player, position r3.Vector, entityID int) events.NadeEvent {
+func buildNadeEvent(nadeType common.EquipmentElement, thrower *common.Player, position r3.Vector, nadeEntityID int) events.NadeEvent {
 	return events.NadeEvent{
-		NadeType: nadeType,
-		Thrower:  thrower,
-		Position: position,
-		EntityID: entityID,
+		NadeType:     nadeType,
+		Thrower:      thrower,
+		Position:     position,
+		NadeEntityID: nadeEntityID,
 	}
 }
 

--- a/game_events.go
+++ b/game_events.go
@@ -9,6 +9,7 @@ import (
 	common "github.com/markus-wa/demoinfocs-golang/common"
 	events "github.com/markus-wa/demoinfocs-golang/events"
 	msg "github.com/markus-wa/demoinfocs-golang/msg"
+	st "github.com/markus-wa/demoinfocs-golang/sendtables"
 )
 
 func (p *Parser) handleGameEventList(gel *msg.CSVCMsg_GameEventList) {
@@ -181,31 +182,32 @@ func (p *Parser) handleGameEvent(ge *msg.CSVCMsg_GameEvent) {
 			Y: float64(data["y"].ValFloat),
 			Z: float64(data["z"].ValFloat),
 		}
+		nadeEntity := p.entities[int(data["entityid"].GetValShort())]
 
 		switch d.Name {
 		case "flashbang_detonate": // Flash exploded
-			p.eventDispatcher.Dispatch(events.FlashExplodedEvent{NadeEvent: buildNadeEvent(common.EqFlash, thrower, position)})
+			p.eventDispatcher.Dispatch(events.FlashExplodedEvent{NadeEvent: buildNadeEvent(common.EqFlash, thrower, position, nadeEntity)})
 
 		case "hegrenade_detonate": // HE exploded
-			p.eventDispatcher.Dispatch(events.HeExplodedEvent{NadeEvent: buildNadeEvent(common.EqHE, thrower, position)})
+			p.eventDispatcher.Dispatch(events.HeExplodedEvent{NadeEvent: buildNadeEvent(common.EqHE, thrower, position, nadeEntity)})
 
 		case "decoy_started": // Decoy started
-			p.eventDispatcher.Dispatch(events.DecoyStartEvent{NadeEvent: buildNadeEvent(common.EqDecoy, thrower, position)})
+			p.eventDispatcher.Dispatch(events.DecoyStartEvent{NadeEvent: buildNadeEvent(common.EqDecoy, thrower, position, nadeEntity)})
 
 		case "decoy_detonate": // Decoy exploded/expired
-			p.eventDispatcher.Dispatch(events.DecoyEndEvent{NadeEvent: buildNadeEvent(common.EqDecoy, thrower, position)})
+			p.eventDispatcher.Dispatch(events.DecoyEndEvent{NadeEvent: buildNadeEvent(common.EqDecoy, thrower, position, nadeEntity)})
 
 		case "smokegrenade_detonate": // Smoke popped
-			p.eventDispatcher.Dispatch(events.SmokeStartEvent{NadeEvent: buildNadeEvent(common.EqSmoke, thrower, position)})
+			p.eventDispatcher.Dispatch(events.SmokeStartEvent{NadeEvent: buildNadeEvent(common.EqSmoke, thrower, position, nadeEntity)})
 
 		case "smokegrenade_expired": // Smoke expired
-			p.eventDispatcher.Dispatch(events.SmokeEndEvent{NadeEvent: buildNadeEvent(common.EqSmoke, thrower, position)})
+			p.eventDispatcher.Dispatch(events.SmokeEndEvent{NadeEvent: buildNadeEvent(common.EqSmoke, thrower, position, nadeEntity)})
 
 		case "inferno_startburn": // Incendiary exploded/started
-			p.eventDispatcher.Dispatch(events.FireNadeStartEvent{NadeEvent: buildNadeEvent(common.EqIncendiary, thrower, position)})
+			p.eventDispatcher.Dispatch(events.FireNadeStartEvent{NadeEvent: buildNadeEvent(common.EqIncendiary, thrower, position, nadeEntity)})
 
 		case "inferno_expire": // Incendiary expired
-			p.eventDispatcher.Dispatch(events.FireNadeEndEvent{NadeEvent: buildNadeEvent(common.EqIncendiary, thrower, position)})
+			p.eventDispatcher.Dispatch(events.FireNadeEndEvent{NadeEvent: buildNadeEvent(common.EqIncendiary, thrower, position, nadeEntity)})
 		}
 
 	case "player_connect": // Bot connected or player reconnected, players normally come in via string tables & data tables
@@ -446,11 +448,12 @@ func mapGameEventData(d *msg.CSVCMsg_GameEventListDescriptorT, e *msg.CSVCMsg_Ga
 }
 
 // Just so we can nicely create NadeEvents in one line
-func buildNadeEvent(nadeType common.EquipmentElement, thrower *common.Player, position r3.Vector) events.NadeEvent {
+func buildNadeEvent(nadeType common.EquipmentElement, thrower *common.Player, position r3.Vector, nadeEntity *st.Entity) events.NadeEvent {
 	return events.NadeEvent{
-		NadeType: nadeType,
-		Thrower:  thrower,
-		Position: position,
+		NadeType:   nadeType,
+		Thrower:    thrower,
+		Position:   position,
+		NadeEntity: nadeEntity,
 	}
 }
 

--- a/game_events.go
+++ b/game_events.go
@@ -9,7 +9,6 @@ import (
 	common "github.com/markus-wa/demoinfocs-golang/common"
 	events "github.com/markus-wa/demoinfocs-golang/events"
 	msg "github.com/markus-wa/demoinfocs-golang/msg"
-	st "github.com/markus-wa/demoinfocs-golang/sendtables"
 )
 
 func (p *Parser) handleGameEventList(gel *msg.CSVCMsg_GameEventList) {
@@ -182,32 +181,32 @@ func (p *Parser) handleGameEvent(ge *msg.CSVCMsg_GameEvent) {
 			Y: float64(data["y"].ValFloat),
 			Z: float64(data["z"].ValFloat),
 		}
-		nadeEntity := p.entities[int(data["entityid"].GetValShort())]
+		entityID := int(data["entityid"].GetValShort())
 
 		switch d.Name {
 		case "flashbang_detonate": // Flash exploded
-			p.eventDispatcher.Dispatch(events.FlashExplodedEvent{NadeEvent: buildNadeEvent(common.EqFlash, thrower, position, nadeEntity)})
+			p.eventDispatcher.Dispatch(events.FlashExplodedEvent{NadeEvent: buildNadeEvent(common.EqFlash, thrower, position, entityID)})
 
 		case "hegrenade_detonate": // HE exploded
-			p.eventDispatcher.Dispatch(events.HeExplodedEvent{NadeEvent: buildNadeEvent(common.EqHE, thrower, position, nadeEntity)})
+			p.eventDispatcher.Dispatch(events.HeExplodedEvent{NadeEvent: buildNadeEvent(common.EqHE, thrower, position, entityID)})
 
 		case "decoy_started": // Decoy started
-			p.eventDispatcher.Dispatch(events.DecoyStartEvent{NadeEvent: buildNadeEvent(common.EqDecoy, thrower, position, nadeEntity)})
+			p.eventDispatcher.Dispatch(events.DecoyStartEvent{NadeEvent: buildNadeEvent(common.EqDecoy, thrower, position, entityID)})
 
 		case "decoy_detonate": // Decoy exploded/expired
-			p.eventDispatcher.Dispatch(events.DecoyEndEvent{NadeEvent: buildNadeEvent(common.EqDecoy, thrower, position, nadeEntity)})
+			p.eventDispatcher.Dispatch(events.DecoyEndEvent{NadeEvent: buildNadeEvent(common.EqDecoy, thrower, position, entityID)})
 
 		case "smokegrenade_detonate": // Smoke popped
-			p.eventDispatcher.Dispatch(events.SmokeStartEvent{NadeEvent: buildNadeEvent(common.EqSmoke, thrower, position, nadeEntity)})
+			p.eventDispatcher.Dispatch(events.SmokeStartEvent{NadeEvent: buildNadeEvent(common.EqSmoke, thrower, position, entityID)})
 
 		case "smokegrenade_expired": // Smoke expired
-			p.eventDispatcher.Dispatch(events.SmokeEndEvent{NadeEvent: buildNadeEvent(common.EqSmoke, thrower, position, nadeEntity)})
+			p.eventDispatcher.Dispatch(events.SmokeEndEvent{NadeEvent: buildNadeEvent(common.EqSmoke, thrower, position, entityID)})
 
 		case "inferno_startburn": // Incendiary exploded/started
-			p.eventDispatcher.Dispatch(events.FireNadeStartEvent{NadeEvent: buildNadeEvent(common.EqIncendiary, thrower, position, nadeEntity)})
+			p.eventDispatcher.Dispatch(events.FireNadeStartEvent{NadeEvent: buildNadeEvent(common.EqIncendiary, thrower, position, entityID)})
 
 		case "inferno_expire": // Incendiary expired
-			p.eventDispatcher.Dispatch(events.FireNadeEndEvent{NadeEvent: buildNadeEvent(common.EqIncendiary, thrower, position, nadeEntity)})
+			p.eventDispatcher.Dispatch(events.FireNadeEndEvent{NadeEvent: buildNadeEvent(common.EqIncendiary, thrower, position, entityID)})
 		}
 
 	case "player_connect": // Bot connected or player reconnected, players normally come in via string tables & data tables
@@ -448,12 +447,12 @@ func mapGameEventData(d *msg.CSVCMsg_GameEventListDescriptorT, e *msg.CSVCMsg_Ga
 }
 
 // Just so we can nicely create NadeEvents in one line
-func buildNadeEvent(nadeType common.EquipmentElement, thrower *common.Player, position r3.Vector, nadeEntity *st.Entity) events.NadeEvent {
+func buildNadeEvent(nadeType common.EquipmentElement, thrower *common.Player, position r3.Vector, entityID int) events.NadeEvent {
 	return events.NadeEvent{
-		NadeType:   nadeType,
-		Thrower:    thrower,
-		Position:   position,
-		NadeEntity: nadeEntity,
+		NadeType: nadeType,
+		Thrower:  thrower,
+		Position: position,
+		EntityID: entityID,
 	}
 }
 

--- a/parser.go
+++ b/parser.go
@@ -79,6 +79,11 @@ func (p *Parser) GameState() *GameState {
 	return &p.gameState
 }
 
+// Entities returns the available entities
+func (p *Parser) Entities() map[int]*st.Entity {
+	return p.entities
+}
+
 // CurrentFrame return the number of the current frame, aka. 'demo-tick' (Since demos often have a different tick-rate than the game).
 // Starts with frame 0, should go up to DemoHeader.PlaybackFrames but might not be the case (usually it's just close to it).
 func (p *Parser) CurrentFrame() int {


### PR DESCRIPTION
The solution with using the entity doesn't really work. For some nades (e.g. molotov), the entity is deleted. If we have the ID, while we cannot access the entity, we can at least relate the different events (throw, explode, expire).