### PR TITLE
Speed up 'go get'

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,8 @@ go:
 install:
   # We need goverage to run go tests with -coverprofile for multiple packages
   - go get github.com/haya14busa/goverage
+  # Download test data
+  - pushd cs-demos && git lfs pull -I '*' && popd
 
 before_script:
   # We don't want to run the demo set test with race condition testing.

--- a/README.md
+++ b/README.md
@@ -17,8 +17,6 @@ There are also [some other rooms](https://gitter.im/csgodemos) available around 
 
 ## Go Get
 
-This might take a while if you have Git LFS installed as it downloads the test-data set (~ 10 demos).
-
 	go get -u github.com/markus-wa/demoinfocs-golang
 
 ## Example
@@ -145,7 +143,7 @@ To run tests [Git LFS](https://git-lfs.github.com) is required.
 ```sh
 git submodule init
 git submodule update
-pushd cs-demos && git lfs pull && popd
+pushd cs-demos && git lfs pull -I '*' && popd
 go test
 ```
 


### PR DESCRIPTION
Avoid downloading test data for the end user.