### PR TITLE
Track player equipment

### DIFF
--- a/common/structs.go
+++ b/common/structs.go
@@ -65,6 +65,8 @@ type Player struct {
 	HasDefuseKit                bool
 	HasHelmet                   bool
 	Connected                   bool
+
+	CurrentEquipment map[int64]*Equipment
 }
 
 // IsAlive returns true if the Hp of the player are > 0.
@@ -100,6 +102,7 @@ type Equipment struct {
 	AmmoType       int
 	Owner          *Player
 	ReserveAmmo    int
+	uniqueID       int64
 }
 
 // GrenadeProjectile is a grenade thrown intentionally by a player. It is used to track grenade projectile
@@ -127,7 +130,9 @@ func NewGrenadeProjectile() *GrenadeProjectile {
 	return &GrenadeProjectile{uniqueID: rand.Int63()}
 }
 
-// UniqueID returns the internal id of the grenade, which is used to distinguish grenades that reuse another entity's entity id.
+// UniqueID returns the unique id of the grenade.
+// The unique id is a random int generated internally by this library and can be used to differentiate
+// grenades from each other. This is needed because demo-files reuse entity ids.
 func (g GrenadeProjectile) UniqueID() int64 {
 	return g.uniqueID
 }
@@ -145,10 +150,17 @@ func NewSkinEquipment(eqName string, skinID string) Equipment {
 	} else {
 		wep = EqUnknown
 	}
-	return Equipment{Weapon: wep, SkinID: skinID}
+	return Equipment{Weapon: wep, SkinID: skinID, uniqueID: rand.Int63()}
+}
+
+// UniqueID returns the unique id of the equipment element.
+// The unique id is a random int generated internally by this library and can be used to differentiate
+// equipment from each other. This is needed because demo-files reuse entity ids.
+func (e Equipment) UniqueID() int64 {
+	return e.uniqueID
 }
 
 // NewPlayer creates a *Player with an initialized equipment map.
 func NewPlayer() *Player {
-	return &Player{RawWeapons: make(map[int]*Equipment)}
+	return &Player{RawWeapons: make(map[int]*Equipment), CurrentEquipment: make(map[int64]*Equipment)}
 }

--- a/datatables.go
+++ b/datatables.go
@@ -289,10 +289,6 @@ func (p *Parser) bindNewPlayer(playerEntity *st.Entity) {
 }
 
 func (p *Parser) bindWeapons() {
-	for i := 0; i < maxEntities; i++ {
-		p.weapons[i] = common.NewEquipment("")
-	}
-
 	for _, sc := range p.stParser.ServerClasses() {
 		for _, bc := range sc.BaseClasses {
 			switch bc.Name {
@@ -328,22 +324,29 @@ func (p *Parser) bindGrenadeProjectiles(event st.EntityCreatedEvent) {
 
 	// @micvbang: not quite sure what the difference between Thrower and Owner is.
 	event.Entity.FindProperty("m_hThrower").RegisterPropertyUpdateHandler(func(val st.PropValue) {
-		throwerID := val.IntVal & indexMask
-		throwerIndex := throwerID - 1
+		proj.Thrower = p.propValueToPlayer(val)
 
-		thrower := p.entityIDToPlayers[throwerIndex]
-		proj.Thrower = thrower
+		// The Owner of a grenade is not modified in CWeaponCSBase when the grenade is thrown. In order to keep
+		// Player.CurrentEquipment updated, we remove thrown grenades here.
+		// @micvbang FYI: once a grenade is thrown it becomes a grenade projectile. The entity ID of a grenade
+		// projectile is _not_ the same as the grenade that was thrown. I haven't been able to find a better
+		// way to identify the thrown grenade, other than simply looping over all CurrentEquipment.
+		for _, eq := range proj.Thrower.CurrentEquipment {
+			if eq.Weapon == proj.Weapon {
+				ammo := proj.Thrower.AmmoLeft[eq.AmmoType]
 
-		if proj.Thrower == nil && thrower != nil {
-			proj.Position = thrower.Position
+				// Flashbang has more ammo, don't remove yet.
+				if eq.Weapon == common.EqFlash && ammo == 1 {
+					continue
+				}
+
+				delete(proj.Thrower.CurrentEquipment, eq.UniqueID())
+			}
 		}
 	})
 
 	event.Entity.FindProperty("m_hOwnerEntity").RegisterPropertyUpdateHandler(func(val st.PropValue) {
-		ownerID := val.IntVal & indexMask
-		ownerIndex := ownerID - 1
-		player := p.entityIDToPlayers[ownerIndex]
-		proj.Owner = player
+		proj.Owner = p.propValueToPlayer(val)
 	})
 
 	event.Entity.FindProperty("m_vecOrigin").RegisterPropertyUpdateHandler(func(val st.PropValue) {
@@ -351,11 +354,18 @@ func (p *Parser) bindGrenadeProjectiles(event st.EntityCreatedEvent) {
 	})
 }
 
+func (p *Parser) propValueToPlayer(val st.PropValue) *common.Player {
+	entityID := val.IntVal & indexMask
+	return p.entityIDToPlayers[entityID-1]
+}
+
 func (p *Parser) bindWeapon(event st.EntityCreatedEvent) {
-	eq := &p.weapons[event.Entity.ID]
+	eq := common.NewEquipment("")
+	p.weapons[event.Entity.ID] = eq
 	eq.EntityID = event.Entity.ID
 	eq.Weapon = p.equipmentMapping[event.ServerClass]
 	eq.AmmoInMagazine = -1
+	eq.Owner = p.propValueToPlayer(event.Entity.FindProperty("m_hOwnerEntity").Value())
 
 	event.Entity.FindProperty("m_iClip1").RegisterPropertyUpdateHandler(func(val st.PropValue) {
 		eq.AmmoInMagazine = val.IntVal - 1
@@ -387,4 +397,27 @@ func (p *Parser) bindWeapon(event st.EntityCreatedEvent) {
 	case common.EqP250:
 		wepFix("_pist_p250", "_pist_cz_75", func() { eq.Weapon = common.EqCZ })
 	}
+
+	event.Entity.FindProperty("m_hPrevOwner").RegisterPropertyUpdateHandler(func(val st.PropValue) {
+		prevOwner := p.propValueToPlayer(val)
+		owner := p.propValueToPlayer(event.Entity.FindProperty("m_hOwnerEntity").Value())
+		if prevOwner != nil && owner != nil && owner.SteamID != prevOwner.SteamID {
+			delete(prevOwner.CurrentEquipment, eq.UniqueID())
+		}
+	})
+
+	event.Entity.FindProperty("m_hOwnerEntity").RegisterPropertyUpdateHandler(func(val st.PropValue) {
+		owner := p.propValueToPlayer(val)
+
+		if owner != nil {
+			owner.CurrentEquipment[eq.UniqueID()] = &eq
+		}
+
+		// Owner changed to nil, remove equipment from old owner
+		if owner == nil && eq.Owner != nil {
+			delete(eq.Owner.CurrentEquipment, eq.UniqueID())
+		}
+
+		eq.Owner = owner
+	})
 }

--- a/game_events.go
+++ b/game_events.go
@@ -360,6 +360,16 @@ func (p *Parser) handleGameEvent(ge *msg.CSVCMsg_GameEvent) {
 				Weapon: weapon,
 			})
 		case "item_remove":
+			// Under the assumption that a player can only have one of each type of weapon,
+			// we can safely find it in CurrentEquipment by looping through and comparing on
+			// the EquipmentElement.
+			for _, eq := range player.CurrentEquipment {
+				if eq.Weapon == weapon.Weapon {
+					delete(player.CurrentEquipment, eq.UniqueID())
+					break
+				}
+			}
+
 			p.eventDispatcher.Dispatch(events.ItemDropEvent{
 				Player: player,
 				Weapon: weapon,
@@ -406,7 +416,6 @@ func (p *Parser) handleGameEvent(ge *msg.CSVCMsg_GameEvent) {
 	case "cs_pre_restart": // Not sure, doesn't seem to be important
 		fallthrough
 	case "round_prestart": // Ditto
-		// @micvbang TODO: do we need to reset player equipment here?
 		fallthrough
 	case "round_poststart": // Ditto
 		fallthrough

--- a/game_events.go
+++ b/game_events.go
@@ -129,9 +129,11 @@ func (p *Parser) handleGameEvent(ge *msg.CSVCMsg_GameEvent) {
 
 		killer := p.gameState.players[int(data["attacker"].GetValShort())]
 		wep := common.NewSkinEquipment(data["weapon"].GetValString(), data["weapon_itemid"].GetValString())
+		victim := p.gameState.players[int(data["userid"].GetValShort())]
+		victim.CurrentEquipment = make(map[int64]*common.Equipment)
 
 		p.eventDispatcher.Dispatch(events.PlayerKilledEvent{
-			Victim:            p.gameState.players[int(data["userid"].GetValShort())],
+			Victim:            victim,
 			Killer:            killer,
 			Assister:          p.gameState.players[int(data["assister"].GetValShort())],
 			IsHeadshot:        data["headshot"].GetValBool(),
@@ -404,6 +406,7 @@ func (p *Parser) handleGameEvent(ge *msg.CSVCMsg_GameEvent) {
 	case "cs_pre_restart": // Not sure, doesn't seem to be important
 		fallthrough
 	case "round_prestart": // Ditto
+		// @micvbang TODO: do we need to reset player equipment here?
 		fallthrough
 	case "round_poststart": // Ditto
 		fallthrough


### PR DESCRIPTION
I've been playing with tracking players' current equipment.

In order to keep the `Player.CurrentEquipment` updated, I unfortunately had to use the `player_death` game event for resetting a player's equipment when he dies, `item_remove` for resetting items on forced round restarts, as well as using `bindGrenadeProjectiles` to track when grenades are removed from the player's inventory. I have been unable to find other ways to retrieve this information.

Once again, this is something that I haven't tested thoroughly on a large amount of demos, but on the demos that I tested it with, it seems to work reasonably well. I have noticed one bug, though, which is that resetting equipment on forced round restarts doesn't always work 100%. An example can be found in https://www.hltv.org/matches/2322780/liquid-vs-astralis-esl-pro-league-season-7-finals on round 16, where Magisk incorrectly, according to `Player.CurrentEquipment` holds both a USP and a cz.

I'm making it available here for you to play with, and hope that you guys can come with suggestions on how to improve it :slightly_smiling_face: 