### PR TITLE
Equipment.AmmoReserve

### DIFF
--- a/datatables.go
+++ b/datatables.go
@@ -419,6 +419,9 @@ func (p *Parser) bindWeapon(entity *st.Entity, wepType common.EquipmentElement) 
 	entity.FindPropertyI("m_iClip1").OnUpdate(func(val st.PropertyValue) {
 		eq.AmmoInMagazine = val.IntVal - 1
 	})
+	entity.FindPropertyI("m_iPrimaryReserveAmmoCount").OnUpdate(func(val st.PropertyValue) {
+		eq.AmmoReserve = val.IntVal
+	})
 
 	// Only weapons with scopes have m_zoomLevel property
 	if zoomLvlProp := entity.FindPropertyI("m_zoomLevel"); zoomLvlProp != nil {

--- a/datatables.go
+++ b/datatables.go
@@ -419,9 +419,10 @@ func (p *Parser) bindWeapon(entity *st.Entity, wepType common.EquipmentElement) 
 	entity.FindPropertyI("m_iClip1").OnUpdate(func(val st.PropertyValue) {
 		eq.AmmoInMagazine = val.IntVal - 1
 	})
-	entity.FindPropertyI("m_iPrimaryReserveAmmoCount").OnUpdate(func(val st.PropertyValue) {
-		eq.AmmoReserve = val.IntVal
-	})
+	// Some weapons in some demos might be missing this property
+	if reserveAmmoProp := entity.FindPropertyI("m_iPrimaryReserveAmmoCount"); reserveAmmoProp != nil {
+		reserveAmmoProp.Bind(&eq.AmmoReserve, st.ValTypeInt)
+	}
 
 	// Only weapons with scopes have m_zoomLevel property
 	if zoomLvlProp := entity.FindPropertyI("m_zoomLevel"); zoomLvlProp != nil {


### PR DESCRIPTION
Added two functions to retrieve all gamephase- and weapon names to allow direct export along with match data.

Equipment.AmmoReserve has been left uninitialized at 0 so far, so i thought i might add that as well.

Not sure if i missed something aside from properly recreating the Interface, reserve ammo update seemed pretty straightforward.