### PR TITLE
events: Add TeamSideSwitch, GameHalfEnd, GamePhaseChanged

### DIFF
--- a/common/gamerules.go
+++ b/common/gamerules.go
@@ -1,0 +1,60 @@
+package common
+
+// GamePhase represents a phase in CS:GO
+type GamePhase int
+
+// The following game rules have been found at https://github.com/pmrowla/hl2sdk-csgo/blob/master/game/shared/teamplayroundbased_gamerules.h#L37.
+// It seems that the naming used in the source engine is _not_ what is used in-game.
+// The original names of the enum fields are added as comments to each field.
+const (
+	// GamePhaseInit is the default value of the game phase
+	GamePhaseInit GamePhase = 0 // enum name: Init
+
+	// GamePhasePregame
+	GamePhasePregame GamePhase = 1 // enum name: Pregame
+
+	// GamePhaseStartGamePhase is set whenever a new game phase is started.
+	// A game phase can be the normal match, i.e. first to 16 rounds, or an overtime match,
+	// i.e. first to 4 rounds. It is set for _all_ overtimes played, i.e. for a match
+	// with 3 overtimes,  GamePhaseStartGamePhase is set 1 time for the normal
+	// match and 1 time for each overtime played, for a total of 4 times.
+	GamePhaseStartGamePhase GamePhase = 2 // enum name: StartGame
+
+	// GamePhaseTeamSideSwitch is set whenever a team side switch happened,
+	// i.e. both during normal game and overtime play.
+	GamePhaseTeamSideSwitch GamePhase = 3 // enum name: PreRound
+
+	// GamePhaseGameHalfEnded is set whenever a game phase has ended.
+	// A game phase can be the normal match, i.e. first to 16 rounds, or an overtime match,
+	// i.e. first to 4 rounds. It is set once for all overtimes played, i.e. for a match
+	// with 3 overtimes,  GamePhaseGameHalfEnded is set 1 time for the normal
+	// match and 1 time for each overtime played, for a total of 4 times.
+	GamePhaseGameHalfEnded GamePhase = 4 // enum name: TeamWin
+
+	// GamePhaseGameEnded is set when the full game has ended.
+	// This existence of this event is not reliable: it has been observed that a demo ends
+	// before this event is set
+	GamePhaseGameEnded GamePhase = 5 // enum name: Restart
+
+	// GamePhaseStaleMate has not been observed so far
+	GamePhaseStaleMate GamePhase = 6 // enum name: StaleMate
+
+	// GamePhaseGameOver has not been observed so far
+	GamePhaseGameOver GamePhase = 7 // enum name: GameOver
+)
+
+// gamePhaseToString maps a GamePhase to a user friendly string
+var gamePhaseToString = map[GamePhase]string{
+	GamePhaseInit:           "Init",
+	GamePhasePregame:        "Pregame",
+	GamePhaseStartGamePhase: "Start game phase",
+	GamePhaseTeamSideSwitch: "Team side switch",
+	GamePhaseGameHalfEnded:  "Game half ended",
+	GamePhaseGameEnded:      "Game ended",
+	GamePhaseStaleMate:      "StaleMate",
+	GamePhaseGameOver:       "GameOver",
+}
+
+func (r GamePhase) String() string {
+	return gamePhaseToString[r]
+}

--- a/events/events.go
+++ b/events/events.go
@@ -437,3 +437,20 @@ type ScoreUpdated struct {
 	NewScore  int
 	TeamState *common.TeamState
 }
+
+// GamePhaseChanged signals that the game phase has changed. This event is for advanced usage, as more
+// user friendly events are available for important game phase changes, such as TeamSideSwitch and GameHalfEnded.
+type GamePhaseChanged struct {
+	OldGamePhase common.GamePhase
+	NewGamePhase common.GamePhase
+}
+
+// TeamSideSwitch signals that teams are switching sides, i.e. swapping between T and CT.
+// TeamSideSwitch is usually dispatched in the beginning of a round, just after OnRoundStart.
+type TeamSideSwitch struct {
+}
+
+// GameHalfEnded signals that the currently ongoing game half has ended.
+// GameHalfEnded is usually dispatched in the end of a round, just before RoundEndOfficial.
+type GameHalfEnded struct {
+}

--- a/game_state.go
+++ b/game_state.go
@@ -81,6 +81,7 @@ func (gs GameState) Bomb() *common.Bomb {
 	return &gs.bomb
 }
 
+// TotalRoundsPlayed returns the amount of total rounds played according to CCSGameRulesProxy.
 func (gs GameState) TotalRoundsPlayed() int {
 	return gs.totalRoundsPlayed
 }

--- a/game_state.go
+++ b/game_state.go
@@ -16,6 +16,8 @@ type GameState struct {
 	infernos           map[int]*common.Inferno           // Maps entity-IDs to active infernos.
 	entities           map[int]*st.Entity                // Maps entity IDs to entities
 	bomb               common.Bomb
+	totalRoundsPlayed  int
+	gamePhase          common.GamePhase
 }
 
 type ingameTickNumber int
@@ -77,6 +79,10 @@ func (gs GameState) Entities() map[int]*st.Entity {
 // Bomb returns the current bomb state.
 func (gs GameState) Bomb() *common.Bomb {
 	return &gs.bomb
+}
+
+func (gs GameState) TotalRoundsPlayed() int {
+	return gs.totalRoundsPlayed
 }
 
 func newGameState() GameState {

--- a/parsing.go
+++ b/parsing.go
@@ -15,6 +15,7 @@ const maxOsPath = 260
 const (
 	playerWeaponPrefix    = "m_hMyWeapons."
 	playerWeaponPrePrefix = "bcc_nonlocaldata."
+	gameRulesPrefix       = "cs_gamerules_data"
 )
 
 // Parsing errors


### PR DESCRIPTION
Hey Markus!

I just stumbled upon a datatable that I'd never seen before. It seems like this datatable holds "facts" that have to be true in order for the demo to be rendered correctly in-game. 
My guess is that some of our problems w.r.t. e.g. missing `RoundEnd` events can be solved (or mitigated) using some of these fields.

I have been looking for a reliable way to detect team side switches for a long time, and I believe that the secret was hidden in `CCSGameRulesProxy` all along!

I've tested the following with approx 50 demos. They all give the same result: both `GameHalfEnd` and `TeamSideSwitch` are dispatched correctly after 15 rounds played (and are dispatched correctly for overtime as well!)