### PR TITLE
Mockable API

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,9 @@ install:
   - go mod download
 
 before_script:
+  # Install interface generator
+  - GO111MODULE=off go get github.com/vburenin/ifacemaker
+
   # Fetch refs for linter
   - git config remote.origin.fetch +refs/heads/*:refs/remotes/origin/*
   - git fetch
@@ -31,6 +34,11 @@ before_script:
 
 script:
   - go build ./...
+
+  # Make sure generated code is up-to-date
+  - go generate
+  - diff_output=$(git diff)
+  - if [[ "$diff_output" != "" ]]; then echo "Generated code is not up-to-date" && echo "$diff_output" && exit 1; fi
 
   # Lint changed code
   - if [[ "$TRAVIS_COMMIT_RANGE" != "" ]]; then commit_range=${TRAVIS_COMMIT_RANGE/.../..} && git diff $commit_range > /dev/null && base_rev=$commit_range || true; fi

--- a/examples/README.md
+++ b/examples/README.md
@@ -9,3 +9,4 @@ Here you can find a overview of examples on how to use demoinfocs-golang.
 |[entities](entities)|Using unhandled data from entities (`Parser.ServerClasses()`)|
 |[net-messages](net-messages)|Parsing and handling custom net-messages|
 |[print-events](print-events)|Printing kills, scores & chat messages|
+|[mocking](mocking)|Using the `fake` package to write unit tests for your code|

--- a/examples/mocking/README.md
+++ b/examples/mocking/README.md
@@ -1,0 +1,104 @@
+# Mocking the parser
+
+This example shows you how to use the provided [`fake` package](https://godoc.org/github.com/markus-wa/demoinfocs-golang/fake) to mock `demoinfocs.IParser` and other parts of the library.
+That way you will be able to write useful unit tests for your application.
+
+## System under test
+
+First, let's have a look at the API of our code, the 'system under test':
+
+```go
+import (
+	dem "github.com/markus-wa/demoinfocs-golang"
+	events "github.com/markus-wa/demoinfocs-golang/events"
+)
+
+func collectKills(parser dem.IParser) (kills []events.Kill, err error) {
+    ...
+}
+```
+
+We deliberately ignore the implementation so we don't make assumptions about the code since it might change in the future.
+
+As you can see `collectKills` takes an `IParser` as input and returns a slice of `events.Kill` and potentially an error.
+
+## Positive test case
+
+Now let's have a look at our first test. Here we want to ensure that all kills are collected and that the order of the collected events is correct.
+
+```go
+import (
+	"errors"
+	"testing"
+
+	assert "github.com/stretchr/testify/assert"
+
+	common "github.com/markus-wa/demoinfocs-golang/common"
+	events "github.com/markus-wa/demoinfocs-golang/events"
+	fake "github.com/markus-wa/demoinfocs-golang/fake"
+)
+
+func TestCollectKills(t *testing.T) {
+	parser := fake.NewParser()
+	kill1 := kill(common.EqAK47)
+	kill2 := kill(common.EqScout)
+	kill3 := kill(common.EqAUG)
+	parser.MockEvents(kill1)        // First frame
+	parser.MockEvents(kill2, kill3) // Second frame
+
+	parser.On("ParseToEnd").Return(nil) // Return no error
+
+	actual, err := collectKills(parser)
+
+	assert.Nil(t, err)
+	expected := []events.Kill{kill1, kill2, kill3}
+	assert.Equal(t, expected, actual)
+}
+
+func kill(wep common.EquipmentElement) events.Kill {
+	eq := common.NewEquipment(wep)
+	return events.Kill{
+		Killer: new(common.Player),
+		Weapon: &eq,
+		Victim: new(common.Player),
+	}
+}
+```
+
+As you can see we first create a mocked parser with `fake.NewParser()`.
+
+Then we create two `Kill` events and add them into the `Parser.Events` map.
+The map index indicates at which frame the events will be sent out, in our case that's during the first and second frame, as we just iterate over the slice indices.
+
+Note: Especially when used together with `Parser.NetMessages` it can be useful to set these indices manually to ensure the events and net-messages are sent at the right moment.
+
+## Negative test case
+
+Last but not least we want to do another test that ensures any error the parser encounters is returned to the callee and not suppressed by our function.
+
+```go
+import (
+	"errors"
+	"testing"
+
+	assert "github.com/stretchr/testify/assert"
+
+	common "github.com/markus-wa/demoinfocs-golang/common"
+	events "github.com/markus-wa/demoinfocs-golang/events"
+	fake "github.com/markus-wa/demoinfocs-golang/fake"
+)
+
+func TestCollectKillsError(t *testing.T) {
+	parser := fake.NewParser()
+	expectedErr := errors.New("Test error")
+	parser.On("ParseToEnd").Return(expectedErr)
+
+	kills, actualErr := collectKills(parser)
+
+	assert.Equal(t, expectedErr, actualErr)
+	assert.Nil(t, kills)
+}
+```
+
+This test simply tells the mock to return the specified error and asserts that our function returns it to us.
+It also makes sure that kills is nil, and not an empty slice.

--- a/examples/mocking/collect_kills.go
+++ b/examples/mocking/collect_kills.go
@@ -1,0 +1,14 @@
+package mocking
+
+import (
+	dem "github.com/markus-wa/demoinfocs-golang"
+	events "github.com/markus-wa/demoinfocs-golang/events"
+)
+
+func collectKills(parser dem.IParser) (kills []events.Kill, err error) {
+	parser.RegisterEventHandler(func(kill events.Kill) {
+		kills = append(kills, kill)
+	})
+	err = parser.ParseToEnd()
+	return
+}

--- a/examples/mocking/mocking_test.go
+++ b/examples/mocking/mocking_test.go
@@ -1,0 +1,49 @@
+package mocking
+
+import (
+	"errors"
+	"testing"
+
+	assert "github.com/stretchr/testify/assert"
+
+	common "github.com/markus-wa/demoinfocs-golang/common"
+	events "github.com/markus-wa/demoinfocs-golang/events"
+	fake "github.com/markus-wa/demoinfocs-golang/fake"
+)
+
+func TestCollectKills(t *testing.T) {
+	parser := fake.NewParser()
+	kill1 := kill(common.EqAK47)
+	kill2 := kill(common.EqScout)
+	kill3 := kill(common.EqAUG)
+	parser.MockEvents(kill1)        // First frame
+	parser.MockEvents(kill2, kill3) // Second frame
+
+	parser.On("ParseToEnd").Return(nil) // Return no error
+
+	actual, err := collectKills(parser)
+
+	assert.Nil(t, err)
+	expected := []events.Kill{kill1, kill2, kill3}
+	assert.Equal(t, expected, actual)
+}
+
+func kill(wep common.EquipmentElement) events.Kill {
+	eq := common.NewEquipment(wep)
+	return events.Kill{
+		Killer: new(common.Player),
+		Weapon: &eq,
+		Victim: new(common.Player),
+	}
+}
+
+func TestCollectKillsError(t *testing.T) {
+	parser := fake.NewParser()
+	expectedErr := errors.New("Test error")
+	parser.On("ParseToEnd").Return(expectedErr)
+
+	kills, actualErr := collectKills(parser)
+
+	assert.Nil(t, kills)
+	assert.Equal(t, expectedErr, actualErr)
+}

--- a/fake/game_state.go
+++ b/fake/game_state.go
@@ -1,0 +1,69 @@
+package fake
+
+import (
+	mock "github.com/stretchr/testify/mock"
+
+	dem "github.com/markus-wa/demoinfocs-golang"
+	common "github.com/markus-wa/demoinfocs-golang/common"
+	st "github.com/markus-wa/demoinfocs-golang/sendtables"
+)
+
+// GameState is a mock for of demoinfocs.IGameState.
+type GameState struct {
+	mock.Mock
+}
+
+// IngameTick is a mock-implementation of IGameState.IngameTick().
+func (gs *GameState) IngameTick() int {
+	return gs.Called().Int(0)
+}
+
+// TeamCounterTerrorists is a mock-implementation of IGameState.TeamCounterTerrorists().
+func (gs *GameState) TeamCounterTerrorists() *common.TeamState {
+	return gs.Called().Get(0).(*common.TeamState)
+}
+
+// TeamTerrorists is a mock-implementation of IGameState.TeamTerrorists().
+func (gs *GameState) TeamTerrorists() *common.TeamState {
+	return gs.Called().Get(0).(*common.TeamState)
+}
+
+// Participants is a mock-implementation of IGameState.Participants().
+func (gs *GameState) Participants() dem.IParticipants {
+	return gs.Called().Get(0).(dem.IParticipants)
+}
+
+// GrenadeProjectiles is a mock-implementation of IGameState.GrenadeProjectiles().
+func (gs *GameState) GrenadeProjectiles() map[int]*common.GrenadeProjectile {
+	return gs.Called().Get(0).(map[int]*common.GrenadeProjectile)
+}
+
+// Infernos is a mock-implementation of IGameState.Infernos().
+func (gs *GameState) Infernos() map[int]*common.Inferno {
+	return gs.Called().Get(0).(map[int]*common.Inferno)
+}
+
+// Entities is a mock-implementation of IGameState.Entities().
+func (gs *GameState) Entities() map[int]*st.Entity {
+	return gs.Called().Get(0).(map[int]*st.Entity)
+}
+
+// Bomb is a mock-implementation of IGameState.Bomb().
+func (gs *GameState) Bomb() *common.Bomb {
+	return gs.Called().Get(0).(*common.Bomb)
+}
+
+// TotalRoundsPlayed is a mock-implementation of IGameState.TotalRoundsPlayed().
+func (gs *GameState) TotalRoundsPlayed() int {
+	return gs.Called().Int(0)
+}
+
+// IsWarmupPeriod is a mock-implementation of IGameState.IsWarmupPeriod().
+func (gs *GameState) IsWarmupPeriod() bool {
+	return gs.Called().Bool(0)
+}
+
+// IsMatchStarted is a mock-implementation of IGameState.IsMatchStarted().
+func (gs *GameState) IsMatchStarted() bool {
+	return gs.Called().Bool(0)
+}

--- a/fake/parser.go
+++ b/fake/parser.go
@@ -1,0 +1,217 @@
+// Package fake provides basic mocks for IParser, IGameState and IParticipants.
+// See examples/mocking (https://github.com/markus-wa/demoinfocs-golang/tree/master/examples/mocking).
+package fake
+
+import (
+	"time"
+
+	dp "github.com/markus-wa/godispatch"
+	mock "github.com/stretchr/testify/mock"
+
+	dem "github.com/markus-wa/demoinfocs-golang"
+	common "github.com/markus-wa/demoinfocs-golang/common"
+	st "github.com/markus-wa/demoinfocs-golang/sendtables"
+)
+
+// Parser is a mock for of demoinfocs.IParser.
+type Parser struct {
+	mock.Mock
+
+	// List of events to be dispatched by frame.
+	// ParseToEnd() / ParseNextFrame() will dispatch them accordingly.
+	// See also: MockEvents() / MockEventsFrame()
+	Events map[int][]interface{}
+
+	// List of net-messages to be dispatched by frame.
+	// ParseToEnd() / ParseNextFrame() will dispatch them accordingly.
+	// See also: MockNetMessages() / MockNetMessagesFrame()
+	NetMessages map[int][]interface{}
+
+	eventDispatcher dp.Dispatcher
+	msgDispatcher   dp.Dispatcher
+	currentFrame    int
+	mockFrame       int
+}
+
+// MockEvents adds entries to Parser.Events.
+// It increments an internal frame-index so each set of events and net-messages added
+// in subsequent calls to this or MockNetMessages() is triggered on a separate frame.
+//
+// See also: MockEventsFrame()
+func (p *Parser) MockEvents(events ...interface{}) {
+	p.MockEventsFrame(p.mockFrame, events...)
+	p.mockFrame++
+}
+
+// MockEventsFrame adds entries to Events that will be dispatched at the frame indicated by the first parameter.
+//
+// See also: MockEvents()
+func (p *Parser) MockEventsFrame(frame int, events ...interface{}) {
+	p.Events[frame] = append(p.Events[frame], events...)
+}
+
+// MockNetMessages adds entries to Parser.NetMessages.
+// It increments an internal frame-index so each set of net-messages and events added
+// in subsequent calls to this or MockEvents() is triggered on a separate frame.
+//
+// See also: MockNetMessagesFrame()
+func (p *Parser) MockNetMessages(messages ...interface{}) {
+	p.MockNetMessagesFrame(p.mockFrame, messages...)
+	p.mockFrame++
+}
+
+// MockNetMessagesFrame adds entries to NetMessages that will be dispatched at the frame indicated by the first parameter.
+//
+// See also: MockNetMessages()
+func (p *Parser) MockNetMessagesFrame(frame int, messages ...interface{}) {
+	p.NetMessages[frame] = append(p.NetMessages[frame], messages...)
+}
+
+// NewParser returns a new parser mock with pre-initialized Events and NetMessages.
+// Pre-mocks RegisterEventHandler() and RegisterNetMessageHandler().
+func NewParser() *Parser {
+	p := &Parser{
+		Events:      make(map[int][]interface{}),
+		NetMessages: make(map[int][]interface{}),
+	}
+
+	p.On("RegisterEventHandler").Return()
+	p.On("RegisterNetMessageHandler").Return()
+
+	return p
+}
+
+// ServerClasses is a mock-implementation of IParser.ServerClasses().
+//
+// Unfortunately sendtables.ServerClasses currently isn't mockable.
+func (p *Parser) ServerClasses() st.ServerClasses {
+	return p.Called().Get(0).(st.ServerClasses)
+}
+
+// Header is a mock-implementation of IParser.Header().
+func (p *Parser) Header() common.DemoHeader {
+	return p.Called().Get(0).(common.DemoHeader)
+}
+
+// GameState is a mock-implementation of IParser.GameState().
+func (p *Parser) GameState() dem.IGameState {
+	return p.Called().Get(0).(dem.IGameState)
+}
+
+// CurrentFrame is a mock-implementation of IParser.CurrentFrame().
+func (p *Parser) CurrentFrame() int {
+	return p.Called().Int(0)
+}
+
+// CurrentTime is a mock-implementation of IParser.CurrentTime().
+func (p *Parser) CurrentTime() time.Duration {
+	return p.Called().Get(0).(time.Duration)
+}
+
+// Progress is a mock-implementation of IParser.Progress().
+func (p *Parser) Progress() float32 {
+	return p.Called().Get(0).(float32)
+}
+
+// RegisterEventHandler is a mock-implementation of IParser.RegisterEventHandler().
+// Return HandlerIdentifier cannot be mocked (for now).
+func (p *Parser) RegisterEventHandler(handler interface{}) dp.HandlerIdentifier {
+	p.Called()
+	return p.eventDispatcher.RegisterHandler(handler)
+}
+
+// UnregisterEventHandler is a mock-implementation of IParser.UnregisterEventHandler().
+func (p *Parser) UnregisterEventHandler(identifier dp.HandlerIdentifier) {
+	p.Called()
+	p.eventDispatcher.UnregisterHandler(identifier)
+}
+
+// RegisterNetMessageHandler is a mock-implementation of IParser.RegisterNetMessageHandler().
+// Return HandlerIdentifier cannot be mocked (for now).
+func (p *Parser) RegisterNetMessageHandler(handler interface{}) dp.HandlerIdentifier {
+	p.Called()
+	return p.msgDispatcher.RegisterHandler(handler)
+}
+
+// UnregisterNetMessageHandler is a mock-implementation of IParser.UnregisterNetMessageHandler().
+func (p *Parser) UnregisterNetMessageHandler(identifier dp.HandlerIdentifier) {
+	p.Called()
+	p.msgDispatcher.UnregisterHandler(identifier)
+}
+
+// ParseHeader is a mock-implementation of IParser.ParseHeader().
+func (p *Parser) ParseHeader() (common.DemoHeader, error) {
+	args := p.Called()
+	return args.Get(0).(common.DemoHeader), args.Error(1)
+}
+
+// ParseToEnd is a mock-implementation of IParser.ParseToEnd().
+//
+// Dispatches Parser.Events and Parser.NetMessages in the specified order.
+//
+// Returns the mocked error value.
+func (p *Parser) ParseToEnd() (err error) {
+	args := p.Called()
+
+	maxFrame := max(p.Events)
+	maxNetMessageFrame := max(p.NetMessages)
+	if maxFrame < maxNetMessageFrame {
+		maxFrame = maxNetMessageFrame
+	}
+
+	for p.currentFrame <= maxFrame {
+		p.parseNextFrame()
+	}
+
+	return args.Error(0)
+}
+
+func (p *Parser) parseNextFrame() {
+	events, ok := p.Events[p.currentFrame]
+	if ok {
+		for _, e := range events {
+			p.eventDispatcher.Dispatch(e)
+		}
+	}
+
+	messages, ok := p.NetMessages[p.currentFrame]
+	if ok {
+		for _, msg := range messages {
+			p.msgDispatcher.Dispatch(msg)
+		}
+	}
+
+	p.currentFrame++
+}
+
+// ParseNextFrame is a mock-implementation of IParser.ParseNextFrame().
+//
+// Dispatches Parser.Events and Parser.NetMessages in the specified order.
+//
+// Returns the mocked bool and error values.
+func (p *Parser) ParseNextFrame() (b bool, err error) {
+	args := p.Called()
+
+	p.parseNextFrame()
+
+	return args.Bool(0), args.Error(1)
+}
+
+func max(numbers map[int][]interface{}) (maxNumber int) {
+	for maxNumber = range numbers {
+		break
+	}
+	for n := range numbers {
+		if n > maxNumber {
+			maxNumber = n
+		}
+	}
+	return
+}
+
+// Cancel is a mock-implementation of IParser.Cancel().
+// Does not cancel the mock's ParseToEnd() function,
+// mock the return value of ParseToEnd() to be ErrCancelled instead.
+func (p *Parser) Cancel() {
+	p.Called()
+}

--- a/fake/parser_test.go
+++ b/fake/parser_test.go
@@ -1,0 +1,130 @@
+package fake_test
+
+import (
+	"testing"
+	"time"
+
+	assert "github.com/stretchr/testify/assert"
+
+	common "github.com/markus-wa/demoinfocs-golang/common"
+	events "github.com/markus-wa/demoinfocs-golang/events"
+	fake "github.com/markus-wa/demoinfocs-golang/fake"
+	msg "github.com/markus-wa/demoinfocs-golang/msg"
+)
+
+func TestParseHeader(t *testing.T) {
+	p := fake.NewParser()
+	expected := common.DemoHeader{
+		Filestamp:      "HL2DEMO",
+		MapName:        "de_cache",
+		PlaybackFrames: 64 * 1000,
+		PlaybackTicks:  128 * 1000,
+		PlaybackTime:   time.Second * 1000,
+	}
+	p.On("ParseHeader").Return(expected, nil)
+
+	actual, err := p.ParseHeader()
+
+	assert.Nil(t, err)
+	assert.Equal(t, expected, actual)
+}
+
+func TestParseNextFrameEvents(t *testing.T) {
+	p := fake.NewParser()
+	p.On("ParseNextFrame").Return(true, nil)
+	expected := []interface{}{kill(common.EqAK47), kill(common.EqScout)}
+	p.MockEvents(expected...)
+	// Kill on second frame that shouldn't be dispatched during the first frame
+	p.MockEvents(kill(common.EqAUG))
+
+	var actual []interface{}
+	p.RegisterEventHandler(func(e events.Kill) {
+		actual = append(actual, e)
+	})
+
+	next, err := p.ParseNextFrame()
+
+	assert.True(t, next)
+	assert.Nil(t, err)
+	assert.Equal(t, expected, actual)
+}
+
+func kill(wepType common.EquipmentElement) events.Kill {
+	wep := common.NewEquipment(wepType)
+	return events.Kill{
+		Killer: common.NewPlayer(),
+		Weapon: &wep,
+		Victim: common.NewPlayer(),
+	}
+}
+
+func TestParseToEndEvents(t *testing.T) {
+	p := fake.NewParser()
+	p.On("ParseToEnd").Return(nil)
+	expected := []interface{}{kill(common.EqAK47), kill(common.EqScout), kill(common.EqAUG)}
+	p.MockEvents(expected[:1]...)
+	p.MockEvents(expected[1:]...)
+
+	var actual []interface{}
+	p.RegisterEventHandler(func(e events.Kill) {
+		actual = append(actual, e)
+	})
+
+	err := p.ParseToEnd()
+
+	assert.Nil(t, err)
+	assert.Equal(t, expected, actual)
+}
+
+func TestParseNextFrameNetMessages(t *testing.T) {
+	p := fake.NewParser()
+	p.On("ParseNextFrame").Return(true, nil)
+	expected := []interface{}{
+		cmdKey(1, 2, 3),
+		cmdKey(100, 255, 8),
+	}
+
+	p.MockNetMessages(expected...)
+	// Message on second frame that shouldn't be dispatched during the first frame
+	p.MockNetMessages(msg.CSVCMsg_Menu{DialogType: 1, MenuKeyValues: []byte{1, 55, 99}})
+
+	var actual []interface{}
+	p.RegisterNetMessageHandler(func(message interface{}) {
+		actual = append(actual, message)
+	})
+
+	next, err := p.ParseNextFrame()
+
+	assert.True(t, next)
+	assert.Nil(t, err)
+	assert.Equal(t, expected, actual)
+}
+
+func TestParseToEndNetMessages(t *testing.T) {
+	p := fake.NewParser()
+	p.On("ParseToEnd").Return(nil)
+	expected := []interface{}{
+		cmdKey(1, 2, 3),
+		cmdKey(100, 255, 8),
+		msg.CSVCMsg_Menu{DialogType: 1, MenuKeyValues: []byte{1, 55, 99}},
+	}
+
+	p.MockNetMessages(expected[:1]...)
+	p.MockNetMessages(expected[1:]...)
+
+	var actual []interface{}
+	p.RegisterNetMessageHandler(func(message interface{}) {
+		actual = append(actual, message)
+	})
+
+	err := p.ParseToEnd()
+
+	assert.Nil(t, err)
+	assert.Equal(t, expected, actual)
+}
+
+func cmdKey(b ...byte) msg.CSVCMsg_CmdKeyValues {
+	return msg.CSVCMsg_CmdKeyValues{
+		Keyvalues: b,
+	}
+}

--- a/fake/participants.go
+++ b/fake/participants.go
@@ -1,0 +1,42 @@
+package fake
+
+import (
+	mock "github.com/stretchr/testify/mock"
+
+	common "github.com/markus-wa/demoinfocs-golang/common"
+)
+
+// Participants is a mock for of demoinfocs.IParticipants.
+type Participants struct {
+	mock.Mock
+}
+
+// ByUserID is a mock-implementation of IParticipants.ByUserID().
+func (ptcp *Participants) ByUserID() map[int]*common.Player {
+	return ptcp.Called().Get(0).(map[int]*common.Player)
+}
+
+// ByEntityID is a mock-implementation of IParticipants.ByEntityID().
+func (ptcp *Participants) ByEntityID() map[int]*common.Player {
+	return ptcp.Called().Get(0).(map[int]*common.Player)
+}
+
+// All is a mock-implementation of IParticipants.All().
+func (ptcp *Participants) All() []*common.Player {
+	return ptcp.Called().Get(0).([]*common.Player)
+}
+
+// Playing is a mock-implementation of IParticipants.Playing().
+func (ptcp *Participants) Playing() []*common.Player {
+	return ptcp.Called().Get(0).([]*common.Player)
+}
+
+// TeamMembers is a mock-implementation of IParticipants.TeamMembers().
+func (ptcp *Participants) TeamMembers(team common.Team) []*common.Player {
+	return ptcp.Called().Get(0).([]*common.Player)
+}
+
+// FindByHandle is a mock-implementation of IParticipants.FindByHandle().
+func (ptcp *Participants) FindByHandle(handle int) *common.Player {
+	return ptcp.Called().Get(0).(*common.Player)
+}

--- a/game_state.go
+++ b/game_state.go
@@ -5,6 +5,9 @@ import (
 	st "github.com/markus-wa/demoinfocs-golang/sendtables"
 )
 
+//go:generate ifacemaker -f game_state.go -s GameState -i IGameState -p demoinfocs -D -y "IGameState is an auto-generated interface for GameState." -c "DO NOT EDIT: Auto generated" -o game_state_interface.go
+//go:generate ifacemaker -f game_state.go -s Participants -i IParticipants -p demoinfocs -D -y "IParticipants is an auto-generated interface for Participants." -c "DO NOT EDIT: Auto generated" -o participants_interface.go
+
 // GameState contains all game-state relevant information.
 type GameState struct {
 	ingameTick         int
@@ -52,7 +55,7 @@ func (gs *GameState) TeamTerrorists() *common.TeamState {
 
 // Participants returns a struct with all currently connected players & spectators and utility functions.
 // The struct contains references to the original maps so it's always up-to-date.
-func (gs GameState) Participants() Participants {
+func (gs GameState) Participants() IParticipants {
 	return Participants{
 		playersByEntityID: gs.playersByEntityID,
 		playersByUserID:   gs.playersByUserID,

--- a/game_state_interface.go
+++ b/game_state_interface.go
@@ -1,0 +1,46 @@
+// DO NOT EDIT: Auto generated
+
+package demoinfocs
+
+import (
+	"github.com/markus-wa/demoinfocs-golang/common"
+	st "github.com/markus-wa/demoinfocs-golang/sendtables"
+)
+
+// IGameState is an auto-generated interface for GameState.
+// GameState contains all game-state relevant information.
+type IGameState interface {
+	// IngameTick returns the latest actual tick number of the server during the game.
+	//
+	// Watch out, I've seen this return wonky negative numbers at the start of demos.
+	IngameTick() int
+	// TeamCounterTerrorists returns the TeamState of the CT team.
+	//
+	// Make sure to handle swapping sides properly if you keep the reference.
+	TeamCounterTerrorists() *common.TeamState
+	// TeamTerrorists returns the TeamState of the T team.
+	//
+	// Make sure to handle swapping sides properly if you keep the reference.
+	TeamTerrorists() *common.TeamState
+	// Participants returns a struct with all currently connected players & spectators and utility functions.
+	// The struct contains references to the original maps so it's always up-to-date.
+	Participants() IParticipants
+	// GrenadeProjectiles returns a map from entity-IDs to all live grenade projectiles.
+	//
+	// Only constains projectiles currently in-flight or still active (smokes etc.),
+	// i.e. have been thrown but have yet to detonate.
+	GrenadeProjectiles() map[int]*common.GrenadeProjectile
+	// Infernos returns a map from entity-IDs to all currently burning infernos (fires from incendiaries and Molotovs).
+	Infernos() map[int]*common.Inferno
+	// Entities returns all currently existing entities.
+	// (Almost?) everything in the game is an entity, such as weapons, players, fire etc.
+	Entities() map[int]*st.Entity
+	// Bomb returns the current bomb state.
+	Bomb() *common.Bomb
+	// TotalRoundsPlayed returns the amount of total rounds played according to CCSGameRulesProxy.
+	TotalRoundsPlayed() int
+	// IsWarmupPeriod returns whether the game is currently in warmup period according to CCSGameRulesProxy.
+	IsWarmupPeriod() bool
+	// IsMatchStarted returns whether the match has started according to CCSGameRulesProxy.
+	IsMatchStarted() bool
+}

--- a/go.mod
+++ b/go.mod
@@ -11,6 +11,7 @@ require (
 	github.com/markus-wa/gobitread v0.2.2
 	github.com/markus-wa/godispatch v1.1.0
 	github.com/pmezard/go-difflib v1.0.0 // indirect
+	github.com/stretchr/objx v0.1.1 // indirect
 	github.com/stretchr/testify v1.2.2
 	golang.org/x/image v0.0.0-20180708004352-c73c2afc3b81 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -20,6 +20,8 @@ github.com/markus-wa/godispatch v1.1.0 h1:J8O+hRkOCexDUQevaSKWDtKeZ3+HcmbEUKY1uY
 github.com/markus-wa/godispatch v1.1.0/go.mod h1:6o18u24oo58yseMXYD0zQFI6LbSkjJSSBQ4YyDqFX5c=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/objx v0.1.1 h1:2vfRuCMp5sSVIDSqO8oNnWJq7mPa6KVP3iPIwFBuy8A=
+github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.2.2 h1:bSDNvY7ZPG5RlJ8otE/7V6gMiyenm9RtJ7IUVIAoJ1w=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 golang.org/x/image v0.0.0-20180708004352-c73c2afc3b81 h1:00VmoueYNlNz/aHIilyyQz/MHSqGoWJzpFv/HW8xpzI=

--- a/parser.go
+++ b/parser.go
@@ -14,9 +14,11 @@ import (
 	st "github.com/markus-wa/demoinfocs-golang/sendtables"
 )
 
+//go:generate ifacemaker -f parser.go -f parsing.go -s Parser -i IParser -p demoinfocs -D -y "IParser is an auto-generated interface for Parser, intended to be used when mockability is needed." -c "DO NOT EDIT: Auto generated" -o parser_interface.go
+
 /*
 Parser can parse a CS:GO demo.
-Creating a Parser is done via NewParser().
+Creating a new instance is done via NewParser().
 
 To start off you may use Parser.ParseHeader() to parse the demo header
 (this can be skipped and will be done automatically if necessary).
@@ -98,7 +100,7 @@ func (p *Parser) Header() common.DemoHeader {
 
 // GameState returns the current game-state.
 // It contains most of the relevant information about the game such as players, teams, scores, grenades etc.
-func (p *Parser) GameState() *GameState {
+func (p *Parser) GameState() IGameState {
 	return &p.gameState
 }
 

--- a/parser_interface.go
+++ b/parser_interface.go
@@ -1,0 +1,114 @@
+// DO NOT EDIT: Auto generated
+
+package demoinfocs
+
+import (
+	"time"
+
+	common "github.com/markus-wa/demoinfocs-golang/common"
+	st "github.com/markus-wa/demoinfocs-golang/sendtables"
+	dp "github.com/markus-wa/godispatch"
+)
+
+// IParser is an auto-generated interface for Parser, intended to be used when mockability is needed.
+// Parser can parse a CS:GO demo.
+// Creating a new instance is done via NewParser().
+//
+// To start off you may use Parser.ParseHeader() to parse the demo header
+// (this can be skipped and will be done automatically if necessary).
+// Further, Parser.ParseNextFrame() and Parser.ParseToEnd() can be used to parse the demo.
+//
+// Use Parser.RegisterEventHandler() to receive notifications about events.
+//
+// Example (without error handling):
+//
+// 	f, _ := os.Open("/path/to/demo.dem")
+// 	p := dem.NewParser(f)
+// 	header := p.ParseHeader()
+// 	fmt.Println("Map:", header.MapName)
+// 	p.RegisterEventHandler(func(e events.BombExplode) {
+// 		fmt.Printf(e.Site, "went BOOM!")
+// 	})
+// 	p.ParseToEnd()
+//
+// Prints out '{A/B} site went BOOM!' when a bomb explodes.
+type IParser interface {
+	// ServerClasses returns the server-classes of this demo.
+	// These are available after events.DataTablesParsed has been fired.
+	ServerClasses() st.ServerClasses
+	// Header returns the DemoHeader which contains the demo's metadata.
+	// Only possible after ParserHeader() has been called.
+	Header() common.DemoHeader
+	// GameState returns the current game-state.
+	// It contains most of the relevant information about the game such as players, teams, scores, grenades etc.
+	GameState() IGameState
+	// CurrentFrame return the number of the current frame, aka. 'demo-tick' (Since demos often have a different tick-rate than the game).
+	// Starts with frame 0, should go up to DemoHeader.PlaybackFrames but might not be the case (usually it's just close to it).
+	CurrentFrame() int
+	// CurrentTime returns the time elapsed since the start of the demo
+	CurrentTime() time.Duration
+	// Progress returns the parsing progress from 0 to 1.
+	// Where 0 means nothing has been parsed yet and 1 means the demo has been parsed to the end.
+	//
+	// Might not be 100% correct since it's just based on the reported tick count of the header.
+	Progress() float32
+	/*
+	   RegisterEventHandler registers a handler for game events.
+
+	   The handler must be of type func(<EventType>) where EventType is the kind of event to be handled.
+	   To catch all events func(interface{}) can be used.
+
+	   Example:
+
+	   	parser.RegisterEventHandler(func(e events.WeaponFired) {
+	   		fmt.Printf("%s fired his %s\n", e.Shooter.Name, e.Weapon.Weapon)
+	   	})
+
+	   Parameter handler has to be of type interface{} because lolnogenerics.
+
+	   Returns a identifier with which the handler can be removed via UnregisterEventHandler().
+	*/
+	RegisterEventHandler(handler interface{}) dp.HandlerIdentifier
+	// UnregisterEventHandler removes a game event handler via identifier.
+	//
+	// The identifier is returned at registration by RegisterEventHandler().
+	UnregisterEventHandler(identifier dp.HandlerIdentifier)
+	/*
+	   RegisterNetMessageHandler registers a handler for net-messages.
+
+	   The handler must be of type func(*<MessageType>) where MessageType is the kind of net-message to be handled.
+
+	   Returns a identifier with which the handler can be removed via UnregisterNetMessageHandler().
+
+	   See also: RegisterEventHandler()
+	*/
+	RegisterNetMessageHandler(handler interface{}) dp.HandlerIdentifier
+	// UnregisterNetMessageHandler removes a net-message handler via identifier.
+	//
+	// The identifier is returned at registration by RegisterNetMessageHandler().
+	UnregisterNetMessageHandler(identifier dp.HandlerIdentifier)
+	// ParseHeader attempts to parse the header of the demo and returns it.
+	// If not done manually this will be called by Parser.ParseNextFrame() or Parser.ParseToEnd().
+	//
+	// Returns ErrInvalidFileType if the filestamp (first 8 bytes) doesn't match HL2DEMO.
+	ParseHeader() (common.DemoHeader, error)
+	// ParseToEnd attempts to parse the demo until the end.
+	// Aborts and returns ErrCancelled if Cancel() is called before the end.
+	//
+	// See also: ParseNextFrame() for other possible errors.
+	ParseToEnd() (err error)
+	// Cancel aborts ParseToEnd().
+	// All information that was already read up to this point may still be used (and new events may still be sent out).
+	Cancel()
+	/*
+	   ParseNextFrame attempts to parse the next frame / demo-tick (not ingame tick).
+
+	   Returns true unless the demo command 'stop' or an error was encountered.
+
+	   May return ErrUnexpectedEndOfDemo for incomplete / corrupt demos.
+	   May panic if the demo is corrupt in some way.
+
+	   See also: ParseToEnd() for parsing the complete demo in one go (faster).
+	*/
+	ParseNextFrame() (b bool, err error)
+}

--- a/participants_interface.go
+++ b/participants_interface.go
@@ -1,0 +1,34 @@
+// DO NOT EDIT: Auto generated
+
+package demoinfocs
+
+import (
+	"github.com/markus-wa/demoinfocs-golang/common"
+)
+
+// IParticipants is an auto-generated interface for Participants.
+// Participants provides helper functions on top of the currently connected players.
+// E.g. ByUserID(), ByEntityID(), TeamMembers(), etc.
+//
+// See GameState.Participants()
+type IParticipants interface {
+	// ByUserID returns all currently connected players in a map where the key is the user-ID.
+	// The map is a snapshot and is not updated (not a reference to the actual, underlying map).
+	// Includes spectators.
+	ByUserID() map[int]*common.Player
+	// ByEntityID returns all currently connected players in a map where the key is the entity-ID.
+	// The map is a snapshot and is not updated (not a reference to the actual, underlying map).
+	// Includes spectators.
+	ByEntityID() map[int]*common.Player
+	// All returns all currently connected players & spectators.
+	All() []*common.Player
+	// Playing returns all players that aren't spectating or unassigned.
+	Playing() []*common.Player
+	// TeamMembers returns all players belonging to the requested team at this time.
+	TeamMembers(team common.Team) []*common.Player
+	// FindByHandle attempts to find a player by his entity-handle.
+	// The entity-handle is often used in entity-properties when referencing other entities such as a weapon's owner.
+	//
+	// Returns nil if not found or if handle == invalidEntityHandle (used when referencing no entity).
+	FindByHandle(handle int) *common.Player
+}


### PR DESCRIPTION
pinging @micvbang 

This is my counter proposal to #57.

As we've discussed there I looked into interface generation to avoid godoc and Intellisense issues.
I found that another nice side-effect of this approach is that the impact on consumers is a bit lighter as they won't need to change their variable/field types from `*Parser` to `Parser` now (though for `GameState` and `Participants` that 'issue' remains).

I also added a new package `mock` that provides basic but (hopefully) extendable mocks for the various interfaces, so not everyone needs to re-implement them unless there's a specific need.

Lastly I added an example on how to use the mocks to write unit tests: https://github.com/markus-wa/demoinfocs-golang/tree/mockable-api/examples/mocking

For the last two I took a lot of inspiration from your gist which was very helpful 😄.

It would be great if you could check if there's something I missed or if this would work for you. Thanks in advance.