### PR TITLE
common: fix regression with Inferno convex hulls

### DIFF
--- a/common/inferno.go
+++ b/common/inferno.go
@@ -4,8 +4,8 @@ import (
 	"math/rand"
 	"sort"
 
-	"github.com/golang/geo/r2"
-	"github.com/golang/geo/r3"
+	r2 "github.com/golang/geo/r2"
+	r3 "github.com/golang/geo/r3"
 	quickhull "github.com/markus-wa/quickhull-go"
 )
 

--- a/common/inferno.go
+++ b/common/inferno.go
@@ -122,15 +122,15 @@ func sortPointsClockwise(points []r2.Point) {
 	sort.Sort(sorter)
 }
 
-// ConvexHull3D returns the triangles making up the 3D convex hull of all the fires in the inferno.
-func (inf Inferno) ConvexHull3D() [][3]r3.Vector {
+// ConvexHull3D returns the 3D convex hull of all the fires in the inferno.
+func (inf Inferno) ConvexHull3D() quickhull.ConvexHull {
 	pointCloud := make([]r3.Vector, len(inf.Fires))
 
 	for i, f := range inf.Fires {
 		pointCloud[i] = f.Vector
 	}
 
-	return convexHull(pointCloud).Triangles()
+	return convexHull(pointCloud)
 }
 
 func convexHull(pointCloud []r3.Vector) quickhull.ConvexHull {

--- a/common/inferno.go
+++ b/common/inferno.go
@@ -2,10 +2,11 @@ package common
 
 import (
 	"math/rand"
+	"sort"
 
+	"github.com/golang/geo/r2"
+	"github.com/golang/geo/r3"
 	quickhull "github.com/markus-wa/quickhull-go"
-
-	r3 "github.com/golang/geo/r3"
 )
 
 // Inferno is a list of Fires with helper functions.
@@ -51,31 +52,89 @@ func (inf Inferno) Active() Inferno {
 	return res
 }
 
-// ConvexHull2D returns the vertices making up the 2D convex hull of all the fires in the inferno.
+// ConvexHull2D returns clockwise sorted corner points making up the 2D convex hull of all the fires in the inferno.
 // Useful for drawing on 2D maps.
-func (inf Inferno) ConvexHull2D() []r3.Vector {
-	pointCloud := make([]r3.Vector, 0, len(inf.Fires))
-
-	for _, f := range inf.Fires {
-		pointCloud = append(pointCloud, r3.Vector{
-			X: f.Vector.X,
-			Y: f.Vector.Y,
-			Z: 0,
-		})
+func (inf Inferno) ConvexHull2D() []r2.Point {
+	pointCloud := make([]r3.Vector, len(inf.Fires))
+	for i, f := range inf.Fires {
+		pointCloud[i] = f.Vector
+		pointCloud[i].Z = 0
 	}
 
-	return quickhull.ConvexHull(pointCloud)
+	vertices := convexHull(convexHull(pointCloud).Vertices).Vertices
+	points := make([]r2.Point, len(vertices))
+	for i, v := range vertices {
+		points[i] = r2.Point{X: v.X, Y: v.Y}
+	}
+	sortPointsClockwise(points)
+
+	return points
 }
 
-// ConvexHull3D returns the vertices making up the 3D convex hull of all the fires in the inferno.
-func (inf Inferno) ConvexHull3D() []r3.Vector {
+// pointsClockwiseSorter implements the Sort interface for slices of Point
+// with a comparator for sorting points in clockwise order around their center.
+type pointsClockwiseSorter struct {
+	center r2.Point
+	points []r2.Point
+}
+
+func (s pointsClockwiseSorter) Len() int { return len(s.points) }
+
+func (s pointsClockwiseSorter) Swap(i, j int) { s.points[i], s.points[j] = s.points[j], s.points[i] }
+
+func (s pointsClockwiseSorter) Less(i, j int) bool {
+	a, b := s.points[i], s.points[j]
+
+	if a.X-s.center.X >= 0 && b.X-s.center.X < 0 {
+		return true
+	}
+	if a.X-s.center.X < 0 && b.X-s.center.X >= 0 {
+		return false
+	}
+	if a.X-s.center.X == 0 && b.X-s.center.X == 0 {
+		if a.Y-s.center.Y >= 0 || b.Y-s.center.Y >= 0 {
+			return a.Y > b.Y
+		}
+		return b.Y > a.Y
+	}
+
+	// compute the cross product of vectors (s.center -> a) X (s.center -> b)
+	det := (a.X-s.center.X)*(b.Y-s.center.Y) - (b.X-s.center.X)*(a.Y-s.center.Y)
+	if det < 0 {
+		return true
+	}
+	if det > 0 {
+		return false
+	}
+
+	// points a and b are on the same line from the s.center
+	// check which point is closer to the s.center
+	d1 := (a.X-s.center.X)*(a.X-s.center.X) + (a.Y-s.center.Y)*(a.Y-s.center.Y)
+	d2 := (b.X-s.center.X)*(b.X-s.center.X) + (b.Y-s.center.Y)*(b.Y-s.center.Y)
+	return d1 > d2
+}
+
+func sortPointsClockwise(points []r2.Point) {
+	sorter := pointsClockwiseSorter{
+		center: r2.RectFromPoints(points...).Center(),
+		points: points,
+	}
+	sort.Sort(sorter)
+}
+
+// ConvexHull3D returns the triangles making up the 3D convex hull of all the fires in the inferno.
+func (inf Inferno) ConvexHull3D() [][3]r3.Vector {
 	pointCloud := make([]r3.Vector, len(inf.Fires))
 
 	for i, f := range inf.Fires {
 		pointCloud[i] = f.Vector
 	}
 
-	return quickhull.ConvexHull(pointCloud)
+	return convexHull(pointCloud).Triangles()
+}
+
+func convexHull(pointCloud []r3.Vector) quickhull.ConvexHull {
+	return new(quickhull.QuickHull).ConvexHull(pointCloud, false, false, 0)
 }
 
 // NewInferno creates a inferno and sets the Unique-ID.

--- a/common/inferno_test.go
+++ b/common/inferno_test.go
@@ -104,5 +104,5 @@ func TestInfernoConvexHull3D(t *testing.T) {
 		{X: 4, Y: 4, Z: 12},
 	}
 
-	assert.ElementsMatch(t, expectedHull, inf.ConvexHull3D(), "ConvexHull3D should contain all fire locations")
+	assert.ElementsMatch(t, expectedHull, inf.ConvexHull3D().Vertices, "ConvexHull3D should contain all fire locations")
 }

--- a/common/inferno_test.go
+++ b/common/inferno_test.go
@@ -1,9 +1,9 @@
 package common
 
 import (
-	"github.com/golang/geo/r2"
 	"testing"
 
+	r2 "github.com/golang/geo/r2"
 	r3 "github.com/golang/geo/r3"
 	assert "github.com/stretchr/testify/assert"
 )

--- a/common/inferno_test.go
+++ b/common/inferno_test.go
@@ -1,6 +1,7 @@
 package common
 
 import (
+	"github.com/golang/geo/r2"
 	"testing"
 
 	r3 "github.com/golang/geo/r3"
@@ -65,16 +66,16 @@ func TestInfernoConvexHull2D(t *testing.T) {
 		},
 	}
 
-	expectedHull := []r3.Vector{
-		{X: 1, Y: 2, Z: 0},
-		{X: 4, Y: 7, Z: 0},
-		{X: 7, Y: 2, Z: 0},
+	expectedHull := []r2.Point{
+		{X: 1, Y: 2},
+		{X: 4, Y: 7},
+		{X: 7, Y: 2},
 	}
 
 	assert.ElementsMatch(t, expectedHull, inf.ConvexHull2D(), "ConvexHull2D should be as expected")
 
 	// 3D-hull should be different
-	assert.NotEqual(t, len(expectedHull), len(inf.ConvexHull3D()), "3D hull should contain the vertex 'D'")
+	assert.NotEqual(t, len(expectedHull), len(inf.ConvexHull3D().Vertices), "3D hull should contain the vertex 'D'")
 }
 
 // Just check that all fires are passed to quickhull.ConvexHull()

--- a/examples/nade-trajectories/nade_trajectories.go
+++ b/examples/nade-trajectories/nade_trajectories.go
@@ -9,6 +9,7 @@ import (
 	_ "image/jpeg"
 	"os"
 
+	"github.com/golang/geo/r2"
 	"github.com/golang/geo/r3"
 	"github.com/llgcode/draw2d/draw2dimg"
 
@@ -135,7 +136,7 @@ func drawInfernos(gc *draw2dimg.GraphicContext, infernos []*common.Inferno) {
 	gc.SetFillColor(colorInferno)
 
 	// Calculate hulls
-	hulls := make([][]r3.Vector, len(infernos))
+	hulls := make([][]r2.Point, len(infernos))
 	for i := range infernos {
 		hulls[i] = infernos[i].ConvexHull2D()
 	}
@@ -155,16 +156,16 @@ func drawInfernos(gc *draw2dimg.GraphicContext, infernos []*common.Inferno) {
 	}
 }
 
-func buildInfernoPath(gc *draw2dimg.GraphicContext, vertices []r3.Vector) {
-	x, y := curMap.TranslateScale(vertices[0].X, vertices[0].Y)
-	gc.MoveTo(x, y)
+func buildInfernoPath(gc *draw2dimg.GraphicContext, vertices []r2.Point) {
+	xOrigin, yOrigin := curMap.TranslateScale(vertices[0].X, vertices[0].Y)
+	gc.MoveTo(xOrigin, yOrigin)
 
 	for _, fire := range vertices[1:] {
-		x, y = curMap.TranslateScale(fire.X, fire.Y)
+		x, y := curMap.TranslateScale(fire.X, fire.Y)
 		gc.LineTo(x, y)
 	}
 
-	gc.LineTo(x, y)
+	gc.LineTo(xOrigin, yOrigin)
 }
 
 func drawTrajectories(gc *draw2dimg.GraphicContext, trajectories []*nadePath) {

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/llgcode/ps v0.0.0-20150911083025-f1443b32eedb // indirect
 	github.com/markus-wa/gobitread v0.2.2
 	github.com/markus-wa/godispatch v1.1.0
-	github.com/markus-wa/quickhull-go v1.0.1
+	github.com/markus-wa/quickhull-go v0.0.0-20190116171133-06b8def50c96
 	github.com/stretchr/objx v0.1.1 // indirect
 	github.com/stretchr/testify v1.2.2
 	golang.org/x/image v0.0.0-20180708004352-c73c2afc3b81 // indirect

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/llgcode/ps v0.0.0-20150911083025-f1443b32eedb // indirect
 	github.com/markus-wa/gobitread v0.2.2
 	github.com/markus-wa/godispatch v1.1.0
-	github.com/markus-wa/quickhull-go v0.0.0-20190116171133-06b8def50c96
+	github.com/markus-wa/quickhull-go v0.0.0-20190116183559-9fb9702adbda
 	github.com/stretchr/objx v0.1.1 // indirect
 	github.com/stretchr/testify v1.2.2
 	golang.org/x/image v0.0.0-20180708004352-c73c2afc3b81 // indirect

--- a/go.sum
+++ b/go.sum
@@ -16,8 +16,8 @@ github.com/markus-wa/gobitread v0.2.2 h1:4Z4oJ8Bf1XnOy6JZ2/9AdFKVAoxdq7awRjrb+j2
 github.com/markus-wa/gobitread v0.2.2/go.mod h1:PcWXMH4gx7o2CKslbkFkLyJB/aHW7JVRG3MRZe3PINg=
 github.com/markus-wa/godispatch v1.1.0 h1:J8O+hRkOCexDUQevaSKWDtKeZ3+HcmbEUKY1uYraAjY=
 github.com/markus-wa/godispatch v1.1.0/go.mod h1:6o18u24oo58yseMXYD0zQFI6LbSkjJSSBQ4YyDqFX5c=
-github.com/markus-wa/quickhull-go v0.0.0-20190116171133-06b8def50c96 h1:HJL6HuxR1fTQ1EuNr5qhWvdQEZ6GlhPSeUOjt9Gortc=
-github.com/markus-wa/quickhull-go v0.0.0-20190116171133-06b8def50c96/go.mod h1:gMPnFb0DpuzRpbHesp64Nq4oFXE5SglAD86nlKrkETs=
+github.com/markus-wa/quickhull-go v0.0.0-20190116183559-9fb9702adbda h1:F7blFtp+y3qD7GE+9mY3YLtUGnmE+6CSlwwAxEl/q5Y=
+github.com/markus-wa/quickhull-go v0.0.0-20190116183559-9fb9702adbda/go.mod h1:gMPnFb0DpuzRpbHesp64Nq4oFXE5SglAD86nlKrkETs=
 github.com/markus-wa/quickhull-go v1.0.1 h1:msrwpA4mlVI2Rww6ZzQuCxv+axXVknMaMJYO1om37Mk=
 github.com/markus-wa/quickhull-go v1.0.1/go.mod h1:gMPnFb0DpuzRpbHesp64Nq4oFXE5SglAD86nlKrkETs=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=

--- a/go.sum
+++ b/go.sum
@@ -16,6 +16,8 @@ github.com/markus-wa/gobitread v0.2.2 h1:4Z4oJ8Bf1XnOy6JZ2/9AdFKVAoxdq7awRjrb+j2
 github.com/markus-wa/gobitread v0.2.2/go.mod h1:PcWXMH4gx7o2CKslbkFkLyJB/aHW7JVRG3MRZe3PINg=
 github.com/markus-wa/godispatch v1.1.0 h1:J8O+hRkOCexDUQevaSKWDtKeZ3+HcmbEUKY1uYraAjY=
 github.com/markus-wa/godispatch v1.1.0/go.mod h1:6o18u24oo58yseMXYD0zQFI6LbSkjJSSBQ4YyDqFX5c=
+github.com/markus-wa/quickhull-go v0.0.0-20190116171133-06b8def50c96 h1:HJL6HuxR1fTQ1EuNr5qhWvdQEZ6GlhPSeUOjt9Gortc=
+github.com/markus-wa/quickhull-go v0.0.0-20190116171133-06b8def50c96/go.mod h1:gMPnFb0DpuzRpbHesp64Nq4oFXE5SglAD86nlKrkETs=
 github.com/markus-wa/quickhull-go v1.0.1 h1:msrwpA4mlVI2Rww6ZzQuCxv+axXVknMaMJYO1om37Mk=
 github.com/markus-wa/quickhull-go v1.0.1/go.mod h1:gMPnFb0DpuzRpbHesp64Nq4oFXE5SglAD86nlKrkETs=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=


### PR DESCRIPTION
`examples/nade-trajectories` broke because the result of `ConvexHull2D()` wasn't ordered counter-clock wise anymore

- `ConvexHull2D()`: return clockwise ordered `r2.Point` slice
- `ConvexHull3D()`: return `quickhull.ConvexHull`

fixes #85

@micvbang can you verify this works for you as well?
One thing to note is that as it no longer returns a `s2.Loop` the start position is only there once, before the start and end of the loop was the same position. Depending on how your drawing code works you might need to change something.