### PR TITLE
Inferno: fix bug where 0 z-dimension gives weird convex hull

### DIFF
--- a/common/inferno.go
+++ b/common/inferno.go
@@ -60,7 +60,7 @@ func (inf Inferno) ConvexHull2D() *s2.Loop {
 			Vector: r3.Vector{
 				X: f.Vector.X,
 				Y: f.Vector.Y,
-				Z: 0,
+				Z: 1,
 			},
 		})
 	}

--- a/common/inferno_test.go
+++ b/common/inferno_test.go
@@ -67,9 +67,9 @@ func TestInfernoConvexHull2D(t *testing.T) {
 	}
 
 	expectedHull := s2.LoopFromPoints([]s2.Point{
-		s2.Point{Vector: r3.Vector{X: 4, Y: 7, Z: 0}},
-		s2.Point{Vector: r3.Vector{X: 1, Y: 2, Z: 0}},
-		s2.Point{Vector: r3.Vector{X: 7, Y: 2, Z: 0}},
+		s2.Point{Vector: r3.Vector{X: 4, Y: 7, Z: 1}},
+		s2.Point{Vector: r3.Vector{X: 1, Y: 2, Z: 1}},
+		s2.Point{Vector: r3.Vector{X: 7, Y: 2, Z: 1}},
 	})
 
 	assert.ElementsMatch(t, expectedHull.Vertices(), inf.ConvexHull2D().Vertices(), "ConvexHull2D should be as expected")


### PR DESCRIPTION
Hey!

I just found that the update to using `z = 0` in inferno positions (7625fa0aead) makes the convex hull algorithm yield a weird result. This PR should fix it :slightly_smiling_face: 

The following screenshots are taken with with z=0 and z=1, respectively
![nade_trajectories_with_0](https://user-images.githubusercontent.com/1486636/47285797-91357d00-d5ec-11e8-9cc2-8b16a90b9e68.jpg)

![nade_trajectories_with_1](https://user-images.githubusercontent.com/1486636/47285799-9397d700-d5ec-11e8-9523-769bfb45de0e.jpg)
