### PR TITLE
events: fix nil Player values after disconnect

### DIFF
--- a/common/player.go
+++ b/common/player.go
@@ -34,6 +34,7 @@ type Player struct {
 	Team                        Team
 	TeamState                   *TeamState // When keeping the reference make sure you notice when the player changes teams
 	IsBot                       bool
+	IsConnected                 bool
 	IsDucking                   bool
 	IsDefusing                  bool
 	HasDefuseKit                bool

--- a/datatables.go
+++ b/datatables.go
@@ -204,6 +204,7 @@ func (p *Parser) bindNewPlayer(playerEntity st.IEntity) {
 	pl.EntityID = entityID
 	pl.Entity = playerEntity
 	pl.AdditionalPlayerInformation = &p.additionalPlayerInfo[entityID]
+	pl.IsConnected = true
 
 	playerEntity.OnDestroy(func() {
 		delete(p.gameState.playersByEntityID, entityID)

--- a/datatables_test.go
+++ b/datatables_test.go
@@ -42,7 +42,7 @@ func TestParser_BindNewPlayer_Issue98(t *testing.T) {
 	player := fakePlayerEntity(2)
 	p.bindNewPlayer(player)
 
-	assert.Len(t, p.GameState().Participants().All(), 1)
+	assert.Len(t, p.GameState().Participants().Connected(), 1)
 }
 
 func TestParser_BindNewPlayer_Issue98_Reconnect(t *testing.T) {

--- a/fake/participants.go
+++ b/fake/participants.go
@@ -26,6 +26,11 @@ func (ptcp *Participants) All() []*common.Player {
 	return ptcp.Called().Get(0).([]*common.Player)
 }
 
+// Connected is a mock-implementation of IParticipants.Connected().
+func (ptcp *Participants) Connected() []*common.Player {
+	return ptcp.Called().Get(0).([]*common.Player)
+}
+
 // Playing is a mock-implementation of IParticipants.Playing().
 func (ptcp *Participants) Playing() []*common.Player {
 	return ptcp.Called().Get(0).([]*common.Player)

--- a/game_events.go
+++ b/game_events.go
@@ -374,9 +374,9 @@ func (geh gameEventHandler) playerDisconnect(desc *msg.CSVCMsg_GameEventListDesc
 		geh.dispatch(events.PlayerDisconnected{
 			Player: pl,
 		})
-	}
 
-	delete(geh.gameState().playersByUserID, uid)
+		geh.playerByUserID(uid).IsConnected = false
+	}
 }
 
 func (geh gameEventHandler) playerTeam(desc *msg.CSVCMsg_GameEventListDescriptorT, ge *msg.CSVCMsg_GameEvent) {

--- a/game_state.go
+++ b/game_state.go
@@ -150,7 +150,7 @@ func (ptcp Participants) ByUserID() map[int]*common.Player {
 	for k, v := range ptcp.playersByUserID {
 		// We need to check if the player entity hasn't been destroyed yet
 		// See https://github.com/markus-wa/demoinfocs-golang/issues/98
-		if v.Entity != nil {
+		if v.IsConnected && v.Entity != nil {
 			res[k] = v
 		}
 	}

--- a/game_state.go
+++ b/game_state.go
@@ -168,9 +168,19 @@ func (ptcp Participants) ByEntityID() map[int]*common.Player {
 	return res
 }
 
-// All returns all currently connected players & spectators.
+// All returns all currently known players & spectators, including disconnected ones, of the demo.
 // The returned slice is a snapshot and is not updated on changes.
 func (ptcp Participants) All() []*common.Player {
+	res := make([]*common.Player, 0, len(ptcp.playersByUserID))
+	for _, p := range ptcp.playersByUserID {
+		res = append(res, p)
+	}
+	return res
+}
+
+// Connected returns all currently connected players & spectators.
+// The returned slice is a snapshot and is not updated on changes.
+func (ptcp Participants) Connected() []*common.Player {
 	res, original := ptcp.initalizeSliceFromByUserID()
 	for _, p := range original {
 		res = append(res, p)

--- a/game_state_test.go
+++ b/game_state_test.go
@@ -134,7 +134,7 @@ func TestParticipants_FindByHandle_InvalidEntityHandle(t *testing.T) {
 	assert.Nil(t, found)
 }
 
-func TestParticipants_SuppressNoEntity(t *testing.T) {
+func TestParticipants_Connected_SuppressNoEntity(t *testing.T) {
 	gs := newGameState()
 	pl := newPlayer()
 	gs.playersByUserID[0] = pl
@@ -142,12 +142,12 @@ func TestParticipants_SuppressNoEntity(t *testing.T) {
 	pl2.IsConnected = true
 	gs.playersByUserID[1] = pl2
 
-	allPlayers := gs.Participants().All()
+	allPlayers := gs.Participants().Connected()
 
 	assert.ElementsMatch(t, []*common.Player{pl}, allPlayers)
 }
 
-func TestParticipants_SuppressNotConnected(t *testing.T) {
+func TestParticipants_Connected_SuppressNotConnected(t *testing.T) {
 	gs := newGameState()
 	pl := newPlayer()
 	gs.playersByUserID[0] = pl
@@ -155,7 +155,7 @@ func TestParticipants_SuppressNotConnected(t *testing.T) {
 	pl2.IsConnected = false
 	gs.playersByUserID[1] = pl2
 
-	allPlayers := gs.Participants().All()
+	allPlayers := gs.Participants().Connected()
 
 	assert.ElementsMatch(t, []*common.Player{pl}, allPlayers)
 }

--- a/game_state_test.go
+++ b/game_state_test.go
@@ -138,7 +138,22 @@ func TestParticipants_SuppressNoEntity(t *testing.T) {
 	gs := newGameState()
 	pl := newPlayer()
 	gs.playersByUserID[0] = pl
-	gs.playersByUserID[1] = common.NewPlayer(0, func() int { return 0 })
+	pl2 := common.NewPlayer(0, func() int { return 0 })
+	pl2.IsConnected = true
+	gs.playersByUserID[1] = pl2
+
+	allPlayers := gs.Participants().All()
+
+	assert.ElementsMatch(t, []*common.Player{pl}, allPlayers)
+}
+
+func TestParticipants_SuppressNotConnected(t *testing.T) {
+	gs := newGameState()
+	pl := newPlayer()
+	gs.playersByUserID[0] = pl
+	pl2 := newPlayer()
+	pl2.IsConnected = false
+	gs.playersByUserID[1] = pl2
 
 	allPlayers := gs.Participants().All()
 
@@ -148,5 +163,6 @@ func TestParticipants_SuppressNoEntity(t *testing.T) {
 func newPlayer() *common.Player {
 	pl := common.NewPlayer(0, func() int { return 0 })
 	pl.Entity = new(st.Entity)
+	pl.IsConnected = true
 	return pl
 }

--- a/participants_interface.go
+++ b/participants_interface.go
@@ -20,9 +20,12 @@ type IParticipants interface {
 	// The returned map is a snapshot and is not updated on changes (not a reference to the actual, underlying map).
 	// Includes spectators.
 	ByEntityID() map[int]*common.Player
-	// All returns all currently connected players & spectators.
+	// All returns all currently known players & spectators, including disconnected ones, of the demo.
 	// The returned slice is a snapshot and is not updated on changes.
 	All() []*common.Player
+	// Connected returns all currently connected players & spectators.
+	// The returned slice is a snapshot and is not updated on changes.
+	Connected() []*common.Player
 	// Playing returns all players that aren't spectating or unassigned.
 	// The returned slice is a snapshot and is not updated on changes.
 	Playing() []*common.Player


### PR DESCRIPTION
In some cases we get events for players shortly after they disconnect.
We now keep these players stored in the gameState so we can still put them into future events.

Also adds `Participants.Connected()` and changes `Participants.All()` to return disconnected players as well.

fixes #69 