### PR TITLE
Parser: Player tracking improvements

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -52,7 +52,7 @@ script:
   - go test -v -race -run "$race_tests" -timeout 15m
 
   # We run all tests again to get full coverage, technically unncecessary tho
-  - coverpkg_ignore='/msg'
+  - coverpkg_ignore='/(msg|fake)'
   # coverpkg for multiple mains is broken in 1.12, so we need to exclude the examples from coverage
   # https://github.com/golang/go/issues/30374
   - if ! [[ "$TRAVIS_GO_VERSION" =~ ^1\.11 ]]; then coverpkg_ignore="${coverpkg_ignore}|/examples"; fi

--- a/common/player.go
+++ b/common/player.go
@@ -25,7 +25,7 @@ type Player struct {
 	ActiveWeaponID              int                // Used internally to set the active weapon, see ActiveWeapon()
 	RawWeapons                  map[int]*Equipment // All weapons the player is currently carrying
 	AmmoLeft                    [32]int            // Ammo left in the various weapons, index corresponds to key of RawWeapons
-	Entity                      *st.Entity
+	Entity                      st.IEntity
 	AdditionalPlayerInformation *AdditionalPlayerInformation // Mostly scoreboard information such as kills, deaths, etc.
 	ViewDirectionX              float32
 	ViewDirectionY              float32

--- a/datatables.go
+++ b/datatables.go
@@ -178,7 +178,7 @@ func (p *Parser) bindPlayers() {
 	})
 }
 
-func (p *Parser) bindNewPlayer(playerEntity *st.Entity) {
+func (p *Parser) bindNewPlayer(playerEntity st.IEntity) {
 	entityID := playerEntity.ID()
 	rp := p.rawPlayers[entityID-1]
 
@@ -206,6 +206,7 @@ func (p *Parser) bindNewPlayer(playerEntity *st.Entity) {
 
 	playerEntity.OnDestroy(func() {
 		delete(p.gameState.playersByEntityID, entityID)
+		pl.Entity = nil
 	})
 
 	// Position

--- a/datatables.go
+++ b/datatables.go
@@ -193,7 +193,7 @@ func (p *Parser) bindNewPlayer(playerEntity *st.Entity) {
 			pl = common.NewPlayer()
 			pl.Name = rp.name
 			pl.SteamID = rp.xuid
-			pl.IsBot = rp.isFakePlayer
+			pl.IsBot = rp.isFakePlayer || rp.guid == "BOT"
 			pl.UserID = rp.userID
 		}
 	}

--- a/datatables_test.go
+++ b/datatables_test.go
@@ -1,0 +1,86 @@
+package demoinfocs
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+
+	"github.com/markus-wa/demoinfocs-golang/events"
+	st "github.com/markus-wa/demoinfocs-golang/sendtables"
+	fakest "github.com/markus-wa/demoinfocs-golang/sendtables/fake"
+)
+
+type DevNullReader struct {
+}
+
+func (DevNullReader) Read(p []byte) (n int, err error) {
+	return len(p), nil
+}
+
+func TestParser_BindNewPlayer_Issue98(t *testing.T) {
+	p := NewParser(new(DevNullReader))
+
+	p.rawPlayers = map[int]*playerInfo{
+		0: {
+			userID: 1,
+			name:   "Zim",
+			guid:   "BOT",
+		},
+		1: {
+			userID: 2,
+			name:   "The Suspect",
+			guid:   "123",
+		},
+	}
+
+	bot := fakePlayerEntity(1)
+	p.bindNewPlayer(bot)
+	bot.Destroy()
+
+	player := fakePlayerEntity(2)
+	p.bindNewPlayer(player)
+
+	assert.Len(t, p.GameState().Participants().All(), 1)
+}
+
+func TestParser_BindNewPlayer_Issue98_Reconnect(t *testing.T) {
+	p := NewParser(new(DevNullReader))
+
+	p.rawPlayers = map[int]*playerInfo{
+		0: {
+			userID: 2,
+			name:   "The Suspect",
+			guid:   "123",
+			xuid:   1,
+		},
+	}
+
+	player := fakePlayerEntity(1)
+	p.bindNewPlayer(player)
+	player.Destroy()
+
+	p.RegisterEventHandler(func(events.PlayerConnect) {
+		t.Error("expected no more PlayerConnect events but got one")
+	})
+	p.bindNewPlayer(player)
+
+	assert.Len(t, p.GameState().Participants().All(), 1)
+
+}
+
+func fakePlayerEntity(id int) st.IEntity {
+	entity := new(fakest.Entity)
+	entity.On("ID").Return(id)
+	var destroyCallback func()
+	entity.On("OnDestroy", mock.Anything).Run(func(args mock.Arguments) {
+		destroyCallback = args.Get(0).(func())
+	})
+	entity.On("OnPositionUpdate", mock.Anything).Return()
+	entity.On("FindProperty", mock.Anything).Return(new(st.Property))
+	entity.On("BindProperty", mock.Anything, mock.Anything, mock.Anything).Return(new(st.Property))
+	entity.On("Destroy").Run(func(mock.Arguments) {
+		destroyCallback()
+	})
+	return entity
+}

--- a/game_events.go
+++ b/game_events.go
@@ -286,7 +286,7 @@ func (geh gameEventHandler) playerBlind(desc *msg.CSVCMsg_GameEventListDescripto
 
 	// Player.FlashDuration hasn't been updated yet,
 	// so we need to wait until the end of the tick before dispatching
-	geh.parser.currentFlashEvents = append(geh.parser.currentFlashEvents, events.PlayerFlashed{
+	geh.parser.delayedEvents = append(geh.parser.delayedEvents, events.PlayerFlashed{
 		Player:   geh.playerByUserID32(data["userid"].GetValShort()),
 		Attacker: geh.gameState().lastFlasher,
 	})
@@ -390,7 +390,10 @@ func (geh gameEventHandler) playerTeam(desc *msg.CSVCMsg_GameEventListDescriptor
 			player.Team = newTeam
 
 			oldTeam := common.Team(data["oldteam"].GetValByte())
-			geh.dispatch(events.PlayerTeamChange{
+			// Delayed for two reasons
+			// - team IDs of other players changing teams in the same tick might not have changed yet
+			// - player entities might not have been re-created yet after a reconnect
+			geh.parser.delayedEvents = append(geh.parser.delayedEvents, events.PlayerTeamChange{
 				Player:       player,
 				IsBot:        data["isbot"].GetValBool(),
 				Silent:       data["silent"].GetValBool(),

--- a/game_state_test.go
+++ b/game_state_test.go
@@ -6,6 +6,7 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	"github.com/markus-wa/demoinfocs-golang/common"
+	st "github.com/markus-wa/demoinfocs-golang/sendtables"
 )
 
 func TestNewGameState(t *testing.T) {
@@ -41,8 +42,8 @@ func TestGameState_Participants(t *testing.T) {
 	byUserID := ptcp.ByUserID()
 
 	// Should update ptcp as well since it uses the same map
-	gs.playersByEntityID[0] = common.NewPlayer()
-	gs.playersByUserID[0] = common.NewPlayer()
+	gs.playersByEntityID[0] = newPlayer()
+	gs.playersByUserID[0] = newPlayer()
 
 	assert.Equal(t, gs.playersByEntityID, ptcp.ByEntityID())
 	assert.Equal(t, gs.playersByUserID, ptcp.ByUserID())
@@ -54,7 +55,7 @@ func TestGameState_Participants(t *testing.T) {
 
 func TestParticipants_All(t *testing.T) {
 	gs := newGameState()
-	pl := common.NewPlayer()
+	pl := newPlayer()
 	gs.playersByUserID[0] = pl
 
 	allPlayers := gs.Participants().All()
@@ -65,19 +66,19 @@ func TestParticipants_All(t *testing.T) {
 func TestParticipants_Playing(t *testing.T) {
 	gs := newGameState()
 
-	terrorist := common.NewPlayer()
+	terrorist := newPlayer()
 	terrorist.Team = common.TeamTerrorists
 	gs.playersByUserID[0] = terrorist
-	ct := common.NewPlayer()
+	ct := newPlayer()
 	ct.Team = common.TeamCounterTerrorists
 	gs.playersByUserID[1] = ct
-	unassigned := common.NewPlayer()
+	unassigned := newPlayer()
 	unassigned.Team = common.TeamUnassigned
 	gs.playersByUserID[2] = unassigned
-	spectator := common.NewPlayer()
+	spectator := newPlayer()
 	spectator.Team = common.TeamSpectators
 	gs.playersByUserID[3] = spectator
-	def := common.NewPlayer()
+	def := newPlayer()
 	gs.playersByUserID[4] = def
 
 	playing := gs.Participants().Playing()
@@ -89,19 +90,19 @@ func TestParticipants_Playing(t *testing.T) {
 func TestParticipants_TeamMembers(t *testing.T) {
 	gs := newGameState()
 
-	terrorist := common.NewPlayer()
+	terrorist := newPlayer()
 	terrorist.Team = common.TeamTerrorists
 	gs.playersByUserID[0] = terrorist
-	ct := common.NewPlayer()
+	ct := newPlayer()
 	ct.Team = common.TeamCounterTerrorists
 	gs.playersByUserID[1] = ct
-	unassigned := common.NewPlayer()
+	unassigned := newPlayer()
 	unassigned.Team = common.TeamUnassigned
 	gs.playersByUserID[2] = unassigned
-	spectator := common.NewPlayer()
+	spectator := newPlayer()
 	spectator.Team = common.TeamSpectators
 	gs.playersByUserID[3] = spectator
-	def := common.NewPlayer()
+	def := newPlayer()
 	gs.playersByUserID[4] = def
 
 	cts := gs.Participants().TeamMembers(common.TeamCounterTerrorists)
@@ -112,7 +113,7 @@ func TestParticipants_TeamMembers(t *testing.T) {
 func TestParticipants_FindByHandle(t *testing.T) {
 	gs := newGameState()
 
-	pl := common.NewPlayer()
+	pl := newPlayer()
 	pl.Team = common.TeamTerrorists
 	gs.playersByEntityID[3000&entityHandleIndexMask] = pl
 
@@ -124,11 +125,28 @@ func TestParticipants_FindByHandle(t *testing.T) {
 func TestParticipants_FindByHandle_InvalidEntityHandle(t *testing.T) {
 	gs := newGameState()
 
-	pl := common.NewPlayer()
+	pl := newPlayer()
 	pl.Team = common.TeamTerrorists
 	gs.playersByEntityID[invalidEntityHandle&entityHandleIndexMask] = pl
 
 	found := gs.Participants().FindByHandle(invalidEntityHandle)
 
 	assert.Nil(t, found)
+}
+
+func TestParticipants_SuppressNoEntity(t *testing.T) {
+	gs := newGameState()
+	pl := newPlayer()
+	gs.playersByUserID[0] = pl
+	gs.playersByUserID[1] = common.NewPlayer()
+
+	allPlayers := gs.Participants().All()
+
+	assert.ElementsMatch(t, []*common.Player{pl}, allPlayers)
+}
+
+func newPlayer() *common.Player {
+	pl := common.NewPlayer()
+	pl.Entity = new(st.Entity)
+	return pl
 }

--- a/parser.go
+++ b/parser.go
@@ -10,7 +10,6 @@ import (
 
 	bit "github.com/markus-wa/demoinfocs-golang/bitread"
 	common "github.com/markus-wa/demoinfocs-golang/common"
-	events "github.com/markus-wa/demoinfocs-golang/events"
 	msg "github.com/markus-wa/demoinfocs-golang/msg"
 	st "github.com/markus-wa/demoinfocs-golang/sendtables"
 )
@@ -70,7 +69,7 @@ type Parser struct {
 	gameEventDescs       map[int32]*msg.CSVCMsg_GameEventListDescriptorT // Maps game-event IDs to descriptors
 	grenadeModelIndices  map[int]common.EquipmentElement                 // Used to map model indices to grenades (used for grenade projectiles)
 	stringTables         []*msg.CSVCMsg_CreateStringTable                // Contains all created sendtables, needed when updating them
-	currentFlashEvents   []events.PlayerFlashed                          // Contains flash events that need to be dispatched at the end of a tick
+	delayedEvents        []interface{}                                   // Contains events that need to be dispatched at the end of a tick (e.g. flash events because FlashDuration isn't updated before that)
 }
 
 type bombsite struct {

--- a/parsing.go
+++ b/parsing.go
@@ -247,10 +247,10 @@ var frameParsedToken = new(frameParsedTokenType)
 func (p *Parser) handleFrameParsed(*frameParsedTokenType) {
 	// PlayerFlashed events need to be dispatched at the end of the tick
 	// because Player.FlashDuration is updated after the game-events are parsed.
-	for _, e := range p.currentFlashEvents {
+	for _, e := range p.delayedEvents {
 		p.eventDispatcher.Dispatch(e)
 	}
-	p.currentFlashEvents = p.currentFlashEvents[:0]
+	p.delayedEvents = p.delayedEvents[:0]
 
 	p.currentFrame++
 	p.eventDispatcher.Dispatch(events.TickDone{})

--- a/sendtables/entity.go
+++ b/sendtables/entity.go
@@ -9,6 +9,8 @@ import (
 	bit "github.com/markus-wa/demoinfocs-golang/bitread"
 )
 
+//go:generate ifacemaker -f entity.go -s Entity -i IEntity -p sendtables -D -y "IEntity is an auto-generated interface for Entity, intended to be used when mockability is needed." -c "DO NOT EDIT: Auto generated" -o entity_interface.go
+
 // Entity stores a entity in the game (e.g. players etc.) with its properties.
 type Entity struct {
 	serverClass *ServerClass
@@ -56,7 +58,7 @@ func (e *Entity) FindProperty(name string) *Property {
 // BindProperty combines FindProperty() & Property.Bind() into one.
 // Essentially binds a property's value to a pointer.
 // See the docs of the two individual functions for more info.
-func (e *Entity) BindProperty(name string, variable interface{}, valueType propertyValueType) {
+func (e *Entity) BindProperty(name string, variable interface{}, valueType PropertyValueType) {
 	e.FindProperty(name).Bind(variable, valueType)
 }
 
@@ -296,12 +298,13 @@ func (pe *Property) Value() PropertyValue {
 	return pe.value
 }
 
-type propertyValueType int
+// PropertyValueType specifies the type of a PropertyValue
+type PropertyValueType int
 
 // Possible types of property values.
 // See Property.Bind()
 const (
-	ValTypeInt propertyValueType = iota
+	ValTypeInt PropertyValueType = iota
 	ValTypeFloat32
 	ValTypeFloat64 // Like ValTypeFloat32 but with additional cast to float64
 	ValTypeString
@@ -339,7 +342,7 @@ This will bind the property's value to i so every time it's updated i is updated
 
 The valueType indicates which field of the PropertyValue to use for the binding.
 */
-func (pe *Property) Bind(variable interface{}, valueType propertyValueType) {
+func (pe *Property) Bind(variable interface{}, valueType PropertyValueType) {
 	var binder PropertyUpdateHandler
 	switch valueType {
 	case ValTypeInt:

--- a/sendtables/entity_interface.go
+++ b/sendtables/entity_interface.go
@@ -1,0 +1,55 @@
+// DO NOT EDIT: Auto generated
+
+package sendtables
+
+import (
+	r3 "github.com/golang/geo/r3"
+	bit "github.com/markus-wa/demoinfocs-golang/bitread"
+)
+
+// IEntity is an auto-generated interface for Entity, intended to be used when mockability is needed.
+// Entity stores a entity in the game (e.g. players etc.) with its properties.
+type IEntity interface {
+	// ServerClass returns the entity's server-class.
+	ServerClass() *ServerClass
+	// ID returns the entity's ID.
+	ID() int
+	// Properties returns all properties of the Entity.
+	Properties() []Property
+	// FindProperty finds a property on the Entity by name.
+	//
+	// Returns nil if the property wasn't found.
+	//
+	// Panics if more than one property with the same name was found.
+	FindProperty(name string) *Property
+	// BindProperty combines FindProperty() & Property.Bind() into one.
+	// Essentially binds a property's value to a pointer.
+	// See the docs of the two individual functions for more info.
+	BindProperty(name string, variable interface{}, valueType PropertyValueType)
+	// ApplyUpdate reads an update to an Enitiy's properties and
+	// triggers registered PropertyUpdateHandlers if values changed.
+	//
+	// Intended for internal use only.
+	ApplyUpdate(reader *bit.BitReader)
+	// Position returns the entity's position in world coordinates.
+	Position() r3.Vector
+	// OnPositionUpdate registers a handler for the entity's position update.
+	// The handler is called with the new position every time a position-relevant property is updated.
+	//
+	// See also Position()
+	OnPositionUpdate(h func(pos r3.Vector))
+	// BindPosition binds the entity's position to a pointer variable.
+	// The pointer is updated every time a position-relevant property is updated.
+	//
+	// See also OnPositionUpdate()
+	BindPosition(pos *r3.Vector)
+	// OnDestroy registers a function to be called on the entity's destruction.
+	OnDestroy(delegate func())
+	// Destroy triggers all via OnDestroy() registered functions.
+	//
+	// Intended for internal use only.
+	Destroy()
+	// OnCreateFinished registers a function to be called once the entity is fully created -
+	// i.e. once all property updates have been sent out.
+	OnCreateFinished(delegate func())
+}

--- a/sendtables/fake/entity.go
+++ b/sendtables/fake/entity.go
@@ -1,0 +1,75 @@
+// Package fake provides basic mocks for IEntity.
+// See examples/mocking (https://github.com/markus-wa/demoinfocs-golang/tree/master/examples/mocking).
+package fake
+
+import (
+	"github.com/golang/geo/r3"
+	"github.com/markus-wa/demoinfocs-golang/bitread"
+	st "github.com/markus-wa/demoinfocs-golang/sendtables"
+	"github.com/stretchr/testify/mock"
+)
+
+// Entity is a mock for of sendtables.IEntity.
+type Entity struct {
+	mock.Mock
+}
+
+// ServerClass is a mock-implementation of IEntity.ServerClass().
+func (e *Entity) ServerClass() *st.ServerClass {
+	return e.Called().Get(0).(*st.ServerClass)
+}
+
+// ID is a mock-implementation of IEntity.ID().
+func (e *Entity) ID() int {
+	return e.Called().Int(0)
+}
+
+// Properties is a mock-implementation of IEntity.Properties().
+func (e *Entity) Properties() []st.Property {
+	return e.Called().Get(0).([]st.Property)
+}
+
+// FindProperty is a mock-implementation of IEntity.FindProperty().
+func (e *Entity) FindProperty(name string) *st.Property {
+	return e.Called(name).Get(0).(*st.Property)
+}
+
+// BindProperty is a mock-implementation of IEntity.BindProperty().
+func (e *Entity) BindProperty(name string, variable interface{}, valueType st.PropertyValueType) {
+	e.Called(name, variable, valueType)
+}
+
+// ApplyUpdate is a mock-implementation of IEntity.ApplyUpdate().
+func (e *Entity) ApplyUpdate(reader *bitread.BitReader) {
+	e.Called(reader)
+}
+
+// Position is a mock-implementation of IEntity.Position().
+func (e *Entity) Position() r3.Vector {
+	return e.Called().Get(0).(r3.Vector)
+}
+
+// OnPositionUpdate is a mock-implementation of IEntity.OnPositionUpdate().
+func (e *Entity) OnPositionUpdate(handler func(pos r3.Vector)) {
+	e.Called(handler)
+}
+
+// BindPosition is a mock-implementation of IEntity.BindPosition().
+func (e *Entity) BindPosition(pos *r3.Vector) {
+	e.Called(pos)
+}
+
+// OnDestroy is a mock-implementation of IEntity.OnDestroy().
+func (e *Entity) OnDestroy(delegate func()) {
+	e.Called(delegate)
+}
+
+// Destroy is a mock-implementation of IEntity.Destroy().
+func (e *Entity) Destroy() {
+	e.Called()
+}
+
+// OnCreateFinished is a mock-implementation of IEntity.OnCreateFinished().
+func (e *Entity) OnCreateFinished(delegate func()) {
+	e.Called()
+}


### PR DESCRIPTION
- Fixes #98 
- Makes `Player.IsBot` more accurate by also checking the GUID
- ~~Adds `PlayerConnect` event for bots.~~ the change for this didn't do what I expected, it ended up sending wrong events instead.
- events: delay PlayerTeamChange until end of tick
  - team IDs of other players changing teams in the same tick might not have changed yet
  - player entities might not have been re-created yet after a reconnect

Depends on #94 



