### PR TITLE
 common: add helper functions for Player and TeamState

### DIFF
--- a/common/common.go
+++ b/common/common.go
@@ -5,7 +5,7 @@ import (
 	"math/rand"
 	"time"
 
-	r3 "github.com/golang/geo/r3"
+	"github.com/golang/geo/r3"
 )
 
 // Team is the type for the various TeamXYZ constants.
@@ -110,7 +110,8 @@ func (b Bomb) Position() r3.Vector {
 
 // TeamState contains a team's ID, score, clan name & country flag.
 type TeamState struct {
-	team Team
+	team            Team
+	membersCallback func(Team) []*Player
 
 	// ID stays the same even after switching sides.
 	ID int
@@ -132,6 +133,55 @@ func (ts TeamState) Team() Team {
 	return ts.team
 }
 
-func NewTeamState(team Team) TeamState {
-	return TeamState{team: team}
+// Members returns the members of the team.
+func (ts TeamState) Members() []*Player {
+	return ts.membersCallback(ts.team)
+}
+
+// CurrentEquipmentValue returns the cumulative value of all equipment currently owned by the members of the team.
+func (ts TeamState) CurrentEquipmentValue() (value int) {
+	for _, pl := range ts.Members() {
+		value += pl.CurrentEquipmentValue
+	}
+	return
+}
+
+// RoundStartEquipmentValue returns the cumulative value of all equipment owned by the members of the team at the start of the current round.
+func (ts TeamState) RoundStartEquipmentValue() (value int) {
+	for _, pl := range ts.Members() {
+		value += pl.RoundStartEquipmentValue
+	}
+	return
+}
+
+// FreezeTimeEndEquipmentValue returns the cumulative value of all equipment owned by the members of the team at the end of the freeze-time of the current round.
+func (ts TeamState) FreezeTimeEndEquipmentValue() (value int) {
+	for _, pl := range ts.Members() {
+		value += pl.FreezetimeEndEquipmentValue
+	}
+	return
+}
+
+// CashSpentThisRound returns the total amount of cash spent by the whole team in the current round.
+func (ts TeamState) CashSpentThisRound() (value int) {
+	for _, pl := range ts.Members() {
+		value += pl.CashSpentThisRound()
+	}
+	return
+}
+
+// CashSpentThisRound returns the total amount of cash spent by the whole team during the whole game up to the current point.
+func (ts TeamState) CashSpentTotal() (value int) {
+	for _, pl := range ts.Members() {
+		value += pl.CashSpentTotal()
+	}
+	return
+}
+
+// NewTeamState creates a new TeamState with the given Team and members callback function.
+func NewTeamState(team Team, membersCallback func(Team) []*Player) TeamState {
+	return TeamState{
+		team:            team,
+		membersCallback: membersCallback,
+	}
 }

--- a/common/common_test.go
+++ b/common/common_test.go
@@ -6,6 +6,8 @@ import (
 
 	"github.com/golang/geo/r3"
 	"github.com/stretchr/testify/assert"
+
+	"github.com/markus-wa/demoinfocs-golang/sendtables"
 )
 
 func TestBombPosition(t *testing.T) {
@@ -43,7 +45,55 @@ func TestDemoHeader_FrameTime_PlaybackFrames_Zero(t *testing.T) {
 	assert.Zero(t, DemoHeader{}.FrameTime())
 }
 
-func TestTeamState(t *testing.T) {
-	assert.Equal(t, TeamTerrorists, NewTeamState(TeamTerrorists).Team())
-	assert.Equal(t, TeamCounterTerrorists, NewTeamState(TeamCounterTerrorists).Team())
+func TestTeamState_Team(t *testing.T) {
+	assert.Equal(t, TeamTerrorists, NewTeamState(TeamTerrorists, nil).Team())
+	assert.Equal(t, TeamCounterTerrorists, NewTeamState(TeamCounterTerrorists, nil).Team())
+}
+
+func TestTeamState_Members(t *testing.T) {
+	members := []*Player{new(Player), new(Player)}
+	state := NewTeamState(TeamTerrorists, func(Team) []*Player { return members })
+
+	assert.Equal(t, members, state.Members())
+}
+
+func TestTeamState_CurrentEquipmentValue(t *testing.T) {
+	members := []*Player{{CurrentEquipmentValue: 100}, {CurrentEquipmentValue: 200}}
+	state := NewTeamState(TeamTerrorists, func(Team) []*Player { return members })
+
+	assert.Equal(t, 300, state.CurrentEquipmentValue())
+}
+
+func TestTeamState_RoundStartEquipmentValue(t *testing.T) {
+	members := []*Player{{RoundStartEquipmentValue: 100}, {RoundStartEquipmentValue: 200}}
+	state := NewTeamState(TeamTerrorists, func(Team) []*Player { return members })
+
+	assert.Equal(t, 300, state.RoundStartEquipmentValue())
+}
+
+func TestTeamState_FreezeTimeEndEquipmentValue(t *testing.T) {
+	members := []*Player{{FreezetimeEndEquipmentValue: 100}, {FreezetimeEndEquipmentValue: 200}}
+	state := NewTeamState(TeamTerrorists, func(Team) []*Player { return members })
+
+	assert.Equal(t, 300, state.FreezeTimeEndEquipmentValue())
+}
+
+func TestTeamState_CashSpentThisRound(t *testing.T) {
+	members := []*Player{
+		playerWithProperty("m_iCashSpentThisRound", sendtables.PropertyValue{IntVal: 100}),
+		playerWithProperty("m_iCashSpentThisRound", sendtables.PropertyValue{IntVal: 200}),
+	}
+	state := NewTeamState(TeamTerrorists, func(Team) []*Player { return members })
+
+	assert.Equal(t, 300, state.CashSpentThisRound())
+}
+
+func TestTeamState_CashSpentTotal(t *testing.T) {
+	members := []*Player{
+		playerWithProperty("m_iTotalCashSpent", sendtables.PropertyValue{IntVal: 100}),
+		playerWithProperty("m_iTotalCashSpent", sendtables.PropertyValue{IntVal: 200}),
+	}
+	state := NewTeamState(TeamTerrorists, func(Team) []*Player { return members })
+
+	assert.Equal(t, 300, state.CashSpentTotal())
 }

--- a/common/player.go
+++ b/common/player.go
@@ -138,6 +138,36 @@ func (p *Player) HasSpotted(other *Player) bool {
 	return other.IsSpottedBy(p)
 }
 
+// IsInBombZone returns whether the player is currently in the bomb zone or not.
+func (p *Player) IsInBombZone() bool {
+	return p.Entity.FindPropertyI("m_bInBombZone").Value().IntVal == 1
+}
+
+// IsInBuyZone returns whether the player is currently in the buy zone or not.
+func (p *Player) IsInBuyZone() bool {
+	return p.Entity.FindPropertyI("m_bInBuyZone").Value().IntVal == 1
+}
+
+// IsWalking returns whether the player is currently walking (sneaking) in or not.
+func (p *Player) IsWalking() bool {
+	return p.Entity.FindPropertyI("m_bIsWalking").Value().IntVal == 1
+}
+
+// IsScoped returns whether the player is currently scoped in or not.
+func (p *Player) IsScoped() bool {
+	return p.Entity.FindPropertyI("m_bIsScoped").Value().IntVal == 1
+}
+
+// CashSpentThisRound returns the amount of cash the player spent in the current round.
+func (p *Player) CashSpentThisRound() int {
+	return p.Entity.FindPropertyI("m_iCashSpentThisRound").Value().IntVal
+}
+
+// CashSpentTotal returns the amount of cash the player spent during the whole game up to the current point.
+func (p *Player) CashSpentTotal() int {
+	return p.Entity.FindPropertyI("m_iTotalCashSpent").Value().IntVal
+}
+
 // AdditionalPlayerInformation contains mostly scoreboard information.
 type AdditionalPlayerInformation struct {
 	Kills          int

--- a/common/player_test.go
+++ b/common/player_test.go
@@ -125,13 +125,8 @@ func TestPlayer_FlashDurationTimeRemaining_Fallback(t *testing.T) {
 }
 
 func TestPlayer_IsSpottedBy_HasSpotted_True(t *testing.T) {
-	pl := newPlayer(0)
-	entity := new(fake.Entity)
-	pl.Entity = entity
+	pl := playerWithProperty("m_bSpottedByMask.000", sendtables.PropertyValue{IntVal: 2})
 	pl.EntityID = 1
-	prop := new(fake.Property)
-	prop.On("Value").Return(sendtables.PropertyValue{IntVal: 2})
-	entity.On("FindPropertyI", "m_bSpottedByMask.000").Return(prop)
 
 	other := newPlayer(0)
 	other.EntityID = 2
@@ -141,13 +136,8 @@ func TestPlayer_IsSpottedBy_HasSpotted_True(t *testing.T) {
 }
 
 func TestPlayer_IsSpottedBy_HasSpotted_False(t *testing.T) {
-	pl := newPlayer(0)
-	entity := new(fake.Entity)
-	pl.Entity = entity
+	pl := playerWithProperty("m_bSpottedByMask.000", sendtables.PropertyValue{IntVal: 0})
 	pl.EntityID = 1
-	prop := new(fake.Property)
-	prop.On("Value").Return(sendtables.PropertyValue{IntVal: 0})
-	entity.On("FindPropertyI", "m_bSpottedByMask.000").Return(prop)
 
 	other := newPlayer(0)
 	other.EntityID = 2
@@ -157,12 +147,7 @@ func TestPlayer_IsSpottedBy_HasSpotted_False(t *testing.T) {
 }
 
 func TestPlayer_IsSpottedBy_HasSpotted_BitOver32(t *testing.T) {
-	pl := newPlayer(0)
-	entity := new(fake.Entity)
-	prop := new(fake.Property)
-	prop.On("Value").Return(sendtables.PropertyValue{IntVal: 1})
-	entity.On("FindPropertyI", "m_bSpottedByMask.001").Return(prop)
-	pl.Entity = entity
+	pl := playerWithProperty("m_bSpottedByMask.001", sendtables.PropertyValue{IntVal: 1})
 	pl.EntityID = 1
 
 	other := newPlayer(0)
@@ -182,10 +167,55 @@ func TestPlayer_IsSpottedBy_EntityNull(t *testing.T) {
 	assert.False(t, other.HasSpotted(pl))
 }
 
+func TestPlayer_IsInBombZone(t *testing.T) {
+	pl := playerWithProperty("m_bInBombZone", sendtables.PropertyValue{IntVal: 1})
+
+	assert.True(t, pl.IsInBombZone())
+}
+
+func TestPlayer_IsInBuyZone(t *testing.T) {
+	pl := playerWithProperty("m_bInBuyZone", sendtables.PropertyValue{IntVal: 1})
+
+	assert.True(t, pl.IsInBuyZone())
+}
+
+func TestPlayer_IsWalking(t *testing.T) {
+	pl := playerWithProperty("m_bIsWalking", sendtables.PropertyValue{IntVal: 1})
+
+	assert.True(t, pl.IsWalking())
+}
+
+func TestPlayer_IsScoped(t *testing.T) {
+	pl := playerWithProperty("m_bIsScoped", sendtables.PropertyValue{IntVal: 1})
+
+	assert.True(t, pl.IsScoped())
+}
+
+func TestPlayer_CashSpentThisRound(t *testing.T) {
+	pl := playerWithProperty("m_iCashSpentThisRound", sendtables.PropertyValue{IntVal: 500})
+
+	assert.Equal(t, 500, pl.CashSpentThisRound())
+}
+
+func TestPlayer_CashSpentTotal(t *testing.T) {
+	pl := playerWithProperty("m_iTotalCashSpent", sendtables.PropertyValue{IntVal: 500})
+
+	assert.Equal(t, 500, pl.CashSpentTotal())
+}
+
 func newPlayer(tick int) *Player {
 	return NewPlayer(128, tickProvider(tick))
 }
 
 func tickProvider(tick int) ingameTickProvider {
 	return func() int { return tick }
+}
+
+func playerWithProperty(propName string, value sendtables.PropertyValue) *Player {
+	entity := new(fake.Entity)
+	prop := new(fake.Property)
+	prop.On("Value").Return(value)
+	entity.On("FindPropertyI", propName).Return(prop)
+	pl := &Player{Entity: entity}
+	return pl
 }

--- a/game_state.go
+++ b/game_state.go
@@ -123,10 +123,10 @@ func newGameState() *GameState {
 		grenadeProjectiles: make(map[int]*common.GrenadeProjectile),
 		infernos:           make(map[int]*common.Inferno),
 		entities:           make(map[int]*st.Entity),
-		tState:             common.NewTeamState(common.TeamTerrorists),
-		ctState:            common.NewTeamState(common.TeamCounterTerrorists),
 	}
 
+	gs.tState = common.NewTeamState(common.TeamTerrorists, gs.Participants().TeamMembers)
+	gs.ctState = common.NewTeamState(common.TeamCounterTerrorists, gs.Participants().TeamMembers)
 	gs.tState.Opponent = &gs.ctState
 	gs.ctState.Opponent = &gs.tState
 


### PR DESCRIPTION
Depends on #121 
Fixes #115

* Added helper functions to `common.Player` for easily retrieving additional data (#115):
  - `Player.IsInBombZone()`
  - `Player.IsInBuyZone()`
  - `Player.IsWalking()`
  - `Player.IsScoped()`
  - `Player.CashSpentThisRound()`
  - `Player.CashSpentTotal()`
* Added helper functions to `common.TeamState` for retrieving information over all members of a team:
  - `TeamState.Members()`
  - `TeamState.CurrentEquipmentValue()`
  - `TeamState.RoundStartEquipmentValue()`
  - `TeamState.FreezeTimeEndEquipmentValue()`
  - `TeamState.CashSpentThisRound()`
  - `TeamState.CashSpentTotal()`