### PR TITLE
events: add BombDefuseAborted event

### DIFF
--- a/common/player.go
+++ b/common/player.go
@@ -33,6 +33,7 @@ type Player struct {
 	Team                        Team
 	IsBot                       bool
 	IsDucking                   bool
+	IsDefusing                  bool
 	HasDefuseKit                bool
 	HasHelmet                   bool
 }

--- a/datatables.go
+++ b/datatables.go
@@ -270,6 +270,14 @@ func (p *Parser) bindNewPlayer(playerEntity *st.Entity) {
 		i2 := i // Copy so it stays the same
 		playerEntity.BindProperty("m_iAmmo."+fmt.Sprintf("%03d", i2), &pl.AmmoLeft[i2], st.ValTypeInt)
 	}
+
+	playerEntity.FindProperty("m_bIsDefusing").OnUpdate(func(val st.PropertyValue) {
+		if p.gameState.currentDefuser == pl && pl.IsDefusing && val.IntVal == 0 {
+			p.eventDispatcher.Dispatch(events.BombDefuseAborted{Player: pl})
+			p.gameState.currentDefuser = nil
+		}
+		pl.IsDefusing = val.IntVal != 0
+	})
 }
 
 func (p *Parser) bindWeapons() {

--- a/events/events.go
+++ b/events/events.go
@@ -283,6 +283,13 @@ type BombDefuseStart struct {
 
 func (BombDefuseStart) implementsBombEventIf() {}
 
+// BombDefuseAborted signals that the defuser aborted the action.
+type BombDefuseAborted struct {
+	Player *common.Player
+}
+
+func (BombDefuseAborted) implementsBombEventIf() {}
+
 // BombDropped signals that the bomb (C4) has been dropped onto the ground.
 // Not fired if it has been dropped to another player (see BombPickup for this).
 type BombDropped struct {

--- a/game_events.go
+++ b/game_events.go
@@ -331,15 +331,19 @@ func (p *Parser) handleGameEvent(ge *msg.CSVCMsg_GameEvent) {
 			p.eventDispatcher.Dispatch(events.BombPlanted{BombEvent: e})
 		case "bomb_defused":
 			p.eventDispatcher.Dispatch(events.BombDefused{BombEvent: e})
+			p.gameState.currentDefuser = nil
 		case "bomb_exploded":
 			p.eventDispatcher.Dispatch(events.BombExplode{BombEvent: e})
+			p.gameState.currentDefuser = nil
 		}
 
 	case "bomb_begindefuse": // Defuse started
 		data = mapGameEventData(d, ge)
 
+		p.gameState.currentDefuser = p.gameState.playersByUserID[int(data["userid"].GetValShort())]
+
 		p.eventDispatcher.Dispatch(events.BombDefuseStart{
-			Player: p.gameState.playersByUserID[int(data["userid"].GetValShort())],
+			Player: p.gameState.currentDefuser,
 			HasKit: data["haskit"].GetValBool(),
 		})
 

--- a/game_state.go
+++ b/game_state.go
@@ -24,6 +24,7 @@ type GameState struct {
 	isWarmupPeriod     bool
 	isMatchStarted     bool
 	lastFlasher        *common.Player // Last player whose flash exploded, used to find the attacker for player_blind events
+	currentDefuser     *common.Player // Player currently defusing the bomb, if any
 }
 
 type ingameTickNumber int


### PR DESCRIPTION
This PR adds `events.BombDefuseAborted`. The event is dispatched when the property `CCSPlayer.m_bIsDefusing` of the player from the last `bomb_defuse` event changes from `1` to `0`

Fixes #74