### PR TITLE
fix nil pointer dereference for valid demo

### DIFF
--- a/common/player.go
+++ b/common/player.go
@@ -49,6 +49,7 @@ type Player struct {
 	IsDefusing                  bool
 	IsPlanting                  bool
 	IsReloading                 bool
+	IsUnknown                   bool // Used to identify unknown/broken players. see https://github.com/markus-wa/demoinfocs-golang/issues/162
 	HasDefuseKit                bool
 	HasHelmet                   bool
 }

--- a/game_events.go
+++ b/game_events.go
@@ -282,6 +282,11 @@ func (geh gameEventHandler) weaponFire(data map[string]*msg.CSVCMsg_GameEventKey
 
 func (geh gameEventHandler) weaponReload(data map[string]*msg.CSVCMsg_GameEventKeyT) {
 	pl := geh.playerByUserID32(data["userid"].GetValShort())
+	if pl == nil {
+		// see #162, "unknown" players since November 2019 update
+		return
+	}
+
 	pl.IsReloading = true
 	geh.dispatch(events.WeaponReload{
 		Player: pl,

--- a/parser.go
+++ b/parser.go
@@ -280,6 +280,7 @@ func (p demoInfoProvider) IngameTick() int {
 }
 
 func (p demoInfoProvider) TickRate() float64 {
+	// TODO: read tickRate from CVARs as fallback
 	return p.parser.header.TickRate()
 }
 


### PR DESCRIPTION
fixes #162

We just assume the player which cannot be found is a bot and skip it, since all human players were parsed correctly in the demo where this problem was encountered.