### PR TITLE
fix PlayerHurt.Weapon not working for alternate weapons

### DIFF
--- a/common/equipment.go
+++ b/common/equipment.go
@@ -327,3 +327,20 @@ func (e Equipment) AmmoReserve2() int {
 func NewEquipment(wep EquipmentElement) Equipment {
 	return Equipment{Weapon: wep, uniqueID: rand.Int63()}
 }
+
+var equipmentToAlternative = map[EquipmentElement]EquipmentElement{
+	EqP2000:     EqUSP,
+	EqP250:      EqCZ, // for old demos where the CZ was the alternative for the P250
+	EqFiveSeven: EqCZ,
+	EqTec9:      EqCZ,
+	EqDeagle:    EqRevolver,
+	EqMP7:       EqMP5,
+	EqM4A4:      EqM4A1,
+}
+
+// EquipmentAlternative returns the EquipmentElement of the alternatively equippable weapon.
+// E.g. returns EquipmentAlternative(EqP2000) returns EqUSP.
+// Only works one way (default-to-alternative) as the Five-Seven and Tec-9 both map to the CZ-75.
+func EquipmentAlternative(eq EquipmentElement) EquipmentElement {
+	return equipmentToAlternative[eq]
+}

--- a/common/equipment_test.go
+++ b/common/equipment_test.go
@@ -78,3 +78,13 @@ func TestEquipment_AmmoReserve2_Grenade_OwnerNil(t *testing.T) {
 
 	assert.Equal(t, 0, wep.AmmoReserve2())
 }
+
+func TestEquipmentAlternative(t *testing.T) {
+	assert.Equal(t, EqUSP, EquipmentAlternative(EqP2000))
+	assert.Equal(t, EqCZ, EquipmentAlternative(EqP250))
+	assert.Equal(t, EqCZ, EquipmentAlternative(EqFiveSeven))
+	assert.Equal(t, EqCZ, EquipmentAlternative(EqTec9))
+	assert.Equal(t, EqRevolver, EquipmentAlternative(EqDeagle))
+	assert.Equal(t, EqMP5, EquipmentAlternative(EqMP7))
+	assert.Equal(t, EqM4A1, EquipmentAlternative(EqM4A4))
+}

--- a/datatables.go
+++ b/datatables.go
@@ -461,6 +461,8 @@ func (p *Parser) bindWeapon(entity *st.Entity, wepType common.EquipmentElement) 
 		wepFix("_pist_p250", "_pist_cz_75", common.EqCZ)
 	case common.EqDeagle:
 		wepFix("_pist_deagle", "_pist_revolver", common.EqRevolver)
+	case common.EqMP7:
+		wepFix("_smg_mp7", "_smg_mp5sd", common.EqMP5)
 	}
 }
 

--- a/game_events.go
+++ b/game_events.go
@@ -546,8 +546,9 @@ func mapGameEventData(d *msg.CSVCMsg_GameEventListDescriptorT, e *msg.CSVCMsg_Ga
 // Returns the players instance of the weapon if applicable or a new instance otherwise.
 func getPlayerWeapon(player *common.Player, wepType common.EquipmentElement) *common.Equipment {
 	if player != nil {
+		alternateWepType := common.EquipmentAlternative(wepType)
 		for _, wep := range player.Weapons() {
-			if wep.Weapon == wepType {
+			if wep.Weapon == wepType || wep.Weapon == alternateWepType {
 				return wep
 			}
 		}


### PR DESCRIPTION
This PR makes getPlayerWeapon() check for alternative weapons
e.g. USP for P2000, silenced M4 variant etc.

fixes #148 & fixes #149 