### PR TITLE
events: Add MatchStartChanged

### DIFF
--- a/datatables.go
+++ b/datatables.go
@@ -497,6 +497,16 @@ func (p *Parser) bindGameRules() {
 		entity.BindProperty(grPrefix("m_totalRoundsPlayed"), &p.gameState.totalRoundsPlayed, st.ValTypeInt)
 		entity.BindProperty(grPrefix("m_bWarmupPeriod"), &p.gameState.isWarmupPeriod, st.ValTypeBoolInt)
 
+		entity.FindProperty(grPrefix("m_bHasMatchStarted")).OnUpdate(func(val st.PropertyValue) {
+			oldMatchStarted := p.gameState.isMatchStarted
+			p.gameState.isMatchStarted = val.IntVal == 1
+
+			p.eventDispatcher.Dispatch(events.MatchStartedChanged{
+				OldIsStarted: oldMatchStarted,
+				NewIsStarted: p.gameState.isMatchStarted,
+			})
+		})
+
 		// TODO: seems like this is more reliable than RoundEnd events
 		// "m_eRoundWinReason"
 

--- a/datatables.go
+++ b/datatables.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 
 	r3 "github.com/golang/geo/r3"
+
 	common "github.com/markus-wa/demoinfocs-golang/common"
 	events "github.com/markus-wa/demoinfocs-golang/events"
 	st "github.com/markus-wa/demoinfocs-golang/sendtables"

--- a/events/events.go
+++ b/events/events.go
@@ -7,7 +7,6 @@ package events
 
 import (
 	r3 "github.com/golang/geo/r3"
-
 	common "github.com/markus-wa/demoinfocs-golang/common"
 	msg "github.com/markus-wa/demoinfocs-golang/msg"
 )
@@ -453,4 +452,11 @@ type TeamSideSwitch struct {
 // GameHalfEnded signals that the currently ongoing game half has ended.
 // GameHalfEnded is usually dispatched in the end of a round, just before RoundEndOfficial.
 type GameHalfEnded struct {
+}
+
+// MatchStartChanged signals that the value of data table DT_GameRulesProxy.m_bHasMatchStarted has changed
+// This can be useful for some demos where the MatchStart event is not sent.
+type MatchStartedChanged struct {
+	OldIsStarted bool
+	NewIsStarted bool
 }

--- a/events/events.go
+++ b/events/events.go
@@ -7,6 +7,7 @@ package events
 
 import (
 	r3 "github.com/golang/geo/r3"
+
 	common "github.com/markus-wa/demoinfocs-golang/common"
 	msg "github.com/markus-wa/demoinfocs-golang/msg"
 )

--- a/game_state.go
+++ b/game_state.go
@@ -19,6 +19,7 @@ type GameState struct {
 	totalRoundsPlayed  int
 	gamePhase          common.GamePhase
 	isWarmupPeriod     bool
+	isMatchStarted     bool
 }
 
 type ingameTickNumber int
@@ -90,6 +91,11 @@ func (gs GameState) TotalRoundsPlayed() int {
 // IsWarmupPeriod returns whether the game is currently in warmup period.
 func (gs GameState) IsWarmupPeriod() bool {
 	return gs.isWarmupPeriod
+}
+
+// IsGameStarted returns whether the match has started according to CCSGameRulesProxy.
+func (gs GameState) IsMatchStarted() bool {
+	return gs.isMatchStarted
 }
 
 func newGameState() GameState {

--- a/game_state.go
+++ b/game_state.go
@@ -88,12 +88,12 @@ func (gs GameState) TotalRoundsPlayed() int {
 	return gs.totalRoundsPlayed
 }
 
-// IsWarmupPeriod returns whether the game is currently in warmup period.
+// IsWarmupPeriod returns whether the game is currently in warmup period according to CCSGameRulesProxy.
 func (gs GameState) IsWarmupPeriod() bool {
 	return gs.isWarmupPeriod
 }
 
-// IsGameStarted returns whether the match has started according to CCSGameRulesProxy.
+// IsMatchStarted returns whether the match has started according to CCSGameRulesProxy.
 func (gs GameState) IsMatchStarted() bool {
 	return gs.isMatchStarted
 }


### PR DESCRIPTION
Hey Markus!

I just ran into another funky demo [1]. In this demo, none of the previous MatchStart events are sent. But, as I had hoped for (yay!), the game rules datatable seems to contain the "truth" about certain things, among them whether a match was started or not. This PR makes it possible to read the `m_bHasMatchStarted` value from the game rules :slightly_smiling_face: 

[1]: https://www.hltv.org/matches/2327377/tyloo-vs-big-starseries-i-league-season-6

