### PR TITLE
common: add function TeamState.Team()

### DIFF
--- a/common/common.go
+++ b/common/common.go
@@ -105,6 +105,8 @@ func (b Bomb) Position() r3.Vector {
 
 // TeamState contains a team's ID, score, clan name & country flag.
 type TeamState struct {
+	team Team
+
 	// ID stays the same even after switching sides.
 	ID int
 
@@ -115,4 +117,13 @@ type TeamState struct {
 	//
 	// Watch out, in some demos this is upper-case and in some lower-case.
 	Flag string
+}
+
+// Team returns the team for which the TeamState contains data.
+func (ts TeamState) Team() Team {
+	return ts.team
+}
+
+func NewTeamState(team Team) TeamState {
+	return TeamState{team: team}
 }

--- a/common/common.go
+++ b/common/common.go
@@ -117,6 +117,9 @@ type TeamState struct {
 	//
 	// Watch out, in some demos this is upper-case and in some lower-case.
 	Flag string
+
+	// Terrorist TeamState for CTs, CT TeamState for Terrorists
+	Opponent *TeamState
 }
 
 // Team returns the team for which the TeamState contains data.

--- a/common/common_test.go
+++ b/common/common_test.go
@@ -38,3 +38,8 @@ func TestDemoHeader(t *testing.T) {
 	assert.Equal(t, float64(128.0), header.TickRate(), "TickRate should be 128")
 	assert.Equal(t, time.Second/128, header.TickTime(), "TickTime should be 1/128")
 }
+
+func TestTeamState(t *testing.T) {
+	assert.Equal(t, TeamTerrorists, NewTeamState(TeamTerrorists).Team())
+	assert.Equal(t, TeamCounterTerrorists, NewTeamState(TeamCounterTerrorists).Team())
+}

--- a/events/events.go
+++ b/events/events.go
@@ -61,9 +61,11 @@ const (
 // Attention: TeamState.Score() won't be up to date yet after this.
 // Add +1 to the winner's score as a workaround.
 type RoundEnd struct {
-	Message string
-	Reason  RoundEndReason
-	Winner  common.Team
+	Message     string
+	Reason      RoundEndReason
+	Winner      common.Team
+	WinnerState *common.TeamState // TeamState of the winner. May be nil if it's a draw (Winner == TeamSpectators)
+	LoserState  *common.TeamState // TeamState of the loser. May be nil if it's a draw (Winner == TeamSpectators)
 }
 
 // RoundEndOfficial signals that the round has 'officially' ended.
@@ -107,11 +109,20 @@ type Footstep struct {
 
 // PlayerTeamChange occurs when a player swaps teams.
 type PlayerTeamChange struct {
-	Player  *common.Player
+	Player *common.Player
+
 	NewTeam common.Team
+	// TeamState of the old team.
+	// May be nil if player changed from spectators/unassigned (OldTeam == TeamSpectators || OldTeam == TeamUnassigned).
+	NewTeamState *common.TeamState
+
 	OldTeam common.Team
-	Silent  bool
-	IsBot   bool
+	// TeamState of the old team.
+	// May be nil if player changed from spectators/unassigned (OldTeam == TeamSpectators || OldTeam == TeamUnassigned).
+	OldTeamState *common.TeamState
+
+	Silent bool
+	IsBot  bool
 }
 
 // PlayerJump signals that a player has jumped.

--- a/game_state.go
+++ b/game_state.go
@@ -41,6 +41,19 @@ func (gs GameState) IngameTick() int {
 	return gs.ingameTick
 }
 
+// Team returns the TeamState corresponding to team.
+// Returns nil if team != TeamTerrorists && team != TeamCounterTerrorists.
+//
+// Make sure to handle swapping sides properly if you keep the reference.
+func (gs *GameState) Team(team common.Team) *common.TeamState {
+	if team == common.TeamTerrorists {
+		return &gs.tState
+	} else if team == common.TeamCounterTerrorists {
+		return &gs.ctState
+	}
+	return nil
+}
+
 // TeamCounterTerrorists returns the TeamState of the CT team.
 //
 // Make sure to handle swapping sides properly if you keep the reference.
@@ -103,8 +116,8 @@ func (gs GameState) IsMatchStarted() bool {
 	return gs.isMatchStarted
 }
 
-func newGameState() GameState {
-	return GameState{
+func newGameState() *GameState {
+	gs := &GameState{
 		playersByEntityID:  make(map[int]*common.Player),
 		playersByUserID:    make(map[int]*common.Player),
 		grenadeProjectiles: make(map[int]*common.GrenadeProjectile),
@@ -113,6 +126,11 @@ func newGameState() GameState {
 		tState:             common.NewTeamState(common.TeamTerrorists),
 		ctState:            common.NewTeamState(common.TeamCounterTerrorists),
 	}
+
+	gs.tState.Opponent = &gs.ctState
+	gs.ctState.Opponent = &gs.tState
+
+	return gs
 }
 
 // Participants provides helper functions on top of the currently connected players.

--- a/game_state.go
+++ b/game_state.go
@@ -110,6 +110,8 @@ func newGameState() GameState {
 		grenadeProjectiles: make(map[int]*common.GrenadeProjectile),
 		infernos:           make(map[int]*common.Inferno),
 		entities:           make(map[int]*st.Entity),
+		tState:             common.NewTeamState(common.TeamTerrorists),
+		ctState:            common.NewTeamState(common.TeamCounterTerrorists),
 	}
 }
 

--- a/game_state_interface.go
+++ b/game_state_interface.go
@@ -14,6 +14,11 @@ type IGameState interface {
 	//
 	// Watch out, I've seen this return wonky negative numbers at the start of demos.
 	IngameTick() int
+	// Team returns the TeamState corresponding to team.
+	// Returns nil if team != TeamTerrorists && team != TeamCounterTerrorists.
+	//
+	// Make sure to handle swapping sides properly if you keep the reference.
+	Team(team common.Team) *common.TeamState
 	// TeamCounterTerrorists returns the TeamState of the CT team.
 	//
 	// Make sure to handle swapping sides properly if you keep the reference.

--- a/game_state_test.go
+++ b/game_state_test.go
@@ -1,0 +1,16 @@
+package demoinfocs
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/markus-wa/demoinfocs-golang/common"
+)
+
+func TestNewGameState(t *testing.T) {
+	gs := newGameState()
+
+	assert.Equal(t, common.TeamTerrorists, gs.tState.Team())
+	assert.Equal(t, common.TeamCounterTerrorists, gs.ctState.Team())
+}

--- a/game_state_test.go
+++ b/game_state_test.go
@@ -8,9 +8,23 @@ import (
 	"github.com/markus-wa/demoinfocs-golang/common"
 )
 
-func TestNewGameState(t *testing.T) {
+func TestNewGameState_TeamState_Team(t *testing.T) {
 	gs := newGameState()
 
 	assert.Equal(t, common.TeamTerrorists, gs.tState.Team())
 	assert.Equal(t, common.TeamCounterTerrorists, gs.ctState.Team())
+}
+
+func TestNewGameState_TeamState_Pointers(t *testing.T) {
+	gs := newGameState()
+
+	assert.True(t, gs.TeamCounterTerrorists() == &gs.ctState)
+	assert.True(t, gs.TeamTerrorists() == &gs.tState)
+}
+
+func TestNewGameState_TeamState_Opponent(t *testing.T) {
+	gs := newGameState()
+
+	assert.True(t, &gs.ctState == gs.tState.Opponent)
+	assert.True(t, &gs.tState == gs.ctState.Opponent)
 }

--- a/parser.go
+++ b/parser.go
@@ -232,7 +232,7 @@ func NewParserWithConfig(demostream io.Reader, config ParserConfig) *Parser {
 	p.rawPlayers = make(map[int]*playerInfo)
 	p.triggers = make(map[int]*boundingBoxInformation)
 	p.cancelChan = make(chan struct{}, 1)
-	p.gameState = newGameState()
+	p.gameState = *newGameState()
 	p.grenadeModelIndices = make(map[int]common.EquipmentElement)
 
 	// Attach proto msg handlers


### PR DESCRIPTION
Useful for when we have a TeamState but don't know which team's it is
from context.

Fixes #76 

@quancore: does this address the issue as expected?