### PR TITLE
Add unique id to Equipment.

### DIFF
--- a/common/structs.go
+++ b/common/structs.go
@@ -108,6 +108,8 @@ type Equipment struct {
 	AmmoType       int
 	Owner          *Player
 	ReserveAmmo    int
+
+	uniqueID int64
 }
 
 // GrenadeProjectile is a grenade thrown intentionally by a player. It is used to track grenade projectile
@@ -130,12 +132,21 @@ func (e Equipment) Class() EquipmentClass {
 	return e.Weapon.Class()
 }
 
+// UniqueID returns the unique id of the equipment element.
+// The unique id is a random int generated internally by this library and can be used to differentiate
+// equipment from each other. This is needed because demo-files reuse entity ids.
+func (e Equipment) UniqueID() int64 {
+	return e.uniqueID
+}
+
 // NewGrenadeProjectile creates a grenade projectile and sets.
 func NewGrenadeProjectile() *GrenadeProjectile {
 	return &GrenadeProjectile{uniqueID: rand.Int63()}
 }
 
-// UniqueID returns the internal id of the grenade, which is used to distinguish grenades that reuse another entity's entity id.
+// UniqueID returns the unique id of the grenade.
+// The unique id is a random int generated internally by this library and can be used to differentiate
+// grenades from each other. This is needed because demo-files reuse entity ids.
 func (g GrenadeProjectile) UniqueID() int64 {
 	return g.uniqueID
 }
@@ -153,7 +164,7 @@ func NewSkinEquipment(eqName string, skinID string) Equipment {
 	} else {
 		wep = EqUnknown
 	}
-	return Equipment{Weapon: wep, SkinID: skinID}
+	return Equipment{Weapon: wep, SkinID: skinID, uniqueID: rand.Int63()}
 }
 
 // NewPlayer creates a *Player with an initialized equipment map.

--- a/datatables.go
+++ b/datatables.go
@@ -291,10 +291,6 @@ func (p *Parser) bindNewPlayer(playerEntity *st.Entity) {
 }
 
 func (p *Parser) bindWeapons() {
-	for i := 0; i < maxEntities; i++ {
-		p.weapons[i] = common.NewEquipment("")
-	}
-
 	for _, sc := range p.stParser.ServerClasses() {
 		for _, bc := range sc.BaseClasses {
 			switch bc.Name {
@@ -374,7 +370,8 @@ func (p *Parser) bindGrenadeProjectiles(event st.EntityCreatedEvent) {
 }
 
 func (p *Parser) bindWeapon(event st.EntityCreatedEvent) {
-	eq := &p.weapons[event.Entity.ID]
+	eq := common.NewEquipment("")
+	p.weapons[event.Entity.ID] = eq
 	eq.EntityID = event.Entity.ID
 	eq.Weapon = p.equipmentMapping[event.ServerClass]
 	eq.AmmoInMagazine = -1


### PR DESCRIPTION
As I argued for GrenadeProjectiles, I find it very useful as a consumer of the library to have unique ids on grenade projectiles. I find the same to be the case for equipment :slightly_smiling_face: 