### PR TITLE
Export functions for equipment and game phase names

### DIFF
--- a/common/equipment.go
+++ b/common/equipment.go
@@ -48,7 +48,7 @@ const (
 	EqDeagle       EquipmentElement = 4
 	EqFiveSeven    EquipmentElement = 5
 	EqDualBerettas EquipmentElement = 6
-	EqDualBarettas EquipmentElement = 6 // Misspelled constant for compatibility
+	EqDualBarettas EquipmentElement = 6 // Deprecated, use EqDualBerettas instead (spelling error)
 	EqTec9         EquipmentElement = 7
 	EqCZ           EquipmentElement = 8
 	EqUSP          EquipmentElement = 9

--- a/common/equipment.go
+++ b/common/equipment.go
@@ -47,7 +47,8 @@ const (
 	EqP250         EquipmentElement = 3
 	EqDeagle       EquipmentElement = 4
 	EqFiveSeven    EquipmentElement = 5
-	EqDualBarettas EquipmentElement = 6
+	EqDualBerettas EquipmentElement = 6
+	EqDualBarettas EquipmentElement = 6 // Misspelled constant for compatibility
 	EqTec9         EquipmentElement = 7
 	EqCZ           EquipmentElement = 8
 	EqUSP          EquipmentElement = 9
@@ -112,6 +113,11 @@ var eqNameToWeapon map[string]EquipmentElement
 
 var eqElementToName map[EquipmentElement]string
 
+// EquipmentElementNames returns all human readable equipment names as map[EquipmentElement]string
+func EquipmentElementNames() map[EquipmentElement]string {
+	return eqElementToName
+}
+
 func init() {
 	initEqNameToWeapon()
 	initEqElementToName()
@@ -129,7 +135,7 @@ func initEqNameToWeapon() {
 	eqNameToWeapon["decoy"] = EqDecoy
 	eqNameToWeapon["decoygrenade"] = EqDecoy
 	eqNameToWeapon["decoyprojectile"] = EqDecoy
-	eqNameToWeapon["elite"] = EqDualBarettas
+	eqNameToWeapon["elite"] = EqDualBerettas
 	eqNameToWeapon["famas"] = EqFamas
 	eqNameToWeapon["fiveseven"] = EqFiveSeven
 	eqNameToWeapon["flashbang"] = EqFlash

--- a/common/gamerules.go
+++ b/common/gamerules.go
@@ -55,6 +55,11 @@ var gamePhaseToString = map[GamePhase]string{
 	GamePhaseGameOver:       "GameOver",
 }
 
+// GamePhaseNames returns all human readable game phase names as map[GamePhase]string
+func GamePhaseNames() map[GamePhase]string {
+	return gamePhaseToString
+}
+
 func (r GamePhase) String() string {
 	return gamePhaseToString[r]
 }


### PR DESCRIPTION
Added two functions to retrieve all gamephase- and weapon names to allow direct export along with match data.

Now with new names and its own pull request :stuck_out_tongue_closed_eyes:  