### PR TITLE
datatables: remove inferno from game state OnDestroy.

### DIFF
--- a/datatables.go
+++ b/datatables.go
@@ -386,6 +386,7 @@ func (p *Parser) bindNewInferno(entity *st.Entity) {
 		p.eventDispatcher.Dispatch(events.InfernoExpiredEvent{
 			Inferno: inf,
 		})
+		delete(p.gameState.infernos, entityID)
 	})
 
 	origin := entity.Position()


### PR DESCRIPTION
In order to keep `gameState.infernos` updated correctly, we need to delete them `OnDestroy` :slightly_smiling_face: 