### PR TITLE
Clean up event naming

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,10 +58,10 @@ func main() {
 	// Get metadata for the map that's being played
 	m := metadata.MapNameToMap[header.MapName]
 
-	// Register handler for WeaponFiredEvent, triggered every time a shot is fired
+	// Register handler for WeaponFire, triggered every time a shot is fired
 	points := []heatmap.DataPoint{}
 	var bounds image.Rectangle
-	p.RegisterEventHandler(func(e events.WeaponFiredEvent) {
+	p.RegisterEventHandler(func(e events.WeaponFire) {
 		// Translate positions from in-game coordinates to radar overview
 		x, y := m.TranslateScale(e.Shooter.Position.X, e.Shooter.Position.Y)
 
@@ -139,7 +139,7 @@ Running the above code (`go run heatmap.go > heatmap.png`) will create a JPEG of
 * Grenade projectiles / trajectories - [docs](https://godoc.org/github.com/markus-wa/demoinfocs-golang#GameState.GrenadeProjectiles) / [example](https://github.com/markus-wa/demoinfocs-golang/tree/master/examples/nade-trajectories)
 * Access to entities, server-classes & data-tables - [docs](https://godoc.org/github.com/markus-wa/demoinfocs-golang/sendtables#ServerClasses) / [example](https://github.com/markus-wa/demoinfocs-golang/tree/master/examples/entities)
 * Access to all net-messages - [docs](https://godoc.org/github.com/markus-wa/demoinfocs-golang#NetMessageCreator) / [example](https://github.com/markus-wa/demoinfocs-golang/tree/master/examples/net-messages)
-* Chat & console messages <sup id="achat1">1</sup> - [docs](https://godoc.org/github.com/markus-wa/demoinfocs-golang/events#ChatMessageEvent) / [example](https://github.com/markus-wa/demoinfocs-golang/tree/master/examples/print-events)
+* Chat & console messages <sup id="achat1">1</sup> - [docs](https://godoc.org/github.com/markus-wa/demoinfocs-golang/events#ChatMessage) / [example](https://github.com/markus-wa/demoinfocs-golang/tree/master/examples/print-events)
 * [Easy debugging via build-flags](#debugging)
 * Built with performance & concurrency in mind
 

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ You can use gitter to ask questions and discuss ideas about this project.
 
 ## Example
 
-This is a simple example on how to use the library. It collects all positions where weapons were fired from (using `events.WeaponFiredEvent`) and creates a heatmap using [go-heatmap](https://github.com/dustin/go-heatmap).
+This is a simple example on how to use the library. It collects all positions where weapons were fired from (using `events.WeaponFire`) and creates a heatmap using [go-heatmap](https://github.com/dustin/go-heatmap).
 
 Check out the [examples](examples) folder for more examples and the [godoc of the `events` package](https://godoc.org/github.com/markus-wa/demoinfocs-golang/events) for some information about the other available events and their purpose.
 

--- a/datatables.go
+++ b/datatables.go
@@ -308,7 +308,7 @@ func (p *Parser) bindGrenadeProjectiles(entity *st.Entity) {
 	p.gameState.grenadeProjectiles[entityID] = proj
 
 	entity.OnCreateFinished(func() {
-		p.eventDispatcher.Dispatch(events.NadeProjectileThrownEvent{
+		p.eventDispatcher.Dispatch(events.GrenadeProjectileThrow{
 			Projectile: proj,
 		})
 	})
@@ -342,7 +342,7 @@ func (p *Parser) bindGrenadeProjectiles(entity *st.Entity) {
 	if bounceProp != nil {
 		bounceProp.OnUpdate(func(val st.PropertyValue) {
 			if val.IntVal != 0 {
-				p.eventDispatcher.Dispatch(events.NadeProjectileBouncedEvent{
+				p.eventDispatcher.Dispatch(events.GrenadeProjectileBounce{
 					Projectile: proj,
 					BounceNr:   val.IntVal,
 				})
@@ -359,7 +359,7 @@ func (p *Parser) nadeProjectileDestroyed(proj *common.GrenadeProjectile) {
 		return
 	}
 
-	p.eventDispatcher.Dispatch(events.NadeProjectileDestroyedEvent{
+	p.eventDispatcher.Dispatch(events.GrenadeProjectileDestroy{
 		Projectile: proj,
 	})
 
@@ -412,7 +412,7 @@ func (p *Parser) bindNewInferno(entity *st.Entity) {
 	p.gameState.infernos[entityID] = inf
 
 	entity.OnCreateFinished(func() {
-		p.eventDispatcher.Dispatch(events.InfernoStartedEvent{
+		p.eventDispatcher.Dispatch(events.InfernoStart{
 			Inferno: inf,
 		})
 	})
@@ -449,7 +449,7 @@ func (p *Parser) infernoExpired(inf *common.Inferno) {
 		return
 	}
 
-	p.eventDispatcher.Dispatch(events.InfernoExpiredEvent{
+	p.eventDispatcher.Dispatch(events.InfernoExpire{
 		Inferno: inf,
 	})
 

--- a/datatables.go
+++ b/datatables.go
@@ -449,7 +449,7 @@ func (p *Parser) infernoExpired(inf *common.Inferno) {
 		return
 	}
 
-	p.eventDispatcher.Dispatch(events.InfernoExpire{
+	p.eventDispatcher.Dispatch(events.InfernoExpired{
 		Inferno: inf,
 	})
 

--- a/demoinfocs_test.go
+++ b/demoinfocs_test.go
@@ -67,7 +67,7 @@ func TestDemoInfoCs(t *testing.T) {
 
 	fmt.Println("Registering handlers")
 	gs := p.GameState()
-	p.RegisterEventHandler(func(e events.RoundEndedEvent) {
+	p.RegisterEventHandler(func(e events.RoundEnd) {
 		var winner *dem.TeamState
 		var loser *dem.TeamState
 		var winnerSide string
@@ -100,7 +100,7 @@ func TestDemoInfoCs(t *testing.T) {
 	})
 
 	// Check some things at match start
-	p.RegisterEventHandler(func(events.MatchStartedEvent) {
+	p.RegisterEventHandler(func(events.MatchStart) {
 		participants := gs.Participants()
 		all := participants.All()
 		players := participants.Playing()
@@ -123,7 +123,7 @@ func TestDemoInfoCs(t *testing.T) {
 	})
 
 	// Regression test for grenade projectiles not being deleted at the end of the round (issue #42)
-	p.RegisterEventHandler(func(events.RoundStartedEvent) {
+	p.RegisterEventHandler(func(events.RoundStart) {
 		if nProjectiles := len(p.GameState().GrenadeProjectiles()); nProjectiles > 0 {
 			t.Error("Expected 0 GrenadeProjectiles at the start of the round, got", nProjectiles)
 		}
@@ -214,7 +214,7 @@ func TestValveMatchmakingFuzzyEmitters(t *testing.T) {
 
 	teamSwitchDone := false
 	tScoreBeforeSwap, ctScoreBeforeSwap := -1, -1
-	p.RegisterEventHandler(func(ev events.RoundEndedEvent) {
+	p.RegisterEventHandler(func(ev events.RoundEnd) {
 		switch ev.Winner {
 		case common.TeamTerrorists:
 			tScoreBeforeSwap = p.GameState().TeamTerrorists().Score() + 1
@@ -261,7 +261,7 @@ func TestCancelParseToEnd(t *testing.T) {
 	var tix int
 
 	var handlerID dispatch.HandlerIdentifier
-	handlerID = p.RegisterEventHandler(func(events.TickDoneEvent) {
+	handlerID = p.RegisterEventHandler(func(events.TickDone) {
 		tix++
 		if tix == maxTicks {
 			p.Cancel()

--- a/demopacket.go
+++ b/demopacket.go
@@ -80,7 +80,7 @@ func (p *Parser) parsePacket() {
 			} else {
 				// Send a warning if the command is unknown
 				// This might mean our proto files are out of date
-				p.eventDispatcher.Dispatch(events.ParserWarnEvent{Message: fmt.Sprintf("Unknown message command %q", cmd)})
+				p.eventDispatcher.Dispatch(events.ParserWarn{Message: fmt.Sprintf("Unknown message command %q", cmd)})
 			}
 
 			// On to the next one

--- a/events/events.go
+++ b/events/events.go
@@ -1,4 +1,8 @@
 // Package events contains all events that can be sent out from demoinfocs.Parser.
+//
+// Events are generally named in the tense that fits the best for each event.
+// E.g. SmokeExpired is in the past tense because it's sent out when the smoke has completely faded away
+// while SmokeStart is in the present tense because it's sent out when the smoke starts to bloom.
 package events
 
 import (

--- a/events/events.go
+++ b/events/events.go
@@ -179,9 +179,8 @@ type SmokeStart struct {
 	GrenadeEvent
 }
 
-// SmokeExpire signals the end of a smoke (fade). Not sure if this means
-// it started to fade, completely faded or something in between.
-type SmokeExpire struct {
+// SmokeExpired signals that a smoke as completely faded away.
+type SmokeExpired struct {
 	GrenadeEvent
 }
 
@@ -190,8 +189,8 @@ type FireGrenadeStart struct {
 	GrenadeEvent
 }
 
-// FireGrenadeExpire signals the end of a molly/incendiary.
-type FireGrenadeExpire struct {
+// FireGrenadeExpired signals that all fires of a molly/incendiary have extinguished.
+type FireGrenadeExpired struct {
 	GrenadeEvent
 }
 
@@ -207,7 +206,7 @@ type GrenadeProjectileThrow struct {
 	Projectile *common.GrenadeProjectile
 }
 
-// GrenadeProjectileDestroy signals that a nade entity has been destroyed (i.e. it detonated / expired).
+// GrenadeProjectileDestroy signals that a nade entity is being destroyed (i.e. it detonated / expired).
 // This is different from the other Grenade events because it's sent out when the projectile entity is destroyed.
 //
 // Mainly useful for getting the full trajectory of the projectile.
@@ -269,8 +268,9 @@ type BombDefuseStart struct {
 	HasKit bool
 }
 
-// BombDrop signals that the bomb (C4) has been dropped.
-type BombDrop struct {
+// BombDropped signals that the bomb (C4) has been dropped onto the ground.
+// Not fired if it has been dropped to another player (see BombPickup for this).
+type BombDropped struct {
 	Player   *common.Player
 	EntityID int
 }
@@ -314,13 +314,13 @@ type PlayerHurt struct {
 	HitGroup     HitGroup
 }
 
-// PlayerConnect signals that a player has connected.
+// PlayerConnect signals that a player has started connecting.
 type PlayerConnect struct {
 	Player *common.Player
 }
 
-// PlayerDisconnect signals that a player has disconnected.
-type PlayerDisconnect struct {
+// PlayerDisconnected signals that a player has disconnected.
+type PlayerDisconnected struct {
 	Player *common.Player
 }
 
@@ -407,16 +407,16 @@ type GenericGameEvent struct {
 	Data map[string]*msg.CSVCMsg_GameEventKeyT
 }
 
-// InfernoStart signals that the fire of a incendiary or Molotov has just started.
+// InfernoStart signals that the fire of a incendiary or Molotov is starting.
 // This is different from the FireGrenadeStart because it's sent out when the inferno entity is created instead of on the game-event.
 type InfernoStart struct {
 	Inferno *common.Inferno
 }
 
-// InfernoExpire signals that all fire from a incendiary or Molotov has extinguished.
+// InfernoExpired signals that all fire from a incendiary or Molotov has extinguished.
 // This is different from the FireGrenadeExpire event because it's sent out when the inferno entity is destroyed instead of on the game-event.
 //
 // Mainly useful for getting the final area of an inferno.
-type InfernoExpire struct {
+type InfernoExpired struct {
 	Inferno *common.Inferno
 }

--- a/events/events.go
+++ b/events/events.go
@@ -8,18 +8,25 @@ import (
 	msg "github.com/markus-wa/demoinfocs-golang/msg"
 )
 
-// TickDoneEvent signals that a tick is done.
-type TickDoneEvent struct{}
+// TickDone signals that a tick is done.
+type TickDone struct{}
 
-// MatchStartedEvent signals that the match has started.
-type MatchStartedEvent struct{}
+// MatchStart signals that the match has started.
+type MatchStart struct{}
 
-// RoundAnnounceMatchStartedEvent signals that the announcement "Match Started" has been displayed.
-type RoundAnnounceMatchStartedEvent struct{}
+// RoundStart signals that a new round has started.
+type RoundStart struct {
+	TimeLimit int
+	FragLimit int
+	Objective string
+}
+
+// RoundFreezetimeEnd signals that the freeze time is over.
+type RoundFreezetimeEnd struct{}
 
 // RoundEndReason is the type for the various RoundEndReasonXYZ constants.
 //
-// See RoundEndedEvent.
+// See RoundEnd.
 type RoundEndReason byte
 
 // RoundEndReason constants give information about why a round ended (Bomb defused, exploded etc.).
@@ -44,21 +51,22 @@ const (
 	RoundEndReasonCTSurrender          RoundEndReason = 18
 )
 
-// RoundEndedEvent signals that a round just finished.
+// RoundEnd signals that a round just finished.
 // Attention: TeamState.Score() won't be up to date yet after this.
 // Add +1 to the winner's score as a workaround.
-type RoundEndedEvent struct {
+type RoundEnd struct {
 	Message string
 	Reason  RoundEndReason
 	Winner  common.Team
 }
 
-// RoundOfficiallyEndedEvent signals that the round 'has officially ended', not exactly sure what that is tbh.
-type RoundOfficiallyEndedEvent struct{}
+// RoundEndOfficial signals that the round has 'officially' ended.
+// After RoundEnd and before this players are still able to walk around.
+type RoundEndOfficial struct{}
 
 // RoundMVPReason is the type for the various MVPReasonYXZ constants.
 //
-// See RoundMVPEvent.
+// See RoundMVPAnnouncement.
 type RoundMVPReason byte
 
 // RoundMVPReasons constants give information about why a player got the MVP award.
@@ -68,38 +76,31 @@ const (
 	MVPReasonBombPlanted      RoundMVPReason = 3
 )
 
-// RoundMVPEvent signals the announcement of the last rounds MVP.
-type RoundMVPEvent struct {
+// RoundMVPAnnouncement signals the announcement of the last rounds MVP.
+type RoundMVPAnnouncement struct {
 	Player *common.Player
 	Reason RoundMVPReason
 }
 
-// RoundStartedEvent signals that a new round has started.
-type RoundStartedEvent struct {
-	TimeLimit int
-	FragLimit int
-	Objective string
-}
+// AnnouncementMatchStarted signals that the announcement "Match Started" has been displayed.
+type AnnouncementMatchStarted struct{}
 
-// WinPanelMatchEvent signals that the 'win panel' has been displayed. I guess that's the final scoreboard.
-type WinPanelMatchEvent struct{}
+// AnnouncementLastRoundHalf signals the last round of the first half.
+type AnnouncementLastRoundHalf struct{}
 
-// FinalRoundEvent signals the 30th round, not raised if the match ends before that.
-type FinalRoundEvent struct{}
+// AnnouncementFinalRound signals the 30th round, not raised if the match ends before that.
+type AnnouncementFinalRound struct{}
 
-// LastRoundHalfEvent signals the last round of the first half.
-type LastRoundHalfEvent struct{}
+// AnnouncementWinPanelMatch signals that the 'win panel' has been displayed. I guess that's the final scoreboard.
+type AnnouncementWinPanelMatch struct{}
 
-// FreezetimeEndedEvent signals that the freeze time is over.
-type FreezetimeEndedEvent struct{}
-
-// PlayerFootstepEvent occurs when a player makes a footstep.
-type PlayerFootstepEvent struct {
+// Footstep occurs when a player makes a footstep.
+type Footstep struct {
 	Player *common.Player
 }
 
-// PlayerTeamChangeEvent occurs when a player swaps teams.
-type PlayerTeamChangeEvent struct {
+// PlayerTeamChange occurs when a player swaps teams.
+type PlayerTeamChange struct {
 	Player  *common.Player
 	NewTeam common.Team
 	OldTeam common.Team
@@ -107,13 +108,13 @@ type PlayerTeamChangeEvent struct {
 	IsBot   bool
 }
 
-// PlayerJumpEvent signals that a player has jumped.
-type PlayerJumpEvent struct {
+// PlayerJump signals that a player has jumped.
+type PlayerJump struct {
 	Player *common.Player
 }
 
-// PlayerKilledEvent signals that a player has been killed.
-type PlayerKilledEvent struct {
+// Kill signals that a player has been killed.
+type Kill struct {
 	Weapon            *common.Equipment
 	Victim            *common.Player
 	Killer            *common.Player
@@ -122,107 +123,104 @@ type PlayerKilledEvent struct {
 	IsHeadshot        bool
 }
 
-// BotTakenOverEvent signals that a player took over a bot.
-type BotTakenOverEvent struct {
+// BotTakenOver signals that a player took over a bot.
+type BotTakenOver struct {
 	Taker *common.Player
 }
 
-// WeaponFiredEvent signals that a weapon has been fired.
-type WeaponFiredEvent struct {
+// WeaponFire signals that a weapon has been fired.
+type WeaponFire struct {
 	Shooter *common.Player
 	Weapon  *common.Equipment
 }
 
-// FIXME: Currently handling NadeEventIf is really annoying. Improve that
-// Same with BombEventIf
-
-// NadeEventIf is the interface for all NadeEvents (except NadeProjectile* events).
+// GrenadeEventIf is the interface for all GrenadeEvents (except GrenadeProjectile* events).
 // Used to catch the different events with the same handler.
-type NadeEventIf interface {
-	Base() NadeEvent
+type GrenadeEventIf interface {
+	Base() GrenadeEvent
 }
 
-// NadeEvent contains the common attributes of nade events. Dont register
-// handlers on this tho, you want NadeEventIf for that
-type NadeEvent struct {
-	NadeType     common.EquipmentElement
-	Position     r3.Vector
-	Thrower      *common.Player
-	NadeEntityID int
+// GrenadeEvent contains the common attributes of nade events. Dont register
+// handlers on this tho, you want GrenadeEventIf for that
+type GrenadeEvent struct {
+	GrenadeType     common.EquipmentElement
+	Position        r3.Vector
+	Thrower         *common.Player
+	GrenadeEntityID int
 }
 
-// Base returns the NadeEvent itself, used for catching all events with NadeEventIf.
-func (ne NadeEvent) Base() NadeEvent {
+// Base returns the GrenadeEvent itself, used for catching all events with GrenadeEventIf.
+func (ne GrenadeEvent) Base() GrenadeEvent {
 	return ne
 }
 
-// HeExplodedEvent signals the explosion of a HE.
-type HeExplodedEvent struct {
-	NadeEvent
+// HeExplode signals the explosion of a HE.
+type HeExplode struct {
+	GrenadeEvent
 }
 
-// FlashExplodedEvent signals the explosion of a Flash.
-type FlashExplodedEvent struct {
-	NadeEvent
+// FlashExplode signals the explosion of a Flash.
+type FlashExplode struct {
+	GrenadeEvent
 }
 
-// DecoyStartEvent signals the start of a decoy.
-type DecoyStartEvent struct {
-	NadeEvent
+// DecoyStart signals the start of a decoy.
+type DecoyStart struct {
+	GrenadeEvent
 }
 
-// DecoyEndEvent signals the end of a decoy.
-type DecoyEndEvent struct {
-	NadeEvent
+// DecoyExpire signals the end of a decoy.
+type DecoyExpire struct {
+	GrenadeEvent
 }
 
-// SmokeStartEvent signals the start of a smoke (pop).
-type SmokeStartEvent struct {
-	NadeEvent
+// SmokeStart signals the start of a smoke (pop).
+type SmokeStart struct {
+	GrenadeEvent
 }
 
-// SmokeEndEvent signals the end of a smoke (fade). Not sure if this means
+// SmokeExpire signals the end of a smoke (fade). Not sure if this means
 // it started to fade, completely faded or something in between.
-type SmokeEndEvent struct {
-	NadeEvent
+type SmokeExpire struct {
+	GrenadeEvent
 }
 
-// FireNadeStartEvent signals the start of a molly/incendiary.
-type FireNadeStartEvent struct {
-	NadeEvent
+// FireGrenadeStart signals the start of a molly/incendiary.
+type FireGrenadeStart struct {
+	GrenadeEvent
 }
 
-// FireNadeEndEvent signals the end of a molly/incendiary.
-type FireNadeEndEvent struct {
-	NadeEvent
+// FireGrenadeExpire signals the end of a molly/incendiary.
+type FireGrenadeExpire struct {
+	GrenadeEvent
 }
 
-// NadeProjectileBouncedEvent signals that a nade has just bounced off a wall/floor/ceiling or object.
-type NadeProjectileBouncedEvent struct {
+// GrenadeProjectileBounce signals that a nade has just bounced off a wall/floor/ceiling or object.
+type GrenadeProjectileBounce struct {
 	Projectile *common.GrenadeProjectile
 	BounceNr   int
 }
 
-// NadeProjectileThrownEvent signals that a nade has just been thrown.
-// This is different from the WeaponFiredEvent because it's sent out when the projectile entity is created.
-type NadeProjectileThrownEvent struct {
+// GrenadeProjectileThrow signals that a nade has just been thrown.
+// This is different from the WeaponFired because it's sent out when the projectile entity is created.
+type GrenadeProjectileThrow struct {
 	Projectile *common.GrenadeProjectile
 }
 
-// NadeProjectileDestroyedEvent signals that a nade entity has been destroyed (i.e. it detonated / expired).
-// This is different from the other Nade events because it's sent out when the projectile entity is destroyed.
+// GrenadeProjectileDestroy signals that a nade entity has been destroyed (i.e. it detonated / expired).
+// This is different from the other Grenade events because it's sent out when the projectile entity is destroyed.
 //
 // Mainly useful for getting the full trajectory of the projectile.
-type NadeProjectileDestroyedEvent struct {
+type GrenadeProjectileDestroy struct {
 	Projectile *common.GrenadeProjectile
 }
 
-// PlayerFlashedEvent signals that a player was flashed.
-type PlayerFlashedEvent struct {
+// PlayerFlashed signals that a player was flashed.
+type PlayerFlashed struct {
 	Player *common.Player
 }
 
-// BombEventIf is the interface for all the bomb events. Like NadeEventIf for NadeEvents.
+// BombEventIf is the interface for all the bomb events. Like GrenadeEventIf for GrenadeEvents.
 type BombEventIf interface {
 	implementsBombEventIf()
 }
@@ -245,48 +243,48 @@ type BombEvent struct {
 // Make BombEvent implement BombEventIf
 func (BombEvent) implementsBombEventIf() {}
 
-// BombBeginPlant signals the start of a plant.
-type BombBeginPlant struct {
+// BombPlantBegin signals the start of a plant.
+type BombPlantBegin struct {
 	BombEvent
 }
 
-// BombPlantedEvent signals that the bomb has been planted.
-type BombPlantedEvent struct {
+// BombPlanted signals that the bomb has been planted.
+type BombPlanted struct {
 	BombEvent
 }
 
-// BombDefusedEvent signals that the bomb has been defused.
-type BombDefusedEvent struct {
+// BombDefused signals that the bomb has been defused.
+type BombDefused struct {
 	BombEvent
 }
 
-// BombExplodedEvent signals that the bomb has exploded.
-type BombExplodedEvent struct {
+// BombExplode signals that the bomb has exploded.
+type BombExplode struct {
 	BombEvent
 }
 
-// BombBeginDefuseEvent signals the start of defusing.
-type BombBeginDefuseEvent struct {
+// BombDefuseStart signals the start of defusing.
+type BombDefuseStart struct {
 	Player *common.Player
 	HasKit bool
 }
 
-// BombDropEvent signals that the bomb (C4) has been dropped.
-type BombDropEvent struct {
+// BombDrop signals that the bomb (C4) has been dropped.
+type BombDrop struct {
 	Player   *common.Player
 	EntityID int
 }
 
-// BombPickupEvent signals that the bomb (C4) has been picked up.
-type BombPickupEvent struct {
+// BombPickup signals that the bomb (C4) has been picked up.
+type BombPickup struct {
 	Player *common.Player
 }
 
-func (BombBeginDefuseEvent) implementsBombEventIf() {}
+func (BombDefuseStart) implementsBombEventIf() {}
 
 // HitGroup is the type for the various HitGroupXYZ constants.
 //
-// See PlayerHurtEvent.
+// See PlayerHurt.
 type HitGroup byte
 
 // HitGroup constants give information about where a player got hit.
@@ -303,8 +301,8 @@ const (
 	HitGroupGear     HitGroup = 10
 )
 
-// PlayerHurtEvent signals that a player has been damaged.
-type PlayerHurtEvent struct {
+// PlayerHurt signals that a player has been damaged.
+type PlayerHurt struct {
 	Player       *common.Player
 	Attacker     *common.Player
 	Health       int
@@ -316,32 +314,32 @@ type PlayerHurtEvent struct {
 	HitGroup     HitGroup
 }
 
-// PlayerBindEvent signals that a player has connected.
-type PlayerBindEvent struct {
+// PlayerConnect signals that a player has connected.
+type PlayerConnect struct {
 	Player *common.Player
 }
 
-// PlayerDisconnectEvent signals that a player has disconnected.
-type PlayerDisconnectEvent struct {
+// PlayerDisconnect signals that a player has disconnected.
+type PlayerDisconnect struct {
 	Player *common.Player
 }
 
-// SayTextEvent signals a chat message. It contains the raw
+// SayText signals a chat message. It contains the raw
 // network message data for admin / console messages.
 // EntIdx will probably always be 0
-// See ChatMessageEvent and SayText2Event for player chat messages.
-type SayTextEvent struct {
+// See ChatMessage and SayText2 for player chat messages.
+type SayText struct {
 	EntIdx    int // Not sure what this is, doesn't seem to be the entity-ID
 	Text      string
 	IsChat    bool // Not sure, from the net-message
 	IsChatAll bool // Seems to always be false, team chat might not be recorded
 }
 
-// SayText2Event signals a chat message. It just contains the raw network message.
-// For player chat messages, ChatMessageEvent may be more interesting.
+// SayText2 signals a chat message. It just contains the raw network message.
+// For player chat messages, ChatMessage may be more interesting.
 // Team chat is generally not recorded so IsChatAll will probably always be false.
-// See SayTextEvent for admin / console messages.
-type SayText2Event struct {
+// See SayText for admin / console messages.
+type SayText2 struct {
 	EntIdx    int      // Not sure what this is, doesn't seem to be the entity-ID
 	MsgName   string   // The message type, e.g. Cstrike_Chat_All for global chat
 	Params    []string // The message's parameters, for Cstrike_Chat_All parameter 1 is the player and 2 the message for example
@@ -349,18 +347,18 @@ type SayText2Event struct {
 	IsChatAll bool     // Seems to always be false, team chat might not be recorded
 }
 
-// ChatMessageEvent signals a player generated chat message.
+// ChatMessage signals a player generated chat message.
 // Since team chat is generally not recorded IsChatAll will probably always be false.
-// See SayTextEvent for admin / console messages and SayText2Event for raw network package data.
-type ChatMessageEvent struct {
+// See SayText for admin / console messages and SayText2 for raw network package data.
+type ChatMessage struct {
 	Sender    *common.Player
 	Text      string
 	IsChatAll bool
 }
 
-// RankUpdateEvent signals the new rank. Not sure if this
+// RankUpdate signals the new rank. Not sure if this
 // only occurs if the rank changed.
-type RankUpdateEvent struct {
+type RankUpdate struct {
 	SteamID    int64
 	RankOld    int
 	RankNew    int
@@ -368,38 +366,38 @@ type RankUpdateEvent struct {
 	RankChange float32
 }
 
-// ItemEquipEvent signals an item was equipped.
-type ItemEquipEvent struct {
+// ItemEquip signals an item was equipped.
+type ItemEquip struct {
 	Weapon common.Equipment
 	Player *common.Player
 }
 
-// ItemPickupEvent signals an item was bought or picked up.
-type ItemPickupEvent struct {
+// ItemPickup signals an item was bought or picked up.
+type ItemPickup struct {
 	Weapon common.Equipment
 	Player *common.Player
 }
 
-// ItemDropEvent signals an item was dropped.
-type ItemDropEvent struct {
+// ItemDrop signals an item was dropped.
+type ItemDrop struct {
 	Weapon common.Equipment
 	Player *common.Player
 }
 
-// DataTablesParsedEvent signals that the datatables were parsed.
+// DataTablesParsed signals that the datatables were parsed.
 // You can use the Parser.SendTableParser() after this event to register update notification on entities & properties.
-type DataTablesParsedEvent struct{}
+type DataTablesParsed struct{}
 
-// StringTableCreatedEvent signals that a string table was created via net message.
+// StringTableCreated signals that a string table was created via net message.
 // Can be useful for figuring out when player-info is available via Parser.GameState().[Playing]Participants().
-// E.g. after the table 'userinfo' has been created the player-data should be available after the next TickDoneEvent.
+// E.g. after the table 'userinfo' has been created the player-data should be available after the next TickDone.
 // The reason it's not immediately available is because we need to do some post-processing to prep that data after a tick has finished.
-type StringTableCreatedEvent struct {
+type StringTableCreated struct {
 	TableName string
 }
 
-// ParserWarnEvent signals that a non-fatal problem occurred during parsing.
-type ParserWarnEvent struct {
+// ParserWarn signals that a non-fatal problem occurred during parsing.
+type ParserWarn struct {
 	Message string
 }
 
@@ -409,16 +407,16 @@ type GenericGameEvent struct {
 	Data map[string]*msg.CSVCMsg_GameEventKeyT
 }
 
-// InfernoStartedEvent signals that the fire of a incendiary or Molotov has just started.
-// This is different from the FireNadeStartedEvent because it's sent out when the inferno entity is created instead of on the game-event.
-type InfernoStartedEvent struct {
+// InfernoStart signals that the fire of a incendiary or Molotov has just started.
+// This is different from the FireGrenadeStart because it's sent out when the inferno entity is created instead of on the game-event.
+type InfernoStart struct {
 	Inferno *common.Inferno
 }
 
-// InfernoExpiredEvent signals that all fire from a incendiary or Molotov has extinguished.
-// This is different from the FireNadeExpiredEvent event because it's sent out when the inferno entity is destroyed instead of on the game-event.
+// InfernoExpire signals that all fire from a incendiary or Molotov has extinguished.
+// This is different from the FireGrenadeExpire event because it's sent out when the inferno entity is destroyed instead of on the game-event.
 //
 // Mainly useful for getting the final area of an inferno.
-type InfernoExpiredEvent struct {
+type InfernoExpire struct {
 	Inferno *common.Inferno
 }

--- a/examples/entities/README.md
+++ b/examples/entities/README.md
@@ -810,8 +810,8 @@ Property-update handlers that are registered in a entity-creation handler will b
 This example prints the life-cycle of all AWPs during the game - i.e. who picked up whose AWP:
 
 ```go
-p.RegisterEventHandler(func(events.DataTablesParsedEvent) {
-	// DataTablesParsedEvent has been sent out, register entity-creation handler
+p.RegisterEventHandler(func(events.DataTablesParsed) {
+	// DataTablesParsed has been sent out, register entity-creation handler
 	p.ServerClasses().FindByName("CWeaponAWP").OnEntityCreated(func(entity *st.Entity) {
 		// Register update-hander on the owning entity (player who's holding the AWP)
 		entity.FindProperty("m_hOwnerEntity").OnUpdate(func(val st.PropertyValue) {

--- a/examples/entities/entities.go
+++ b/examples/entities/entities.go
@@ -23,7 +23,7 @@ func main() {
 	_, err = p.ParseHeader()
 	checkError(err)
 
-	p.RegisterEventHandler(func(events.DataTablesParsedEvent) {
+	p.RegisterEventHandler(func(events.DataTablesParsed) {
 		p.ServerClasses().FindByName("CWeaponAWP").OnEntityCreated(func(ent *st.Entity) {
 			ent.FindProperty("m_hOwnerEntity").OnUpdate(func(val st.PropertyValue) {
 				x := p.GameState().Participants().FindByHandle(val.IntVal)

--- a/examples/heatmap/heatmap.go
+++ b/examples/heatmap/heatmap.go
@@ -32,10 +32,10 @@ func main() {
 	// Get metadata for the map that's being played
 	m := metadata.MapNameToMap[header.MapName]
 
-	// Register handler for WeaponFiredEvent, triggered every time a shot is fired
+	// Register handler for WeaponFire, triggered every time a shot is fired
 	points := []heatmap.DataPoint{}
 	var bounds image.Rectangle
-	p.RegisterEventHandler(func(e events.WeaponFiredEvent) {
+	p.RegisterEventHandler(func(e events.WeaponFire) {
 		// Translate positions from in-game coordinates to radar overview
 		x, y := m.TranslateScale(e.Shooter.Position.X, e.Shooter.Position.Y)
 

--- a/examples/nade-trajectories/nade_trajectories.go
+++ b/examples/nade-trajectories/nade_trajectories.go
@@ -76,7 +76,7 @@ func main() {
 
 	var infernos []*common.Inferno
 
-	p.RegisterEventHandler(func(e events.InfernoExpire) {
+	p.RegisterEventHandler(func(e events.InfernoExpired) {
 		infernos = append(infernos, e.Inferno)
 	})
 

--- a/examples/nade-trajectories/nade_trajectories.go
+++ b/examples/nade-trajectories/nade_trajectories.go
@@ -55,7 +55,7 @@ func main() {
 
 	nadeTrajectories := make(map[int64]*nadePath) // Trajectories of all destroyed nades
 
-	p.RegisterEventHandler(func(e events.NadeProjectileDestroyedEvent) {
+	p.RegisterEventHandler(func(e events.GrenadeProjectileDestroy) {
 		id := e.Projectile.UniqueID()
 
 		// Sometimes the thrower is nil, in that case we want the team to be unassigned (which is the default value)
@@ -76,14 +76,14 @@ func main() {
 
 	var infernos []*common.Inferno
 
-	p.RegisterEventHandler(func(e events.InfernoExpiredEvent) {
+	p.RegisterEventHandler(func(e events.InfernoExpire) {
 		infernos = append(infernos, e.Inferno)
 	})
 
 	var nadeTrajectoriesFirst5Rounds []*nadePath
 	var infernosFirst5Rounds []*common.Inferno
 	round := 0
-	p.RegisterEventHandler(func(events.RoundEndedEvent) {
+	p.RegisterEventHandler(func(events.RoundEnd) {
 		round++
 		// We only want the data from the first 5 rounds so the image is not too cluttered
 		// This is a very cheap way to do it. Won't work with demos that have match-restarts etc.

--- a/examples/print-events/print_events.go
+++ b/examples/print-events/print_events.go
@@ -25,7 +25,7 @@ func main() {
 	fmt.Println("Map:", h.MapName)
 
 	// Register handler on kill events
-	p.RegisterEventHandler(func(e events.PlayerKilledEvent) {
+	p.RegisterEventHandler(func(e events.Kill) {
 		var hs string
 		if e.IsHeadshot {
 			hs = " (HS)"
@@ -38,7 +38,7 @@ func main() {
 	})
 
 	// Register handler on round end to figure out who won
-	p.RegisterEventHandler(func(e events.RoundEndedEvent) {
+	p.RegisterEventHandler(func(e events.RoundEnd) {
 		gs := p.GameState()
 		switch e.Winner {
 		case common.TeamTerrorists:
@@ -53,7 +53,7 @@ func main() {
 	})
 
 	// Register handler for chat messages to print them
-	p.RegisterEventHandler(func(e events.ChatMessageEvent) {
+	p.RegisterEventHandler(func(e events.ChatMessage) {
 		fmt.Printf("Chat - %s says: %s\n", formatPlayer(e.Sender), e.Text)
 	})
 

--- a/fuzzy/team_switch.go
+++ b/fuzzy/team_switch.go
@@ -35,13 +35,13 @@ func (em *ValveMatchmakingTeamSwitchEmitter) Register(parser *dem.Parser, dispat
 }
 
 // Get to the last round of the first half
-func (em *ValveMatchmakingTeamSwitchEmitter) handleLastRoundHalf(events.LastRoundHalfEvent) {
+func (em *ValveMatchmakingTeamSwitchEmitter) handleLastRoundHalf(events.AnnouncementLastRoundHalf) {
 	em.parser.UnregisterEventHandler(em.currentHandlerID)
 	em.currentHandlerID = em.parser.RegisterEventHandler(em.handleRoundEnded)
 }
 
 // Get scores before switch
-func (em *ValveMatchmakingTeamSwitchEmitter) handleRoundEnded(ev events.RoundEndedEvent) {
+func (em *ValveMatchmakingTeamSwitchEmitter) handleRoundEnded(ev events.RoundEnd) {
 	em.tScoreBeforeSwitch = em.parser.GameState().TeamTerrorists().Score()
 	em.ctScoreBeforeSwitch = em.parser.GameState().TeamCounterTerrorists().Score()
 
@@ -58,13 +58,13 @@ func (em *ValveMatchmakingTeamSwitchEmitter) handleRoundEnded(ev events.RoundEnd
 }
 
 // Find first round of second half
-func (em *ValveMatchmakingTeamSwitchEmitter) handleRoundStarted(events.RoundStartedEvent) {
+func (em *ValveMatchmakingTeamSwitchEmitter) handleRoundStarted(events.RoundStart) {
 	em.parser.UnregisterEventHandler(em.currentHandlerID)
 	em.currentHandlerID = em.parser.RegisterEventHandler(em.handleTickDone)
 }
 
-// Wait for score to update - this isn't (necessarily?) the case after RoundStartedEvent
-func (em *ValveMatchmakingTeamSwitchEmitter) handleTickDone(events.TickDoneEvent) {
+// Wait for score to update - this isn't (necessarily?) the case after RoundStart
+func (em *ValveMatchmakingTeamSwitchEmitter) handleTickDone(events.TickDone) {
 	tScoreOk := em.parser.GameState().TeamTerrorists().Score() == em.ctScoreBeforeSwitch
 	ctScoreOk := em.parser.GameState().TeamCounterTerrorists().Score() == em.tScoreBeforeSwitch
 	if tScoreOk && ctScoreOk {

--- a/game_events.go
+++ b/game_events.go
@@ -215,13 +215,13 @@ func (p *Parser) handleGameEvent(ge *msg.CSVCMsg_GameEvent) {
 			p.eventDispatcher.Dispatch(events.SmokeStart{GrenadeEvent: buildNadeEvent(common.EqSmoke, thrower, position, nadeEntityID)})
 
 		case "smokegrenade_expired": // Smoke expired
-			p.eventDispatcher.Dispatch(events.SmokeExpire{GrenadeEvent: buildNadeEvent(common.EqSmoke, thrower, position, nadeEntityID)})
+			p.eventDispatcher.Dispatch(events.SmokeExpired{GrenadeEvent: buildNadeEvent(common.EqSmoke, thrower, position, nadeEntityID)})
 
 		case "inferno_startburn": // Incendiary exploded/started
 			p.eventDispatcher.Dispatch(events.FireGrenadeStart{GrenadeEvent: buildNadeEvent(common.EqIncendiary, thrower, position, nadeEntityID)})
 
 		case "inferno_expire": // Incendiary expired
-			p.eventDispatcher.Dispatch(events.FireGrenadeExpire{GrenadeEvent: buildNadeEvent(common.EqIncendiary, thrower, position, nadeEntityID)})
+			p.eventDispatcher.Dispatch(events.FireGrenadeExpired{GrenadeEvent: buildNadeEvent(common.EqIncendiary, thrower, position, nadeEntityID)})
 		}
 
 	case "player_connect": // Bot connected or player reconnected, players normally come in via string tables & data tables
@@ -250,7 +250,7 @@ func (p *Parser) handleGameEvent(ge *msg.CSVCMsg_GameEvent) {
 
 		pl := p.gameState.playersByUserID[uid]
 		if pl != nil {
-			e := events.PlayerDisconnect{
+			e := events.PlayerDisconnected{
 				Player: pl,
 			}
 			p.eventDispatcher.Dispatch(e)
@@ -371,10 +371,11 @@ func (p *Parser) handleGameEvent(ge *msg.CSVCMsg_GameEvent) {
 		player := p.gameState.playersByUserID[int(data["userid"].GetValShort())]
 		entityID := int(data["entityid"].GetValShort())
 
-		p.eventDispatcher.Dispatch(events.BombDrop{
+		p.eventDispatcher.Dispatch(events.BombDropped{
 			Player:   player,
 			EntityID: entityID,
 		})
+
 	case "bomb_pickup": // Bomb picked up
 		p.eventDispatcher.Dispatch(events.BombPickup{
 			Player: p.gameState.playersByUserID[int(data["userid"].GetValShort())],

--- a/parser.go
+++ b/parser.go
@@ -29,7 +29,7 @@ Example (without error handling):
 	p := dem.NewParser(f)
 	header := p.ParseHeader()
 	fmt.Println("Map:", header.MapName)
-	p.RegisterEventHandler(func(e events.BombExplodedEvent) {
+	p.RegisterEventHandler(func(e events.BombExplode) {
 		fmt.Printf(e.Site, "went BOOM!")
 	})
 	p.ParseToEnd()
@@ -84,7 +84,7 @@ func (bbi boundingBoxInformation) contains(point r3.Vector) bool {
 }
 
 // ServerClasses returns the server-classes of this demo.
-// These are available after events.DataTablesParsedEvent has been fired.
+// These are available after events.DataTablesParsed has been fired.
 func (p *Parser) ServerClasses() st.ServerClasses {
 	return p.stParser.ServerClasses()
 }
@@ -128,7 +128,7 @@ To catch all events func(interface{}) can be used.
 
 Example:
 
-	parser.RegisterEventHandler(func(e events.WeaponFiredEvent) {
+	parser.RegisterEventHandler(func(e events.WeaponFired) {
 		fmt.Printf("%s fired his %s\n", e.Shooter.Name, e.Weapon.Weapon)
 	})
 

--- a/parsing.go
+++ b/parsing.go
@@ -203,7 +203,7 @@ func (p *Parser) parseFrame() bool {
 		p.mapEquipment()
 		p.bindEntities()
 
-		p.eventDispatcher.Dispatch(events.DataTablesParsedEvent{})
+		p.eventDispatcher.Dispatch(events.DataTablesParsed{})
 
 	case dcStringTables:
 		p.msgDispatcher.SyncQueues(p.msgQueue)
@@ -262,12 +262,12 @@ func (p *Parser) handleFrameParsed(*frameParsedTokenType) {
 				pl.UserID = rp.userID
 
 				if pl.SteamID != 0 {
-					p.eventDispatcher.Dispatch(events.PlayerBindEvent{Player: pl})
+					p.eventDispatcher.Dispatch(events.PlayerConnect{Player: pl})
 				}
 			}
 		}
 	}
 
 	p.currentFrame++
-	p.eventDispatcher.Dispatch(events.TickDoneEvent{})
+	p.eventDispatcher.Dispatch(events.TickDone{})
 }

--- a/stringtables.go
+++ b/stringtables.go
@@ -121,7 +121,7 @@ func (p *Parser) handleCreateStringTable(tab *msg.CSVCMsg_CreateStringTable) {
 
 	p.stringTables = append(p.stringTables, tab)
 
-	p.eventDispatcher.Dispatch(events.StringTableCreatedEvent{TableName: tab.Name})
+	p.eventDispatcher.Dispatch(events.StringTableCreated{TableName: tab.Name})
 }
 
 func (p *Parser) processStringTable(tab *msg.CSVCMsg_CreateStringTable) {


### PR DESCRIPTION
See #45

Cc @micvbang - Any feedback appreciated.

I also decided to switch from past to present tense, removing many 'ed' suffixes, except where necessary so the events aren't confused with something else.

E.g. if it were `BombDefuse` instead of `BombDefused` it could be mistaken for the start of defusing.