### PR TITLE
events: add Attacker & FlashDuration() to PlayerFlashed event

### DIFF
--- a/events/events.go
+++ b/events/events.go
@@ -6,6 +6,8 @@
 package events
 
 import (
+	"time"
+
 	r3 "github.com/golang/geo/r3"
 
 	common "github.com/markus-wa/demoinfocs-golang/common"
@@ -220,7 +222,14 @@ type GrenadeProjectileDestroy struct {
 
 // PlayerFlashed signals that a player was flashed.
 type PlayerFlashed struct {
-	Player *common.Player
+	Player   *common.Player
+	Attacker *common.Player
+}
+
+// FlashDuration returns the duration of the blinding effect.
+// This is just a shortcut for Player.FlashDurationTime().
+func (e PlayerFlashed) FlashDuration() time.Duration {
+	return e.Player.FlashDurationTime()
 }
 
 // BombEventIf is the interface for all the bomb events. Like GrenadeEventIf for GrenadeEvents.

--- a/events/events_test.go
+++ b/events/events_test.go
@@ -1,0 +1,21 @@
+package events
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/markus-wa/demoinfocs-golang/common"
+)
+
+func TestPlayerFlashed_FlashDuration(t *testing.T) {
+	p := common.NewPlayer()
+	e := PlayerFlashed{Player: p}
+
+	assert.Equal(t, time.Duration(0), e.FlashDuration())
+
+	p.FlashDuration = 2.3
+
+	assert.Equal(t, 2300*time.Millisecond, e.FlashDuration())
+}

--- a/game_state.go
+++ b/game_state.go
@@ -23,6 +23,7 @@ type GameState struct {
 	gamePhase          common.GamePhase
 	isWarmupPeriod     bool
 	isMatchStarted     bool
+	lastFlasher        *common.Player // Last player whose flash exploded, used to find the attacker for player_blind events
 }
 
 type ingameTickNumber int

--- a/parser.go
+++ b/parser.go
@@ -10,6 +10,7 @@ import (
 
 	bit "github.com/markus-wa/demoinfocs-golang/bitread"
 	common "github.com/markus-wa/demoinfocs-golang/common"
+	events "github.com/markus-wa/demoinfocs-golang/events"
 	msg "github.com/markus-wa/demoinfocs-golang/msg"
 	st "github.com/markus-wa/demoinfocs-golang/sendtables"
 )
@@ -68,6 +69,7 @@ type Parser struct {
 	gameEventDescs       map[int32]*msg.CSVCMsg_GameEventListDescriptorT // Maps game-event IDs to descriptors
 	grenadeModelIndices  map[int]common.EquipmentElement                 // Used to map model indices to grenades (used for grenade projectiles)
 	stringTables         []*msg.CSVCMsg_CreateStringTable                // Contains all created sendtables, needed when updating them
+	currentFlashEvents   []events.PlayerFlashed                          // Contains flash events that need to be dispatched at the end of a tick
 }
 
 type bombsite struct {

--- a/parsing.go
+++ b/parsing.go
@@ -273,6 +273,13 @@ func (p *Parser) handleFrameParsed(*frameParsedTokenType) {
 		}
 	}
 
+	// PlayerFlashed events need to be dispatched at the end of the tick
+	// because Player.FlashDuration is updated after the game-events are parsed.
+	for _, e := range p.currentFlashEvents {
+		p.eventDispatcher.Dispatch(e)
+	}
+	p.currentFlashEvents = p.currentFlashEvents[:0]
+
 	p.currentFrame++
 	p.eventDispatcher.Dispatch(events.TickDone{})
 }


### PR DESCRIPTION
Changes to `PlayerFlashed`:
- new attribute `Attacker`
- new utility function `FlashDuration()` - returns `Player.FlashDurationTime()`

Also fixes the issue with `PlayerFlashed.Player.FlashDuration` being 0 in
most cases by waiting with dispatching the events until the end of the tick.

Fixes #70 & #71

@quancore please verify