### PR TITLE
GameState: Allow accessing .gamePhase

### DIFF
--- a/fake/game_state.go
+++ b/fake/game_state.go
@@ -65,6 +65,11 @@ func (gs *GameState) TotalRoundsPlayed() int {
 	return gs.Called().Int(0)
 }
 
+// GamePhase is a mock-implementation of IGameState.GamePhase().
+func (gs *GameState) GamePhase() common.GamePhase {
+	return gs.Called().Get(0).(common.GamePhase)
+}
+
 // IsWarmupPeriod is a mock-implementation of IGameState.IsWarmupPeriod().
 func (gs *GameState) IsWarmupPeriod() bool {
 	return gs.Called().Bool(0)

--- a/game_state.go
+++ b/game_state.go
@@ -106,6 +106,11 @@ func (gs GameState) TotalRoundsPlayed() int {
 	return gs.totalRoundsPlayed
 }
 
+// GamePhase returns the game phase of the current game state. See common/gamerules.go for more.
+func (gs GameState) GamePhase() common.GamePhase {
+	return gs.gamePhase
+}
+
 // IsWarmupPeriod returns whether the game is currently in warmup period according to CCSGameRulesProxy.
 func (gs GameState) IsWarmupPeriod() bool {
 	return gs.isWarmupPeriod

--- a/game_state_interface.go
+++ b/game_state_interface.go
@@ -44,6 +44,8 @@ type IGameState interface {
 	Bomb() *common.Bomb
 	// TotalRoundsPlayed returns the amount of total rounds played according to CCSGameRulesProxy.
 	TotalRoundsPlayed() int
+	// GamePhase returns the game phase of the current game state. See common/gamerules.go for more.
+	GamePhase() common.GamePhase
 	// IsWarmupPeriod returns whether the game is currently in warmup period according to CCSGameRulesProxy.
 	IsWarmupPeriod() bool
 	// IsMatchStarted returns whether the match has started according to CCSGameRulesProxy.


### PR DESCRIPTION
Added IGameState.GamePhase() function to retrieve current game phase

Like #134 without .currentDefuser