### PR TITLE
game_events: begin dispatching events after any 'player_' event

### DIFF
--- a/game_events.go
+++ b/game_events.go
@@ -36,11 +36,6 @@ func (p *Parser) handleGameEvent(ge *msg.CSVCMsg_GameEvent) {
 
 	debugGameEvent(d, ge)
 
-	// Ignore events before players are connected to speed things up
-	if len(p.gameState.playersByUserID) == 0 && d.Name != "player_connect" {
-		return
-	}
-
 	var data map[string]*msg.CSVCMsg_GameEventKeyT
 
 	switch d.Name {


### PR DESCRIPTION
Hey Markus!

I just found that in map 1 (dust2) of this demo https://www.hltv.org/matches/2322780/liquid-vs-astralis-esl-pro-league-season-7-finals, the demo recording is started _after_ players have connected. 

This means that no events are dispatched until `playersByUserID` has length > 0. `playersByUserID` is updated _later_ than `Parser.rawPlayers`, and does not necessarily contain any players before interesting events (e.g. `MatchStart`), although there are players on the server.

Here's a suggestion for a fix