### PR TITLE
common: fix Player.IsBlinded() inaccuracies

### DIFF
--- a/common/player.go
+++ b/common/player.go
@@ -30,6 +30,7 @@ type Player struct {
 	ViewDirectionX              float32
 	ViewDirectionY              float32
 	FlashDuration               float32 // Blindness duration from the flashbang currently affecting the player (seconds)
+	FlashTick                   int     // In-game tick at which the player was last flashed
 	Team                        Team
 	TeamState                   *TeamState // When keeping the reference make sure you notice when the player changes teams
 	IsBot                       bool
@@ -37,6 +38,9 @@ type Player struct {
 	IsDefusing                  bool
 	HasDefuseKit                bool
 	HasHelmet                   bool
+
+	tickRate           float64            // the in-game tick rate, used for IsBlinded()
+	ingameTickProvider ingameTickProvider // provider for the current in-game tick, used for IsBlinded()
 }
 
 // IsAlive returns true if the Hp of the player are > 0.
@@ -44,13 +48,18 @@ func (p *Player) IsAlive() bool {
 	return p.Hp > 0
 }
 
-// IsBlinded returns true if the player is currently flashed (FlashDuration > 0).
+// IsBlinded returns true if the player is currently flashed.
+// This is more accurate than 'FlashDuration != 0' as it takes into account the FlashTick and GameState.IngameTick().
 func (p *Player) IsBlinded() bool {
-	return p.FlashDuration > 0
+	return p.FlashDuration > float32(p.ingameTickProvider()-p.FlashTick)/float32(p.tickRate)
 }
 
 // FlashDurationTime returns the duration of the blinding effect as time.Duration instead of float32 in seconds.
+// Will return 0 if IsBlinded() returns false.
 func (p *Player) FlashDurationTime() time.Duration {
+	if !p.IsBlinded() {
+		return time.Duration(0)
+	}
 	return time.Duration(float32(time.Second) * p.FlashDuration)
 }
 
@@ -95,9 +104,16 @@ type AdditionalPlayerInformation struct {
 	TotalCashSpent int
 }
 
+// ingameTickProvider is a function that returns the current ingame tick of the demo related to a player.
+type ingameTickProvider func() int
+
 // NewPlayer creates a *Player with an initialized equipment map.
 //
 // Intended for internal use only.
-func NewPlayer() *Player {
-	return &Player{RawWeapons: make(map[int]*Equipment)}
+func NewPlayer(tickRate float64, ingameTickProvider ingameTickProvider) *Player {
+	return &Player{
+		RawWeapons:         make(map[int]*Equipment),
+		tickRate:           tickRate,
+		ingameTickProvider: ingameTickProvider,
+	}
 }

--- a/common/player_test.go
+++ b/common/player_test.go
@@ -69,14 +69,56 @@ func TestPlayerFlashed_FlashDuration_Over(t *testing.T) {
 	assert.False(t, pl.IsBlinded(), "Should not be flashed")
 }
 
+func TestPlayer_FlashDurationTime_Default(t *testing.T) {
+	pl := newPlayer(0)
+
+	assert.Equal(t, time.Duration(0), pl.FlashDurationTime())
+}
+
 func TestPlayer_FlashDurationTime(t *testing.T) {
-	p := newPlayer(0)
+	pl := newPlayer(0)
 
-	assert.Equal(t, time.Duration(0), p.FlashDurationTime())
+	pl.FlashDuration = 2.3
 
-	p.FlashDuration = 2.3
+	assert.Equal(t, 2300*time.Millisecond, pl.FlashDurationTime())
+}
 
-	assert.Equal(t, 2300*time.Millisecond, p.FlashDurationTime())
+func TestPlayer_FlashDurationTimeRemaining_Default(t *testing.T) {
+	pl := NewPlayer(0, tickProvider(128))
+
+	assert.Equal(t, time.Duration(0), pl.FlashDurationTimeRemaining())
+}
+
+func TestPlayer_FlashDurationTimeRemaining(t *testing.T) {
+	pl := newPlayer(128 * 2)
+
+	pl.FlashDuration = 3
+	pl.FlashTick = 128
+	assert.Equal(t, 2*time.Second, pl.FlashDurationTimeRemaining())
+}
+
+func TestPlayer_FlashDurationTimeRemaining_Zero(t *testing.T) {
+	pl := newPlayer(128 * 4)
+
+	pl.FlashDuration = 3
+	pl.FlashTick = 128
+	assert.Equal(t, time.Duration(0), pl.FlashDurationTimeRemaining())
+}
+
+func TestPlayer_FlashDurationTimeRemaining_FlashDuration_Over(t *testing.T) {
+	pl := newPlayer(128 * 4)
+
+	pl.FlashDuration = 1
+	pl.FlashTick = 128
+	assert.Equal(t, time.Duration(0), pl.FlashDurationTimeRemaining())
+}
+
+func TestPlayer_FlashDurationTimeRemaining_Fallback(t *testing.T) {
+	pl := NewPlayer(0, tickProvider(128))
+
+	pl.FlashDuration = 2
+	pl.FlashTick = 128 * 2
+	assert.Equal(t, 2*time.Second, pl.FlashDurationTimeRemaining())
 }
 
 func newPlayer(tick int) *Player {

--- a/common/player_test.go
+++ b/common/player_test.go
@@ -12,7 +12,7 @@ func TestPlayerActiveWeapon(t *testing.T) {
 	glock := NewEquipment(EqGlock)
 	ak47 := NewEquipment(EqAK47)
 
-	pl := NewPlayer()
+	pl := newPlayer(0)
 	pl.RawWeapons[1] = &knife
 	pl.RawWeapons[2] = &glock
 	pl.RawWeapons[3] = &ak47
@@ -20,12 +20,13 @@ func TestPlayerActiveWeapon(t *testing.T) {
 
 	assert.Equal(t, &ak47, pl.ActiveWeapon(), "Should have AK-47 equipped")
 }
+
 func TestPlayerWeapons(t *testing.T) {
 	knife := NewEquipment(EqKnife)
 	glock := NewEquipment(EqGlock)
 	ak47 := NewEquipment(EqAK47)
 
-	pl := NewPlayer()
+	pl := newPlayer(0)
 	pl.RawWeapons[1] = &knife
 	pl.RawWeapons[2] = &glock
 	pl.RawWeapons[3] = &ak47
@@ -35,7 +36,7 @@ func TestPlayerWeapons(t *testing.T) {
 }
 
 func TestPlayerAlive(t *testing.T) {
-	pl := NewPlayer()
+	pl := newPlayer(0)
 
 	pl.Hp = 100
 	assert.Equal(t, true, pl.IsAlive(), "Should be alive")
@@ -51,20 +52,37 @@ func TestPlayerAlive(t *testing.T) {
 }
 
 func TestPlayerFlashed(t *testing.T) {
-	pl := NewPlayer()
+	pl := newPlayer(128)
 
 	assert.False(t, pl.IsBlinded(), "Should not be flashed")
 
 	pl.FlashDuration = 2.3
+	pl.FlashTick = 50
 	assert.True(t, pl.IsBlinded(), "Should be flashed")
 }
 
+func TestPlayerFlashed_FlashDuration_Over(t *testing.T) {
+	pl := newPlayer(128 * 3)
+
+	pl.FlashDuration = 1.9
+	pl.FlashTick = 128
+	assert.False(t, pl.IsBlinded(), "Should not be flashed")
+}
+
 func TestPlayer_FlashDurationTime(t *testing.T) {
-	p := NewPlayer()
+	p := newPlayer(0)
 
 	assert.Equal(t, time.Duration(0), p.FlashDurationTime())
 
 	p.FlashDuration = 2.3
 
 	assert.Equal(t, 2300*time.Millisecond, p.FlashDurationTime())
+}
+
+func newPlayer(tick int) *Player {
+	return NewPlayer(128, tickProvider(tick))
+}
+
+func tickProvider(tick int) ingameTickProvider {
+	return func() int { return tick }
 }

--- a/datatables.go
+++ b/datatables.go
@@ -190,7 +190,8 @@ func (p *Parser) bindNewPlayer(playerEntity st.IEntity) {
 		if pl == nil {
 			isNew = true
 
-			pl = common.NewPlayer()
+			// TODO: read tickRate from CVARs as fallback
+			pl = common.NewPlayer(p.header.TickRate(), p.gameState.IngameTick)
 			pl.Name = rp.name
 			pl.SteamID = rp.xuid
 			pl.IsBot = rp.isFakePlayer || rp.guid == "BOT"
@@ -231,7 +232,14 @@ func (p *Parser) bindNewPlayer(playerEntity st.IEntity) {
 
 	playerEntity.BindProperty("m_angEyeAngles[1]", &pl.ViewDirectionX, st.ValTypeFloat32)
 	playerEntity.BindProperty("m_angEyeAngles[0]", &pl.ViewDirectionY, st.ValTypeFloat32)
-	playerEntity.BindProperty("m_flFlashDuration", &pl.FlashDuration, st.ValTypeFloat32)
+	playerEntity.FindProperty("m_flFlashDuration").OnUpdate(func(val st.PropertyValue) {
+		if val.FloatVal == 0 {
+			pl.FlashTick = 0
+		} else {
+			pl.FlashTick = p.gameState.ingameTick
+		}
+		pl.FlashDuration = val.FloatVal
+	})
 
 	// Velocity
 	playerEntity.BindProperty("localdata.m_vecVelocity[0]", &pl.Velocity.X, st.ValTypeFloat64)

--- a/datatables_test.go
+++ b/datatables_test.go
@@ -6,6 +6,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 
+	"github.com/markus-wa/demoinfocs-golang/common"
 	"github.com/markus-wa/demoinfocs-golang/events"
 	st "github.com/markus-wa/demoinfocs-golang/sendtables"
 	fakest "github.com/markus-wa/demoinfocs-golang/sendtables/fake"
@@ -19,7 +20,7 @@ func (DevNullReader) Read(p []byte) (n int, err error) {
 }
 
 func TestParser_BindNewPlayer_Issue98(t *testing.T) {
-	p := NewParser(new(DevNullReader))
+	p := newParser()
 
 	p.rawPlayers = map[int]*playerInfo{
 		0: {
@@ -45,7 +46,7 @@ func TestParser_BindNewPlayer_Issue98(t *testing.T) {
 }
 
 func TestParser_BindNewPlayer_Issue98_Reconnect(t *testing.T) {
-	p := NewParser(new(DevNullReader))
+	p := newParser()
 
 	p.rawPlayers = map[int]*playerInfo{
 		0: {
@@ -67,6 +68,12 @@ func TestParser_BindNewPlayer_Issue98_Reconnect(t *testing.T) {
 
 	assert.Len(t, p.GameState().Participants().All(), 1)
 
+}
+
+func newParser() *Parser {
+	p := NewParser(new(DevNullReader))
+	p.header = &common.DemoHeader{}
+	return p
 }
 
 func fakePlayerEntity(id int) st.IEntity {

--- a/events/events_test.go
+++ b/events/events_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 func TestPlayerFlashed_FlashDuration(t *testing.T) {
-	p := common.NewPlayer()
+	p := common.NewPlayer(128, func() int { return 0 })
 	e := PlayerFlashed{Player: p}
 
 	assert.Equal(t, time.Duration(0), e.FlashDuration())

--- a/fake/parser_test.go
+++ b/fake/parser_test.go
@@ -52,9 +52,9 @@ func TestParseNextFrameEvents(t *testing.T) {
 func kill(wepType common.EquipmentElement) events.Kill {
 	wep := common.NewEquipment(wepType)
 	return events.Kill{
-		Killer: common.NewPlayer(),
+		Killer: new(common.Player),
 		Weapon: &wep,
-		Victim: common.NewPlayer(),
+		Victim: new(common.Player),
 	}
 }
 

--- a/game_state_test.go
+++ b/game_state_test.go
@@ -138,7 +138,7 @@ func TestParticipants_SuppressNoEntity(t *testing.T) {
 	gs := newGameState()
 	pl := newPlayer()
 	gs.playersByUserID[0] = pl
-	gs.playersByUserID[1] = common.NewPlayer()
+	gs.playersByUserID[1] = common.NewPlayer(0, func() int { return 0 })
 
 	allPlayers := gs.Participants().All()
 
@@ -146,7 +146,7 @@ func TestParticipants_SuppressNoEntity(t *testing.T) {
 }
 
 func newPlayer() *common.Player {
-	pl := common.NewPlayer()
+	pl := common.NewPlayer(0, func() int { return 0 })
 	pl.Entity = new(st.Entity)
 	return pl
 }


### PR DESCRIPTION
This should fix ~~any~~ most issues with `Player.IsBlinded()`.
It may still return wrong values if the demo's header is lacking the tickrate.

It also adds another utility function `Player.FlashDurationTimeRemaining()` which returns the remaining duration of the flash. This may be useful as the player may be able to partially see if the remaining time is fairly low.
