### PR TITLE
Player spotting information [Player.IsSpottedBy()]

### DIFF
--- a/common/player.go
+++ b/common/player.go
@@ -3,7 +3,7 @@ package common
 import (
 	"time"
 
-	r3 "github.com/golang/geo/r3"
+	"github.com/golang/geo/r3"
 	st "github.com/markus-wa/demoinfocs-golang/sendtables"
 )
 
@@ -112,6 +112,30 @@ func (p *Player) Weapons() []*Equipment {
 		res = append(res, w)
 	}
 	return res
+}
+
+// IsSpottedBy returns true if the player has been spotted by the other player.
+func (p *Player) IsSpottedBy(other *Player) bool {
+	if p.Entity == nil {
+		return false
+	}
+
+	// TODO extract ClientSlot() function
+	clientSlot := other.EntityID - 1
+	bit := uint(clientSlot)
+	var mask st.IProperty
+	if bit < 32 {
+		mask = p.Entity.FindPropertyI("m_bSpottedByMask.000")
+	} else {
+		bit -= 32
+		mask = p.Entity.FindPropertyI("m_bSpottedByMask.001")
+	}
+	return (mask.Value().IntVal & (1 << bit)) != 0
+}
+
+// HasSpotted returns true if the player has spotted the other player.
+func (p *Player) HasSpotted(other *Player) bool {
+	return other.IsSpottedBy(p)
 }
 
 // AdditionalPlayerInformation contains mostly scoreboard information.

--- a/datatables.go
+++ b/datatables.go
@@ -4,10 +4,10 @@ import (
 	"fmt"
 	"strings"
 
-	r3 "github.com/golang/geo/r3"
+	"github.com/golang/geo/r3"
 
-	common "github.com/markus-wa/demoinfocs-golang/common"
-	events "github.com/markus-wa/demoinfocs-golang/events"
+	"github.com/markus-wa/demoinfocs-golang/common"
+	"github.com/markus-wa/demoinfocs-golang/events"
 	st "github.com/markus-wa/demoinfocs-golang/sendtables"
 )
 
@@ -220,7 +220,7 @@ func (p *Parser) bindNewPlayer(playerEntity st.IEntity) {
 	})
 
 	// General info
-	playerEntity.FindProperty("m_iTeamNum").OnUpdate(func(val st.PropertyValue) {
+	playerEntity.FindPropertyI("m_iTeamNum").OnUpdate(func(val st.PropertyValue) {
 		pl.Team = common.Team(val.IntVal) // Need to cast to team so we can't use BindProperty
 		pl.TeamState = p.gameState.Team(pl.Team)
 	})
@@ -233,7 +233,7 @@ func (p *Parser) bindNewPlayer(playerEntity st.IEntity) {
 
 	playerEntity.BindProperty("m_angEyeAngles[1]", &pl.ViewDirectionX, st.ValTypeFloat32)
 	playerEntity.BindProperty("m_angEyeAngles[0]", &pl.ViewDirectionY, st.ValTypeFloat32)
-	playerEntity.FindProperty("m_flFlashDuration").OnUpdate(func(val st.PropertyValue) {
+	playerEntity.FindPropertyI("m_flFlashDuration").OnUpdate(func(val st.PropertyValue) {
 		if val.FloatVal == 0 {
 			pl.FlashTick = 0
 		} else {
@@ -254,7 +254,7 @@ func (p *Parser) bindNewPlayer(playerEntity st.IEntity) {
 
 	// Some demos have an additional prefix for player weapons weapon
 	var wepPrefix string
-	if playerEntity.FindProperty(playerWeaponPrefix+"000") != nil {
+	if playerEntity.FindPropertyI(playerWeaponPrefix+"000") != nil {
 		wepPrefix = playerWeaponPrefix
 	} else {
 		wepPrefix = playerWeaponPrePrefix + playerWeaponPrefix
@@ -264,7 +264,7 @@ func (p *Parser) bindNewPlayer(playerEntity st.IEntity) {
 	var cache [maxWeapons]int
 	for i := range cache {
 		i2 := i // Copy for passing to handler
-		playerEntity.FindProperty(wepPrefix + fmt.Sprintf("%03d", i)).OnUpdate(func(val st.PropertyValue) {
+		playerEntity.FindPropertyI(wepPrefix + fmt.Sprintf("%03d", i)).OnUpdate(func(val st.PropertyValue) {
 			entityID := val.IntVal & entityHandleIndexMask
 			if entityID != entityHandleIndexMask {
 				if cache[i2] != 0 {
@@ -289,7 +289,7 @@ func (p *Parser) bindNewPlayer(playerEntity st.IEntity) {
 	}
 
 	// Active weapon
-	playerEntity.FindProperty("m_hActiveWeapon").OnUpdate(func(val st.PropertyValue) {
+	playerEntity.FindPropertyI("m_hActiveWeapon").OnUpdate(func(val st.PropertyValue) {
 		pl.ActiveWeaponID = val.IntVal & entityHandleIndexMask
 	})
 
@@ -298,7 +298,7 @@ func (p *Parser) bindNewPlayer(playerEntity st.IEntity) {
 		playerEntity.BindProperty("m_iAmmo."+fmt.Sprintf("%03d", i2), &pl.AmmoLeft[i2], st.ValTypeInt)
 	}
 
-	playerEntity.FindProperty("m_bIsDefusing").OnUpdate(func(val st.PropertyValue) {
+	playerEntity.FindPropertyI("m_bIsDefusing").OnUpdate(func(val st.PropertyValue) {
 		if p.gameState.currentDefuser == pl && pl.IsDefusing && val.IntVal == 0 {
 			p.eventDispatcher.Dispatch(events.BombDefuseAborted{Player: pl})
 			p.gameState.currentDefuser = nil

--- a/datatables.go
+++ b/datatables.go
@@ -95,7 +95,7 @@ func (p *Parser) bindBomb() {
 	// Track bomb when it is being held by a player
 	scPlayerC4 := p.stParser.ServerClasses().FindByName("CC4")
 	scPlayerC4.OnEntityCreated(func(bombEntity *st.Entity) {
-		bombEntity.FindProperty("m_hOwner").OnUpdate(func(val st.PropertyValue) {
+		bombEntity.FindPropertyI("m_hOwner").OnUpdate(func(val st.PropertyValue) {
 			bomb.Carrier = p.gameState.Participants().FindByHandle(val.IntVal)
 		})
 	})
@@ -103,7 +103,7 @@ func (p *Parser) bindBomb() {
 
 func (p *Parser) bindTeamStates() {
 	p.stParser.ServerClasses().FindByName("CCSTeam").OnEntityCreated(func(entity *st.Entity) {
-		team := entity.FindProperty("m_szTeamname").Value().StringVal
+		team := entity.FindPropertyI("m_szTeamname").Value().StringVal
 
 		var s *common.TeamState
 
@@ -127,7 +127,7 @@ func (p *Parser) bindTeamStates() {
 			entity.BindProperty("m_szClanTeamname", &s.ClanName, st.ValTypeString)
 			entity.BindProperty("m_szTeamFlagImage", &s.Flag, st.ValTypeString)
 
-			entity.FindProperty("m_scoreTotal").OnUpdate(func(val st.PropertyValue) {
+			entity.FindPropertyI("m_scoreTotal").OnUpdate(func(val st.PropertyValue) {
 				oldScore := s.Score
 				s.Score = val.IntVal
 
@@ -349,16 +349,16 @@ func (p *Parser) bindGrenadeProjectiles(entity *st.Entity) {
 		p.nadeProjectileDestroyed(proj)
 	})
 
-	entity.FindProperty("m_nModelIndex").OnUpdate(func(val st.PropertyValue) {
+	entity.FindPropertyI("m_nModelIndex").OnUpdate(func(val st.PropertyValue) {
 		proj.Weapon = p.grenadeModelIndices[val.IntVal]
 	})
 
 	// @micvbang: not quite sure what the difference between Thrower and Owner is.
-	entity.FindProperty("m_hThrower").OnUpdate(func(val st.PropertyValue) {
+	entity.FindPropertyI("m_hThrower").OnUpdate(func(val st.PropertyValue) {
 		proj.Thrower = p.gameState.Participants().FindByHandle(val.IntVal)
 	})
 
-	entity.FindProperty("m_hOwnerEntity").OnUpdate(func(val st.PropertyValue) {
+	entity.FindPropertyI("m_hOwnerEntity").OnUpdate(func(val st.PropertyValue) {
 		proj.Owner = p.gameState.Participants().FindByHandle(val.IntVal)
 	})
 
@@ -370,8 +370,7 @@ func (p *Parser) bindGrenadeProjectiles(entity *st.Entity) {
 
 	// Some demos don't have this property as it seems
 	// So we need to check for nil and can't send out bounce events if it's missing
-	bounceProp := entity.FindProperty("m_nBounces")
-	if bounceProp != nil {
+	if bounceProp := entity.FindPropertyI("m_nBounces"); bounceProp != nil {
 		bounceProp.OnUpdate(func(val st.PropertyValue) {
 			if val.IntVal != 0 {
 				p.eventDispatcher.Dispatch(events.GrenadeProjectileBounce{
@@ -405,19 +404,19 @@ func (p *Parser) bindWeapon(entity *st.Entity, wepType common.EquipmentElement) 
 	eq.EntityID = entityID
 	eq.AmmoInMagazine = -1
 
-	entity.FindProperty("m_iClip1").OnUpdate(func(val st.PropertyValue) {
+	entity.FindPropertyI("m_iClip1").OnUpdate(func(val st.PropertyValue) {
 		eq.AmmoInMagazine = val.IntVal - 1
 	})
 
 	// Only weapons with scopes have m_zoomLevel property
-	if entity.FindProperty("m_zoomLevel") != nil {
-		entity.BindProperty("m_zoomLevel", &eq.ZoomLevel, st.ValTypeInt)
+	if zoomLvlProp := entity.FindPropertyI("m_zoomLevel"); zoomLvlProp != nil {
+		zoomLvlProp.Bind(&eq.ZoomLevel, st.ValTypeInt)
 	}
 
-	eq.AmmoType = entity.FindProperty("LocalWeaponData.m_iPrimaryAmmoType").Value().IntVal
+	eq.AmmoType = entity.FindPropertyI("LocalWeaponData.m_iPrimaryAmmoType").Value().IntVal
 
 	// Detect alternative weapons (P2k -> USP, M4A4 -> M4A1-S etc.)
-	modelIndex := entity.FindProperty("m_nModelIndex").Value().IntVal
+	modelIndex := entity.FindPropertyI("m_nModelIndex").Value().IntVal
 	eq.OriginalString = p.modelPreCache[modelIndex]
 
 	wepFix := func(defaultName, altName string, alt common.EquipmentElement) {
@@ -459,13 +458,13 @@ func (p *Parser) bindNewInferno(entity *st.Entity) {
 
 	origin := entity.Position()
 	nFires := 0
-	entity.FindProperty("m_fireCount").OnUpdate(func(val st.PropertyValue) {
+	entity.FindPropertyI("m_fireCount").OnUpdate(func(val st.PropertyValue) {
 		for i := nFires; i < val.IntVal; i++ {
 			iStr := fmt.Sprintf("%03d", i)
 			offset := r3.Vector{
-				X: float64(entity.FindProperty("m_fireXDelta." + iStr).Value().IntVal),
-				Y: float64(entity.FindProperty("m_fireYDelta." + iStr).Value().IntVal),
-				Z: float64(entity.FindProperty("m_fireZDelta." + iStr).Value().IntVal),
+				X: float64(entity.FindPropertyI("m_fireXDelta." + iStr).Value().IntVal),
+				Y: float64(entity.FindPropertyI("m_fireYDelta." + iStr).Value().IntVal),
+				Z: float64(entity.FindPropertyI("m_fireZDelta." + iStr).Value().IntVal),
 			}
 
 			fire := &common.Fire{Vector: origin.Add(offset), IsBurning: true}
@@ -499,7 +498,7 @@ func (p *Parser) bindGameRules() {
 
 	gameRules := p.ServerClasses().FindByName("CCSGameRulesProxy")
 	gameRules.OnEntityCreated(func(entity *st.Entity) {
-		entity.FindProperty(grPrefix("m_gamePhase")).OnUpdate(func(val st.PropertyValue) {
+		entity.FindPropertyI(grPrefix("m_gamePhase")).OnUpdate(func(val st.PropertyValue) {
 			oldGamePhase := p.gameState.gamePhase
 			p.gameState.gamePhase = common.GamePhase(val.IntVal)
 
@@ -517,7 +516,7 @@ func (p *Parser) bindGameRules() {
 		})
 
 		entity.BindProperty(grPrefix("m_totalRoundsPlayed"), &p.gameState.totalRoundsPlayed, st.ValTypeInt)
-		entity.FindProperty(grPrefix("m_bWarmupPeriod")).OnUpdate(func(val st.PropertyValue) {
+		entity.FindPropertyI(grPrefix("m_bWarmupPeriod")).OnUpdate(func(val st.PropertyValue) {
 			oldIsWarmupPeriod := p.gameState.isWarmupPeriod
 			p.gameState.isWarmupPeriod = val.IntVal == 1
 
@@ -527,7 +526,7 @@ func (p *Parser) bindGameRules() {
 			})
 		})
 
-		entity.FindProperty(grPrefix("m_bHasMatchStarted")).OnUpdate(func(val st.PropertyValue) {
+		entity.FindPropertyI(grPrefix("m_bHasMatchStarted")).OnUpdate(func(val st.PropertyValue) {
 			oldMatchStarted := p.gameState.isMatchStarted
 			p.gameState.isMatchStarted = val.IntVal == 1
 

--- a/datatables.go
+++ b/datatables.go
@@ -306,6 +306,15 @@ func (p *Parser) bindNewPlayer(playerEntity st.IEntity) {
 		pl.IsDefusing = val.IntVal != 0
 	})
 
+	spottedByMaskProp := playerEntity.FindPropertyI("m_bSpottedByMask.000")
+	if spottedByMaskProp != nil {
+		spottersChanged := func(val st.PropertyValue) {
+			p.eventDispatcher.Dispatch(events.PlayerSpottersChanged{Spotted: pl})
+		}
+		spottedByMaskProp.OnUpdate(spottersChanged)
+		playerEntity.FindPropertyI("m_bSpottedByMask.001").OnUpdate(spottersChanged)
+	}
+
 	if isNew && pl.SteamID != 0 {
 		p.eventDispatcher.Dispatch(events.PlayerConnect{Player: pl})
 	}

--- a/datatables_test.go
+++ b/datatables_test.go
@@ -84,7 +84,7 @@ func fakePlayerEntity(id int) st.IEntity {
 		destroyCallback = args.Get(0).(func())
 	})
 	entity.On("OnPositionUpdate", mock.Anything).Return()
-	entity.On("FindProperty", mock.Anything).Return(new(st.Property))
+	entity.On("FindPropertyI", mock.Anything).Return(new(st.Property))
 	entity.On("BindProperty", mock.Anything, mock.Anything, mock.Anything).Return(new(st.Property))
 	entity.On("Destroy").Run(func(mock.Arguments) {
 		destroyCallback()

--- a/datatables_test.go
+++ b/datatables_test.go
@@ -67,7 +67,50 @@ func TestParser_BindNewPlayer_Issue98_Reconnect(t *testing.T) {
 	p.bindNewPlayer(player)
 
 	assert.Len(t, p.GameState().Participants().All(), 1)
+}
 
+func TestParser_BindNewPlayer_PlayerSpotted_Under32(t *testing.T) {
+	testPlayerSpotted(t, "m_bSpottedByMask.000")
+}
+func TestParser_BindNewPlayer_PlayerSpotted_Over32(t *testing.T) {
+	testPlayerSpotted(t, "m_bSpottedByMask.001")
+}
+
+func testPlayerSpotted(t *testing.T, propName string) {
+	p := newParser()
+
+	p.rawPlayers = map[int]*playerInfo{
+		0: {
+			userID: 2,
+			name:   "Spotter",
+			guid:   "123",
+			xuid:   1,
+		},
+	}
+
+	// TODO: Player interface so we don't have to mock all this
+	spotted := new(fakest.Entity)
+	spottedByProp0 := new(fakest.Property)
+	var spottedByUpdateHandler st.PropertyUpdateHandler
+	spottedByProp0.On("OnUpdate", mock.Anything).Run(func(args mock.Arguments) {
+		spottedByUpdateHandler = args.Get(0).(st.PropertyUpdateHandler)
+	})
+	spotted.On("FindPropertyI", propName).Return(spottedByProp0)
+	configurePlayerEntityMock(1, spotted)
+	p.bindNewPlayer(spotted)
+
+	var actual events.PlayerSpottersChanged
+	p.RegisterEventHandler(func(e events.PlayerSpottersChanged) {
+		actual = e
+	})
+
+	spottedByUpdateHandler(st.PropertyValue{IntVal: 1})
+
+	expected := events.PlayerSpottersChanged{
+		Spotted: p.gameState.playersByEntityID[1],
+	}
+	assert.NotNil(t, expected.Spotted)
+	assert.Equal(t, expected, actual)
 }
 
 func newParser() *Parser {
@@ -76,8 +119,13 @@ func newParser() *Parser {
 	return p
 }
 
-func fakePlayerEntity(id int) st.IEntity {
+func fakePlayerEntity(id int) *fakest.Entity {
 	entity := new(fakest.Entity)
+	configurePlayerEntityMock(id, entity)
+	return entity
+}
+
+func configurePlayerEntityMock(id int, entity *fakest.Entity) {
 	entity.On("ID").Return(id)
 	var destroyCallback func()
 	entity.On("OnDestroy", mock.Anything).Run(func(args mock.Arguments) {
@@ -85,9 +133,8 @@ func fakePlayerEntity(id int) st.IEntity {
 	})
 	entity.On("OnPositionUpdate", mock.Anything).Return()
 	entity.On("FindPropertyI", mock.Anything).Return(new(st.Property))
-	entity.On("BindProperty", mock.Anything, mock.Anything, mock.Anything).Return(new(st.Property))
+	entity.On("BindProperty", mock.Anything, mock.Anything, mock.Anything)
 	entity.On("Destroy").Run(func(mock.Arguments) {
 		destroyCallback()
 	})
-	return entity
 }

--- a/events/events.go
+++ b/events/events.go
@@ -501,3 +501,8 @@ type IsWarmupPeriodChanged struct {
 	OldIsWarmupPeriod bool
 	NewIsWarmupPeriod bool
 }
+
+// PlayerSpottersChanged signals that a player's spotters (other players that can se him) changed.
+type PlayerSpottersChanged struct {
+	Spotted *common.Player
+}

--- a/examples/entities/README.md
+++ b/examples/entities/README.md
@@ -815,11 +815,11 @@ p.RegisterEventHandler(func(events.DataTablesParsed) {
 	// DataTablesParsed has been sent out, register entity-creation handler
 	p.ServerClasses().FindByName("CWeaponAWP").OnEntityCreated(func(entity *st.Entity) {
 		// Register update-hander on the owning entity (player who's holding the AWP)
-		entity.FindProperty("m_hOwnerEntity").OnUpdate(func(val st.PropertyValue) {
+		entity.FindPropertyI("m_hOwnerEntity").OnUpdate(func(val st.PropertyValue) {
 			owner := p.GameState().Participants().FindByHandle(val.IntVal)
 			if owner != nil {
 				var prev string
-				prevHandle := entity.FindProperty("m_hPrevOwner").Value().IntVal
+				prevHandle := entity.FindPropertyI("m_hPrevOwner").Value().IntVal
 				prevPlayer := p.GameState().Participants().FindByHandle(prevHandle)
 				if prevPlayer != nil {
 					if prevHandle != val.IntVal {

--- a/examples/entities/entities.go
+++ b/examples/entities/entities.go
@@ -6,7 +6,7 @@ import (
 	"os"
 
 	dem "github.com/markus-wa/demoinfocs-golang"
-	events "github.com/markus-wa/demoinfocs-golang/events"
+	"github.com/markus-wa/demoinfocs-golang/events"
 	ex "github.com/markus-wa/demoinfocs-golang/examples"
 	st "github.com/markus-wa/demoinfocs-golang/sendtables"
 )
@@ -21,11 +21,11 @@ func main() {
 
 	p.RegisterEventHandler(func(events.DataTablesParsed) {
 		p.ServerClasses().FindByName("CWeaponAWP").OnEntityCreated(func(ent *st.Entity) {
-			ent.FindProperty("m_hOwnerEntity").OnUpdate(func(val st.PropertyValue) {
+			ent.FindPropertyI("m_hOwnerEntity").OnUpdate(func(val st.PropertyValue) {
 				x := p.GameState().Participants().FindByHandle(val.IntVal)
 				if x != nil {
 					var prev string
-					prevHandle := ent.FindProperty("m_hPrevOwner").Value().IntVal
+					prevHandle := ent.FindPropertyI("m_hPrevOwner").Value().IntVal
 					prevPlayer := p.GameState().Participants().FindByHandle(prevHandle)
 					if prevPlayer != nil {
 						if prevHandle != val.IntVal {

--- a/fake/game_state.go
+++ b/fake/game_state.go
@@ -8,6 +8,8 @@ import (
 	st "github.com/markus-wa/demoinfocs-golang/sendtables"
 )
 
+var _ dem.IGameState = new(GameState)
+
 // GameState is a mock for of demoinfocs.IGameState.
 type GameState struct {
 	mock.Mock
@@ -25,6 +27,11 @@ func (gs *GameState) TeamCounterTerrorists() *common.TeamState {
 
 // TeamTerrorists is a mock-implementation of IGameState.TeamTerrorists().
 func (gs *GameState) TeamTerrorists() *common.TeamState {
+	return gs.Called().Get(0).(*common.TeamState)
+}
+
+// Team is a mock-implementation of IGameState.Team().
+func (gs *GameState) Team(team common.Team) *common.TeamState {
 	return gs.Called().Get(0).(*common.TeamState)
 }
 

--- a/fake/parser.go
+++ b/fake/parser.go
@@ -13,6 +13,8 @@ import (
 	st "github.com/markus-wa/demoinfocs-golang/sendtables"
 )
 
+var _ dem.IParser = new(Parser)
+
 // Parser is a mock for of demoinfocs.IParser.
 type Parser struct {
 	mock.Mock

--- a/fake/participants.go
+++ b/fake/participants.go
@@ -1,10 +1,13 @@
 package fake
 
 import (
-	mock "github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/mock"
 
-	common "github.com/markus-wa/demoinfocs-golang/common"
+	dem "github.com/markus-wa/demoinfocs-golang"
+	"github.com/markus-wa/demoinfocs-golang/common"
 )
+
+var _ dem.IParticipants = new(Participants)
 
 // Participants is a mock for of demoinfocs.IParticipants.
 type Participants struct {
@@ -44,4 +47,14 @@ func (ptcp *Participants) TeamMembers(team common.Team) []*common.Player {
 // FindByHandle is a mock-implementation of IParticipants.FindByHandle().
 func (ptcp *Participants) FindByHandle(handle int) *common.Player {
 	return ptcp.Called().Get(0).(*common.Player)
+}
+
+// SpottersOf is a mock-implementation of IParticipants.SpottersOf().
+func (ptcp *Participants) SpottersOf(spotted *common.Player) []*common.Player {
+	return ptcp.Called().Get(0).([]*common.Player)
+}
+
+// SpottedBy is a mock-implementation of IParticipants.SpottedBy().
+func (ptcp *Participants) SpottedBy(spotter *common.Player) []*common.Player {
+	return ptcp.Called().Get(0).([]*common.Player)
 }

--- a/game_events.go
+++ b/game_events.go
@@ -4,11 +4,11 @@ import (
 	"fmt"
 	"strconv"
 
-	r3 "github.com/golang/geo/r3"
+	"github.com/golang/geo/r3"
 
-	common "github.com/markus-wa/demoinfocs-golang/common"
-	events "github.com/markus-wa/demoinfocs-golang/events"
-	msg "github.com/markus-wa/demoinfocs-golang/msg"
+	"github.com/markus-wa/demoinfocs-golang/common"
+	"github.com/markus-wa/demoinfocs-golang/events"
+	"github.com/markus-wa/demoinfocs-golang/msg"
 )
 
 func (p *Parser) handleGameEventList(gel *msg.CSVCMsg_GameEventList) {

--- a/game_state.go
+++ b/game_state.go
@@ -228,3 +228,23 @@ func (ptcp Participants) initalizeSliceFromByUserID() ([]*common.Player, map[int
 	byUserID := ptcp.ByUserID()
 	return make([]*common.Player, 0, len(byUserID)), byUserID
 }
+
+// SpottersOf returns a list of all players who have spotted the passed player.
+func (ptcp Participants) SpottersOf(spotted *common.Player) (spotters []*common.Player) {
+	for _, other := range ptcp.playersByUserID {
+		if spotted.IsSpottedBy(other) {
+			spotters = append(spotters, other)
+		}
+	}
+	return
+}
+
+// SpottedBy returns a list of all players that the passed player has spotted.
+func (ptcp Participants) SpottedBy(spotter *common.Player) (spotted []*common.Player) {
+	for _, other := range ptcp.playersByUserID {
+		if other.Entity != nil && other.IsSpottedBy(spotter) {
+			spotted = append(spotted, other)
+		}
+	}
+	return
+}

--- a/participants_interface.go
+++ b/participants_interface.go
@@ -37,4 +37,8 @@ type IParticipants interface {
 	//
 	// Returns nil if not found or if handle == invalidEntityHandle (used when referencing no entity).
 	FindByHandle(handle int) *common.Player
+	// SpottersOf returns a list of all players who have spotted the passed player.
+	SpottersOf(spotted *common.Player) (spotters []*common.Player)
+	// SpottedBy returns a list of all players that the passed player has spotted.
+	SpottedBy(spotter *common.Player) (spotted []*common.Player)
 }

--- a/sendtables/entity.go
+++ b/sendtables/entity.go
@@ -73,11 +73,11 @@ func (e *Entity) FindPropertyI(name string) IProperty {
 	return prop
 }
 
-// BindProperty combines FindProperty() & Property.Bind() into one.
+// BindProperty combines FindPropertyI() & Property.Bind() into one.
 // Essentially binds a property's value to a pointer.
 // See the docs of the two individual functions for more info.
 func (e *Entity) BindProperty(name string, variable interface{}, valueType PropertyValueType) {
-	e.FindProperty(name).Bind(variable, valueType)
+	e.FindPropertyI(name).Bind(variable, valueType)
 }
 
 var updatedPropIndicesPool = sync.Pool{
@@ -189,13 +189,13 @@ const (
 )
 
 // Sets up the Entity.Position() function
-// Necessary because FindProperty() is fairly slow
+// Necessary because FindPropertyI() is fairly slow
 // This way we only need to find the necessary properties once
 func (e *Entity) initialize() {
 	// Player positions are calculated differently
 	if e.isPlayer() {
-		xyProp := e.FindProperty(propVecOriginPlayerXY)
-		zProp := e.FindProperty(propVecOriginPlayerZ)
+		xyProp := e.FindPropertyI(propVecOriginPlayerXY)
+		zProp := e.FindPropertyI(propVecOriginPlayerZ)
 
 		e.position = func() r3.Vector {
 			xy := xyProp.Value().VectorVal
@@ -207,11 +207,11 @@ func (e *Entity) initialize() {
 			}
 		}
 	} else {
-		cellBitsProp := e.FindProperty(propCellBits)
-		cellXProp := e.FindProperty(propCellX)
-		cellYProp := e.FindProperty(propCellY)
-		cellZProp := e.FindProperty(propCellZ)
-		offsetProp := e.FindProperty(propVecOrigin)
+		cellBitsProp := e.FindPropertyI(propCellBits)
+		cellXProp := e.FindPropertyI(propCellX)
+		cellYProp := e.FindPropertyI(propCellY)
+		cellZProp := e.FindPropertyI(propCellZ)
+		offsetProp := e.FindPropertyI(propVecOrigin)
 
 		e.position = func() r3.Vector {
 			cellWidth := 1 << uint(cellBitsProp.Value().IntVal)
@@ -253,13 +253,13 @@ func (e *Entity) OnPositionUpdate(h func(pos r3.Vector)) {
 	}
 
 	if e.isPlayer() {
-		e.FindProperty(propVecOriginPlayerXY).OnUpdate(firePosUpdate)
-		e.FindProperty(propVecOriginPlayerZ).OnUpdate(firePosUpdate)
+		e.FindPropertyI(propVecOriginPlayerXY).OnUpdate(firePosUpdate)
+		e.FindPropertyI(propVecOriginPlayerZ).OnUpdate(firePosUpdate)
 	} else {
-		e.FindProperty(propCellX).OnUpdate(firePosUpdate)
-		e.FindProperty(propCellY).OnUpdate(firePosUpdate)
-		e.FindProperty(propCellZ).OnUpdate(firePosUpdate)
-		e.FindProperty(propVecOrigin).OnUpdate(firePosUpdate)
+		e.FindPropertyI(propCellX).OnUpdate(firePosUpdate)
+		e.FindPropertyI(propCellY).OnUpdate(firePosUpdate)
+		e.FindPropertyI(propCellZ).OnUpdate(firePosUpdate)
+		e.FindPropertyI(propVecOrigin).OnUpdate(firePosUpdate)
 	}
 }
 

--- a/sendtables/entity_interface.go
+++ b/sendtables/entity_interface.go
@@ -3,7 +3,7 @@
 package sendtables
 
 import (
-	r3 "github.com/golang/geo/r3"
+	"github.com/golang/geo/r3"
 	bit "github.com/markus-wa/demoinfocs-golang/bitread"
 )
 
@@ -14,15 +14,19 @@ type IEntity interface {
 	ServerClass() *ServerClass
 	// ID returns the entity's ID.
 	ID() int
-	// Properties returns all properties of the Entity.
-	Properties() []Property
-	// FindProperty finds a property on the Entity by name.
+	// Properties is deprecated, use PropertiesI() instead.
+	Properties() (out []Property)
+	// PropertiesI returns all properties of the Entity.
+	PropertiesI() (out []IProperty)
+	// FindProperty is deprecated, use FindPropertyI() instead.
+	FindProperty(name string) (prop *Property)
+	// FindPropertyI finds a property on the Entity by name.
 	//
 	// Returns nil if the property wasn't found.
 	//
 	// Panics if more than one property with the same name was found.
-	FindProperty(name string) *Property
-	// BindProperty combines FindProperty() & Property.Bind() into one.
+	FindPropertyI(name string) (prop IProperty)
+	// BindProperty combines FindPropertyI() & Property.Bind() into one.
 	// Essentially binds a property's value to a pointer.
 	// See the docs of the two individual functions for more info.
 	BindProperty(name string, variable interface{}, valueType PropertyValueType)

--- a/sendtables/fake/doc.go
+++ b/sendtables/fake/doc.go
@@ -1,0 +1,3 @@
+// Package fake provides basic mocks for IEntity and IProperty.
+// See examples/mocking (https://github.com/markus-wa/demoinfocs-golang/tree/master/examples/mocking).
+package fake

--- a/sendtables/fake/entity.go
+++ b/sendtables/fake/entity.go
@@ -1,13 +1,14 @@
-// Package fake provides basic mocks for IEntity.
-// See examples/mocking (https://github.com/markus-wa/demoinfocs-golang/tree/master/examples/mocking).
 package fake
 
 import (
 	"github.com/golang/geo/r3"
+	"github.com/stretchr/testify/mock"
+
 	"github.com/markus-wa/demoinfocs-golang/bitread"
 	st "github.com/markus-wa/demoinfocs-golang/sendtables"
-	"github.com/stretchr/testify/mock"
 )
+
+var _ st.IEntity = new(Entity)
 
 // Entity is a mock for of sendtables.IEntity.
 type Entity struct {
@@ -29,9 +30,19 @@ func (e *Entity) Properties() []st.Property {
 	return e.Called().Get(0).([]st.Property)
 }
 
+// PropertiesI is a mock-implementation of IEntity.PropertiesI().
+func (e *Entity) PropertiesI() []st.IProperty {
+	return e.Called().Get(0).([]st.IProperty)
+}
+
 // FindProperty is a mock-implementation of IEntity.FindProperty().
 func (e *Entity) FindProperty(name string) *st.Property {
 	return e.Called(name).Get(0).(*st.Property)
+}
+
+// FindPropertyI is a mock-implementation of IEntity.FindPropertyI().
+func (e *Entity) FindPropertyI(name string) st.IProperty {
+	return e.Called(name).Get(0).(st.IProperty)
 }
 
 // BindProperty is a mock-implementation of IEntity.BindProperty().

--- a/sendtables/fake/property.go
+++ b/sendtables/fake/property.go
@@ -25,10 +25,10 @@ func (p *Property) Value() st.PropertyValue {
 
 // OnUpdate is a mock-implementation of IProperty.OnUpdate().
 func (p *Property) OnUpdate(handler st.PropertyUpdateHandler) {
-	p.Called()
+	p.Called(handler)
 }
 
 // Bind is a mock-implementation of IProperty.Bind().
 func (p *Property) Bind(variable interface{}, valueType st.PropertyValueType) {
-	p.Called()
+	p.Called(variable, valueType)
 }

--- a/sendtables/fake/property.go
+++ b/sendtables/fake/property.go
@@ -1,0 +1,34 @@
+package fake
+
+import (
+	"github.com/stretchr/testify/mock"
+
+	st "github.com/markus-wa/demoinfocs-golang/sendtables"
+)
+
+var _ st.IProperty = new(Property)
+
+// Property is a mock for of sendtables.IProperty.
+type Property struct {
+	mock.Mock
+}
+
+// Namp is a mock-implementation of IProperty.Name().
+func (p *Property) Name() string {
+	return p.Called().Get(0).(string)
+}
+
+// Value is a mock-implementation of IProperty.Value().
+func (p *Property) Value() st.PropertyValue {
+	return p.Called().Get(0).(st.PropertyValue)
+}
+
+// OnUpdate is a mock-implementation of IProperty.OnUpdate().
+func (p *Property) OnUpdate(handler st.PropertyUpdateHandler) {
+	p.Called()
+}
+
+// Bind is a mock-implementation of IProperty.Bind().
+func (p *Property) Bind(variable interface{}, valueType st.PropertyValueType) {
+	p.Called()
+}

--- a/sendtables/property_interface.go
+++ b/sendtables/property_interface.go
@@ -1,0 +1,29 @@
+// DO NOT EDIT: Auto generated
+
+package sendtables
+
+// IProperty is an auto-generated interface for Property, intended to be used when mockability is needed.
+// Property wraps a flattenedPropEntry and allows registering handlers
+// that can be triggered on a update of the property.
+type IProperty interface {
+	// Name returns the property's name.
+	Name() string
+	// Value returns current value of the property.
+	Value() PropertyValue
+	// OnUpdate registers a handler for updates of the Property's value.
+	//
+	// The handler will be called with the current value upon registration.
+	OnUpdate(handler PropertyUpdateHandler)
+	/*
+	   Bind binds a property's value to a pointer.
+
+	   Example:
+	   	var i int
+	   	Property.Bind(&i, ValTypeInt)
+
+	   This will bind the property's value to i so every time it's updated i is updated as well.
+
+	   The valueType indicates which field of the PropertyValue to use for the binding.
+	*/
+	Bind(variable interface{}, valueType PropertyValueType)
+}


### PR DESCRIPTION
Fixes #114 

* Added `PlayerSpottersChanged` event
* Added helper functions to `common.Player`
  - `IsSpottedBy(*Player) bool`
  - `HasSpotted(*Player) bool`
* Added helper functions to `Participants`
  - `SpottersOf(*Player) []*Player`
  - `SpottedBy(*Player) []*Player`

* `Entity.FindProperty()` has been deprecated, use `Entity.FindPropertyI()` instead which returns `IProperty` instead of `*Property`
* `Entity.Properties()` has been deprecated, use `Entity.PropertiesI()` instead which returns `[]IProperty` instead of `[]Property`

`Entity.Properties()` and `Entity.FindProperty()` have been deprecated and should be replaced with `Entity.PropertiesI()` and `Entity.FindPropertyI()` which return interfaces so we can mock the returned values in unit tests.