### PR TITLE
Parser: Refactor Parser.gameState.playersByUserID population

### DIFF
--- a/parsing.go
+++ b/parsing.go
@@ -245,31 +245,6 @@ type frameParsedTokenType struct{}
 var frameParsedToken = new(frameParsedTokenType)
 
 func (p *Parser) handleFrameParsed(*frameParsedTokenType) {
-	for k, rp := range p.rawPlayers {
-		// We need to re-map the players from their entityID to their UID.
-		// This is necessary because we don't always have the UID when the player connects (or something like that, not really sure tbh).
-		// k+1 for index -> ID
-		if pl := p.gameState.playersByEntityID[k+1]; pl != nil {
-			pl.Name = rp.name
-			pl.SteamID = rp.xuid
-			pl.IsBot = rp.isFakePlayer
-			pl.AdditionalPlayerInformation = &p.additionalPlayerInfo[pl.EntityID]
-
-			if pl.IsAlive() {
-				pl.LastAlivePosition = pl.Position
-			}
-
-			if p.gameState.playersByUserID[rp.userID] == nil {
-				p.gameState.playersByUserID[rp.userID] = pl
-				pl.UserID = rp.userID
-
-				if pl.SteamID != 0 {
-					p.eventDispatcher.Dispatch(events.PlayerConnect{Player: pl})
-				}
-			}
-		}
-	}
-
 	// PlayerFlashed events need to be dispatched at the end of the tick
 	// because Player.FlashDuration is updated after the game-events are parsed.
 	for _, e := range p.currentFlashEvents {

--- a/sendtables/entity.go
+++ b/sendtables/entity.go
@@ -314,7 +314,10 @@ const (
 type PropertyUpdateHandler func(PropertyValue)
 
 // OnUpdate registers a handler for updates of the Property's value.
+//
+// The handler will be called with the current value upon registration.
 func (pe *Property) OnUpdate(handler PropertyUpdateHandler) {
+	handler(pe.value)
 	pe.updateHandlers = append(pe.updateHandlers, handler)
 }
 

--- a/sendtables/sendtables.go
+++ b/sendtables/sendtables.go
@@ -120,11 +120,6 @@ func (sc *ServerClass) newEntity(entityDataReader *bit.BitReader, entityID int) 
 		h(entity)
 	}
 
-	// Fire update-handlers
-	for _, v := range entity.props {
-		v.firePropertyUpdate()
-	}
-
 	// Fire all post-creation actions
 	for _, f := range entity.onCreateFinished {
 		f()


### PR DESCRIPTION
Instead of checking after each tick whether there's new players to be added to `Parser.gameState.playersByUserID` we can (hopefully) do this in `Parser.bindNewPlayer()` instead.

This seems to avoid **some** game-events with `nil` values for players.
It also prevents an issue where `Participants.ByEntityID()` got out of sync and contained pointers to old players.

Also, as a bonus, it improves performance by about **5-10% (!)** according to my benchmarks.