### PR TITLE
Backport fixes for #38 & #42

### DIFF
--- a/datatables.go
+++ b/datatables.go
@@ -316,6 +316,17 @@ func (p *Parser) bindGrenadeProjectiles(event st.EntityCreatedEvent) {
 	})
 }
 
+// Seperate function because we also use it in round_officially_ended (issue #42)
+func (p *Parser) nadeProjectileDestroyed(proj *common.GrenadeProjectile) {
+	// If the grenade projectile entity is destroyed AFTER round_officially_ended
+	// we already executed this code when we received that event.
+	if _, exists := p.gameState.grenadeProjectiles[proj.EntityID]; !exists {
+		return
+	}
+
+	delete(p.gameState.grenadeProjectiles, proj.EntityID)
+}
+
 func (p *Parser) bindWeapon(event st.EntityCreatedEvent) {
 	p.weapons[event.Entity.ID] = common.NewEquipment("")
 	eq := &p.weapons[event.Entity.ID]

--- a/demoinfocs_test.go
+++ b/demoinfocs_test.go
@@ -98,6 +98,7 @@ func TestDemoInfoCs(t *testing.T) {
 			t.Error("Unexprected default value, check output of last round")
 		}
 	})
+
 	// Check some things at match start
 	p.RegisterEventHandler(func(events.MatchStartedEvent) {
 		participants := gs.Participants()
@@ -117,6 +118,13 @@ func TestDemoInfoCs(t *testing.T) {
 		if nCTs := len(gs.TeamMembers(common.TeamCounterTerrorists)); nCTs != 5 {
 			// We know there should be 5 CTs at match start in the default demo
 			t.Error("Expected 5 CTs; got", nCTs)
+		}
+	})
+
+	// Regression test for grenade projectiles not being deleted at the end of the round (issue #42)
+	p.RegisterEventHandler(func(events.RoundStartedEvent) {
+		if nProjectiles := len(p.GameState().GrenadeProjectiles()); nProjectiles > 0 {
+			t.Error("Expected 0 GrenadeProjectiles at the start of the round, got", nProjectiles)
 		}
 	})
 


### PR DESCRIPTION
See #38 & #42

* Delete nade projectiles & infernos at end of round to remove immortal nades
* `Entity.Position()` for `CCSPlayer` entities