### PR TITLE
 datatables: fix bug where entries in Parser.weapons are not updated correctly.

### DIFF
--- a/datatables.go
+++ b/datatables.go
@@ -370,8 +370,8 @@ func (p *Parser) bindGrenadeProjectiles(event st.EntityCreatedEvent) {
 }
 
 func (p *Parser) bindWeapon(event st.EntityCreatedEvent) {
-	eq := common.NewEquipment("")
-	p.weapons[event.Entity.ID] = eq
+	p.weapons[event.Entity.ID] = common.NewEquipment("")
+	eq := &p.weapons[event.Entity.ID]
 	eq.EntityID = event.Entity.ID
 	eq.Weapon = p.equipmentMapping[event.ServerClass]
 	eq.AmmoInMagazine = -1


### PR DESCRIPTION
I didn't catch this bug that I introduced when I was testing bb14185.

The effect is that the data on each weapon is never updated. This PR should fix it.