### PR TITLE
datatables: default inferno fires to IsBurning=true

### DIFF
--- a/datatables.go
+++ b/datatables.go
@@ -438,7 +438,7 @@ func (p *Parser) bindNewInferno(entity *st.Entity) {
 				Z: float64(entity.FindProperty("m_fireZDelta." + iStr).Value().IntVal),
 			}
 
-			fire := &common.Fire{Vector: origin.Add(offset)}
+			fire := &common.Fire{Vector: origin.Add(offset), IsBurning: true}
 			entity.BindProperty("m_bFireIsBurning."+iStr, &fire.IsBurning, st.ValTypeBoolInt)
 
 			inf.Fires = append(inf.Fires, fire)


### PR DESCRIPTION
Hey Markus!

As far as I can tell, `m_bFireIsBurning` is not triggered when it starts burning, but it only appears in the list if it actually _is_ burning. So it seems that it should be defaulted to true :slightly_smiling_face: 