### PR TITLE
Fix players being skipped in processStringTable

### DIFF
--- a/stringtables.go
+++ b/stringtables.go
@@ -194,7 +194,7 @@ func (p *Parser) processStringTable(tab *msg.CSVCMsg_CreateStringTable) {
 		}
 
 		if len(userdat) == 0 {
-			break
+			continue
 		}
 
 		switch tab.Name {


### PR DESCRIPTION
Due to an error when porting StatsHelix's demoinfocs, players were
skipped if there was a 'gap' between the string-table entries.

So if the string-table's userdata at index 3 was empty for example,
players at index 4 and above would be ignored.