### PR TITLE
Add GameState.Bomb()

### DIFF
--- a/common/structs.go
+++ b/common/structs.go
@@ -245,3 +245,9 @@ func (inf Inferno) ConvexHull3D() *s2.Loop {
 func NewInferno() *Inferno {
 	return &Inferno{uniqueID: rand.Int63()}
 }
+
+// Bomb tracks the bomb's position, and the player carrying it, if any.
+type Bomb struct {
+	Position r3.Vector
+	Player   *Player
+}

--- a/common/structs.go
+++ b/common/structs.go
@@ -248,6 +248,19 @@ func NewInferno() *Inferno {
 
 // Bomb tracks the bomb's position, and the player carrying it, if any.
 type Bomb struct {
-	Position r3.Vector
-	Player   *Player
+	// Intended for internal use only. Use Position() instead.
+	// Contains the last location of the dropped or planted bomb.
+	LastOnGroundPosition r3.Vector
+	Carrier              *Player
+}
+
+// Position returns the current position of the bomb.
+// This is either the position of the player holding it
+// or LastOnGroundPosition if it's dropped or planted.
+func (b Bomb) Position() r3.Vector {
+	if b.Carrier != nil {
+		return b.Carrier.Position
+	}
+
+	return b.LastOnGroundPosition
 }

--- a/datatables.go
+++ b/datatables.go
@@ -94,12 +94,6 @@ func (p *Parser) bindBomb() {
 	// Track bomb when it is being held by a player
 	scPlayerC4 := p.stParser.ServerClasses().FindByName("CC4")
 	scPlayerC4.OnEntityCreated(func(bombEntity *st.Entity) {
-		// TODO: @micvbang please document why this was introduced
-		wep := p.equipmentMapping[scPlayerC4]
-		if wep != common.EqBomb {
-			return
-		}
-
 		bombEntity.FindProperty("m_hOwner").OnUpdate(func(val st.PropertyValue) {
 			ownerEntityID := val.IntVal & entityHandleIndexMask
 			bomb.Carrier = p.gameState.playersByEntityID[ownerEntityID]

--- a/datatables.go
+++ b/datatables.go
@@ -29,7 +29,6 @@ func (p *Parser) mapEquipment() {
 			if bc.Name() == "CBaseGrenade" { // Grenades projectiles, i.e. thrown by player
 				p.equipmentMapping[sc] = common.MapEquipment(strings.ToLower(sc.DataTableName()[3:]))
 			}
-
 		}
 
 		if len(baseClasses) > 6 && baseClasses[6].Name() == "CWeaponCSBase" {
@@ -372,6 +371,7 @@ func (p *Parser) bindGrenadeProjectiles(entity *st.Entity) {
 		p.eventDispatcher.Dispatch(events.NadeProjectileDestroyedEvent{
 			Projectile: proj,
 		})
+
 		delete(p.gameState.grenadeProjectiles, entityID)
 	})
 

--- a/datatables.go
+++ b/datatables.go
@@ -29,6 +29,7 @@ func (p *Parser) mapEquipment() {
 			if bc.Name() == "CBaseGrenade" { // Grenades projectiles, i.e. thrown by player
 				p.equipmentMapping[sc] = common.MapEquipment(strings.ToLower(sc.DataTableName()[3:]))
 			}
+
 		}
 
 		if len(baseClasses) > 6 && baseClasses[6].Name() == "CWeaponCSBase" {
@@ -65,6 +66,89 @@ func (p *Parser) bindEntities() {
 	p.bindBombSites()
 	p.bindPlayers()
 	p.bindWeapons()
+	p.bindBomb()
+}
+
+func (p *Parser) bindBomb() {
+	p.gameState.bomb = common.Bomb{}
+	bomb := &p.gameState.bomb
+
+	// Track bomb when it is not held by a player
+	p.stParser.ServerClasses().FindByName("CC4").OnEntityCreated(func(bomb *st.Entity) {
+		bomb.OnPositionUpdate(func(pos r3.Vector) {
+			p.gameState.bomb.Player = nil // Bomb only has a position when not held by a player
+			p.gameState.bomb.Position = pos
+		})
+	})
+
+	// Track bomb when it has been planted
+	scPlantedC4 := p.stParser.ServerClasses().FindByName("CPlantedC4")
+	scPlantedC4.OnEntityCreated(func(bombEntity *st.Entity) {
+		p.gameState.bomb.Player = nil // Player can't hold the bomb when it has been planted
+		bomb.Position = bombEntity.Position()
+	})
+
+	// Track bomb when it is being held by a player
+	scPlayerC4 := p.stParser.ServerClasses().FindByName("CC4")
+	scPlayerC4.OnEntityCreated(func(bombEntity *st.Entity) {
+		wep := p.equipmentMapping[scPlayerC4]
+		if wep != common.EqBomb {
+			return
+		}
+
+		// TODO: fix this hack to "unregister" OnUpdate handlers
+		handlerRegistered := make(map[int]bool)
+
+		bombEntity.FindProperty("m_hPrevOwner").OnUpdate(func(val st.PropertyValue) {
+			ownerEntityID := val.IntVal & entityHandleIndexMask
+			handlerRegistered[ownerEntityID] = false
+		})
+
+		bombEntity.FindProperty("m_hOwner").OnUpdate(func(val st.PropertyValue) {
+			// TODO: for performance, it would be nice to be able to unregister the
+			// potential previous OnUpdate registrations from below, here
+
+			ownerEntityID := val.IntVal & entityHandleIndexMask
+			owner := p.gameState.playersByEntityID[ownerEntityID]
+			if owner == nil {
+				return
+			}
+			handlerRegistered[ownerEntityID] = true
+
+			updateBombPosition := func() {
+				if !handlerRegistered[ownerEntityID] {
+					return
+				}
+
+				// Because of the way that bomb entities are created and destroyed, m_hOwner and m_hPrevOwner
+				// aren't always triggered as one would expect when the bomb is planted, defused, and even
+				// dropped in some cases.
+				//
+				// An example: if a player drops the bomb directly to another player, i.e. the bomb never
+				// touches the ground, the bomb entity stays the same. In this case, the m_h{Prev}Owner
+				// properties are updated. Here, the does-player-still-hold-bomb check below is not required.
+				//
+				// If, instead, the bomb is dropped on the ground, the bomb entity is destroyed and a new one
+				// is created. In this case, the m_h{Prev}Owner properties are not updated, and we need the check
+				// below.
+				if _, hasBomb := owner.RawWeapons[bombEntity.ID()]; !hasBomb {
+					handlerRegistered[ownerEntityID] = false
+					return
+				}
+
+				bomb.Position = owner.Position
+				bomb.Player = owner
+			}
+
+			owner.Entity.FindProperty("cslocaldata.m_vecOrigin").OnUpdate(func(val st.PropertyValue) {
+				updateBombPosition()
+			})
+
+			owner.Entity.FindProperty("cslocaldata.m_vecOrigin[2]").OnUpdate(func(val st.PropertyValue) {
+				updateBombPosition()
+			})
+		})
+	})
 }
 
 func (p *Parser) bindTeamScores() {
@@ -288,7 +372,6 @@ func (p *Parser) bindGrenadeProjectiles(entity *st.Entity) {
 		p.eventDispatcher.Dispatch(events.NadeProjectileDestroyedEvent{
 			Projectile: proj,
 		})
-
 		delete(p.gameState.grenadeProjectiles, entityID)
 	})
 

--- a/events/events.go
+++ b/events/events.go
@@ -271,6 +271,17 @@ type BombBeginDefuseEvent struct {
 	HasKit bool
 }
 
+// BombDropEvent signals that the bomb (C4) has been dropped.
+type BombDropEvent struct {
+	Player   *common.Player
+	EntityID int
+}
+
+// BombPickupEvent signals that the bomb (C4) has been picked up.
+type BombPickupEvent struct {
+	Player *common.Player
+}
+
 func (BombBeginDefuseEvent) implementsBombEventIf() {}
 
 // HitGroup is the type for the various HitGroupXYZ constants.

--- a/game_events.go
+++ b/game_events.go
@@ -352,6 +352,18 @@ func (p *Parser) handleGameEvent(ge *msg.CSVCMsg_GameEvent) {
 				Weapon: weapon,
 			})
 		}
+	case "bomb_dropped": // Bomb dropped
+		player := p.gameState.playersByUserID[int(data["userid"].GetValShort())]
+		entityID := int(data["entityid"].GetValShort())
+
+		p.eventDispatcher.Dispatch(events.BombDropEvent{
+			Player:   player,
+			EntityID: entityID,
+		})
+	case "bomb_pickup": // Bomb picked up
+		p.eventDispatcher.Dispatch(events.BombPickupEvent{
+			Player: p.gameState.playersByUserID[int(data["userid"].GetValShort())],
+		})
 
 	// TODO: Might be interesting:
 	case "player_connect_full": // Connecting finished
@@ -361,10 +373,6 @@ func (p *Parser) handleGameEvent(ge *msg.CSVCMsg_GameEvent) {
 	case "weapon_zoom": // Zooming in
 		fallthrough
 	case "weapon_reload": // Weapon reloaded
-		fallthrough
-	case "bomb_dropped": // Bomb dropped
-		fallthrough
-	case "bomb_pickup": // Bomb picked up
 		fallthrough
 	case "round_time_warning": // Round time warning
 		fallthrough

--- a/game_state.go
+++ b/game_state.go
@@ -15,6 +15,7 @@ type GameState struct {
 	grenadeProjectiles map[int]*common.GrenadeProjectile // Maps entity-IDs to active nade-projectiles. That's grenades that have been thrown, but have not yet detonated.
 	infernos           map[int]*common.Inferno           // Maps entity-IDs to active infernos.
 	entities           map[int]*st.Entity                // Maps entity IDs to entities
+	bomb               common.Bomb
 }
 
 type ingameTickNumber int
@@ -70,6 +71,11 @@ func (gs GameState) Infernos() map[int]*common.Inferno {
 // Entities returns all currently existing entities.
 func (gs GameState) Entities() map[int]*st.Entity {
 	return gs.entities
+}
+
+// Bomb returns the current bomb state.
+func (gs GameState) Bomb() *common.Bomb {
+	return &gs.bomb
 }
 
 func newGameState() GameState {


### PR DESCRIPTION
I was looking into tracking the bomb's position, and it seems like it's something that could be useful to include in the library.

As you can see from the TODOs, I found a slight problem with the current interface of `Property.OnUpdate`. It seems like it could be useful to return a `HandlerIdentifier`, as is already being done in the event dispatcher.

I'm not sure where you would like this to go, but since I'm actively using branch v1.0.0 now, I branched out from here and pointed the PR here as well :slightly_smiling_face: 