### PR TITLE
common: add new ammo functions to Equipment for grenades

### DIFF
--- a/common/equipment.go
+++ b/common/equipment.go
@@ -274,7 +274,7 @@ type Equipment struct {
 	Weapon         EquipmentElement // The type of weapon which the equipment instantiates.
 	Owner          *Player          // The player carrying the equipment, not necessarily the buyer.
 	AmmoType       int              // TODO: Remove this? doesn't seem applicable to CS:GO
-	AmmoInMagazine int              // Amount of bullets in the weapon's magazine
+	AmmoInMagazine int              // Amount of bullets in the weapon's magazine. Deprecated, use AmmoInMagazine2() instead.
 	AmmoReserve    int              // Amount of reserve bullets
 	OriginalString string           // E.g. 'models/weapons/w_rif_m4a1_s.mdl'. Used internally to differentiate alternative weapons (M4A4 / M4A1-S etc.).
 	ZoomLevel      int              // How far the player has zoomed in on the weapon. 0=no zoom, 1=first level, 2=maximum zoom
@@ -293,6 +293,32 @@ func (e Equipment) Class() EquipmentClass {
 // equipment from each other. This is needed because demo-files reuse entity ids.
 func (e Equipment) UniqueID() int64 {
 	return e.uniqueID
+}
+
+// AmmoInMagazine2 returns the ammo left in the magazine.
+// Returns CWeaponCSBase.m_iClip1 for most weapons and 1 for grenades.
+func (e Equipment) AmmoInMagazine2() int {
+	if e.Class() == EqClassGrenade {
+		return 1
+	}
+
+	return e.AmmoInMagazine
+}
+
+// AmmoReserve2 returns the ammo left available for reloading.
+// Returns CWeaponCSBase.m_iPrimaryReserveAmmoCount for most weapons and 'Owner.AmmoLeft[AmmoType] - 1' for grenades.
+// Use AmmoInMagazine2() + AmmoReserve2() to quickly get the amount of grenades a player owns.
+func (e Equipment) AmmoReserve2() int {
+	if e.Class() == EqClassGrenade {
+		if e.Owner != nil {
+			// minus one for 'InMagazine'
+			return e.Owner.AmmoLeft[e.AmmoType] - 1
+		}
+
+		return 0
+	}
+
+	return e.AmmoReserve
 }
 
 // NewEquipment creates a new Equipment and sets the UniqueID.

--- a/common/equipment_test.go
+++ b/common/equipment_test.go
@@ -35,3 +35,46 @@ func TestEquipment_Class(t *testing.T) {
 func TestEquipment_UniqueID(t *testing.T) {
 	assert.NotEqual(t, NewEquipment(EqAK47).UniqueID(), NewEquipment(EqAK47).UniqueID(), "UniqueIDs of different equipment instances should be different")
 }
+
+func TestEquipment_AmmoInMagazine2_Default(t *testing.T) {
+	wep := &Equipment{AmmoInMagazine: 1}
+
+	assert.Equal(t, 1, wep.AmmoInMagazine2())
+}
+
+func TestEquipment_AmmoInMagazine2_Grenade(t *testing.T) {
+	wep := &Equipment{
+		Weapon: EqFlash,
+	}
+
+	assert.Equal(t, 1, wep.AmmoInMagazine2())
+}
+
+func TestEquipment_AmmoReserve2_Default(t *testing.T) {
+	wep := &Equipment{
+		AmmoReserve: 1,
+	}
+
+	assert.Equal(t, 1, wep.AmmoReserve2())
+}
+
+func TestEquipment_AmmoReserve2_Grenade(t *testing.T) {
+	owner := new(Player)
+	owner.AmmoLeft[1] = 2
+	wep := &Equipment{
+		Weapon:         EqFlash,
+		AmmoInMagazine: -1,
+		Owner:          owner,
+		AmmoType:       1,
+	}
+
+	assert.Equal(t, 1, wep.AmmoReserve2())
+}
+
+func TestEquipment_AmmoReserve2_Grenade_OwnerNil(t *testing.T) {
+	wep := &Equipment{
+		Weapon: EqFlash,
+	}
+
+	assert.Equal(t, 0, wep.AmmoReserve2())
+}

--- a/common/player.go
+++ b/common/player.go
@@ -4,6 +4,7 @@ import (
 	"time"
 
 	"github.com/golang/geo/r3"
+
 	st "github.com/markus-wa/demoinfocs-golang/sendtables"
 )
 
@@ -26,7 +27,7 @@ type Player struct {
 	RoundStartEquipmentValue    int
 	ActiveWeaponID              int                // Used internally to set the active weapon, see ActiveWeapon()
 	RawWeapons                  map[int]*Equipment // All weapons the player is currently carrying
-	AmmoLeft                    [32]int            // Ammo left in the various weapons, index corresponds to key of RawWeapons
+	AmmoLeft                    [32]int            // Ammo left for special weapons (e.g. grenades), index corresponds Equipment.AmmoType
 	Entity                      st.IEntity
 	AdditionalPlayerInformation *AdditionalPlayerInformation // Mostly scoreboard information such as kills, deaths, etc.
 	ViewDirectionX              float32

--- a/datatables.go
+++ b/datatables.go
@@ -276,8 +276,14 @@ func (p *Parser) bindNewPlayer(playerEntity st.IEntity) {
 				}
 				cache[i2] = entityID
 
-				// Attribute weapon to player
 				wep := &p.weapons[entityID]
+
+				// Clear previous owner
+				if wep.Owner != nil {
+					delete(wep.Owner.RawWeapons, wep.EntityID)
+				}
+
+				// Attribute weapon to player
 				wep.Owner = pl
 				pl.RawWeapons[entityID] = wep
 			} else {
@@ -411,8 +417,10 @@ func (p *Parser) nadeProjectileDestroyed(proj *common.GrenadeProjectile) {
 
 func (p *Parser) bindWeapon(entity *st.Entity, wepType common.EquipmentElement) {
 	entityID := entity.ID()
+	currentOwner := p.weapons[entityID].Owner
 	p.weapons[entityID] = common.NewEquipment(wepType)
 	eq := &p.weapons[entityID]
+	eq.Owner = currentOwner
 	eq.EntityID = entityID
 	eq.AmmoInMagazine = -1
 

--- a/game_events.go
+++ b/game_events.go
@@ -545,9 +545,7 @@ func mapGameEventData(d *msg.CSVCMsg_GameEventListDescriptorT, e *msg.CSVCMsg_Ga
 
 // Returns the players instance of the weapon if applicable or a new instance otherwise.
 func getPlayerWeapon(player *common.Player, wepType common.EquipmentElement) *common.Equipment {
-	class := wepType.Class()
-	isSpecialWeapon := class == common.EqClassGrenade || (class == common.EqClassEquipment && wepType != common.EqKnife)
-	if !isSpecialWeapon && player != nil {
+	if player != nil {
 		for _, wep := range player.Weapons() {
 			if wep.Weapon == wepType {
 				return wep

--- a/game_events_test.go
+++ b/game_events_test.go
@@ -53,3 +53,36 @@ func TestRoundEnd_LoserState_Score(t *testing.T) {
 
 	assert.Equal(t, 1, eventOccurred)
 }
+
+func TestGetPlayerWeapon_NilPlayer(t *testing.T) {
+	wep := getPlayerWeapon(nil, common.EqAK47)
+
+	assert.NotNil(t, wep)
+	assert.Equal(t, common.EqAK47, wep.Weapon)
+}
+
+func TestGetPlayerWeapon_Found(t *testing.T) {
+	ak := &common.Equipment{Weapon: common.EqAK47}
+	pl := &common.Player{
+		RawWeapons: map[int]*common.Equipment{
+			1: ak,
+		},
+	}
+
+	wep := getPlayerWeapon(pl, common.EqAK47)
+
+	assert.True(t, wep == ak)
+}
+
+func TestGetPlayerWeapon_NotFound(t *testing.T) {
+	ak := &common.Equipment{Weapon: common.EqAK47}
+	pl := &common.Player{
+		RawWeapons: map[int]*common.Equipment{
+			1: ak,
+		},
+	}
+
+	wep := getPlayerWeapon(pl, common.EqM4A1)
+
+	assert.Equal(t, common.EqM4A1, wep.Weapon)
+}


### PR DESCRIPTION
fixes #145

- AmmoInMagazine2() returns 1 for grenades
- AmmoReserve2() returns 'Owner.LeftAmmo[AmmoType] - 1' for grenades

This means if a player has two flashbangs:
- `AmmoInMagazine2()` will return 1
- `AmmoInReserve2()` will return 1
- total amount of flashbangs (2) = `AmmoInMagazine2() + AmmoInReserve2()` 