### PR TITLE
add IParticipants.AllByUserID() method (#167)

### DIFF
--- a/datatables_test.go
+++ b/datatables_test.go
@@ -116,12 +116,14 @@ func testPlayerSpotted(t *testing.T, propName string) {
 func newParser() *Parser {
 	p := NewParser(new(DevNullReader))
 	p.header = &common.DemoHeader{}
+
 	return p
 }
 
 func fakePlayerEntity(id int) *fakest.Entity {
 	entity := new(fakest.Entity)
 	configurePlayerEntityMock(id, entity)
+
 	return entity
 }
 

--- a/demoinfocs_test.go
+++ b/demoinfocs_test.go
@@ -361,6 +361,7 @@ func BenchmarkConcurrent(b *testing.B) {
 func openFile(tb testing.TB, file string) *os.File {
 	f, err := os.Open(file)
 	assert.NoError(tb, err, "failed to open file %q", file)
+
 	return f
 }
 
@@ -369,6 +370,7 @@ func assertGolden(tb testing.TB, assertions *assert.Assertions, testCase string,
 	if ver := runtime.Version(); strings.Compare(ver, goldenVerificationGoVersionMin) < 0 {
 		tb.Logf("old go version %q detected, skipping golden file verification", ver)
 		tb.Logf("need at least version %q to compare against golden file", goldenVerificationGoVersionMin)
+
 		return
 	}
 

--- a/fake/participants.go
+++ b/fake/participants.go
@@ -24,6 +24,11 @@ func (ptcp *Participants) ByEntityID() map[int]*common.Player {
 	return ptcp.Called().Get(0).(map[int]*common.Player)
 }
 
+// AllByUserID is a mock-implementation of IParticipants.AllByUserID().
+func (ptcp *Participants) AllByUserID() map[int]*common.Player {
+	return ptcp.Called().Get(0).(map[int]*common.Player)
+}
+
 // All is a mock-implementation of IParticipants.All().
 func (ptcp *Participants) All() []*common.Player {
 	return ptcp.Called().Get(0).([]*common.Player)

--- a/game_state.go
+++ b/game_state.go
@@ -59,6 +59,7 @@ func (gs *GameState) Team(team common.Team) *common.TeamState {
 	} else if team == common.TeamCounterTerrorists {
 		return &gs.ctState
 	}
+
 	return nil
 }
 
@@ -179,6 +180,7 @@ func (ptcp Participants) ByUserID() map[int]*common.Player {
 			res[k] = v
 		}
 	}
+
 	return res
 }
 
@@ -190,6 +192,7 @@ func (ptcp Participants) ByEntityID() map[int]*common.Player {
 	for k, v := range ptcp.playersByEntityID {
 		res[k] = v
 	}
+
 	return res
 }
 
@@ -202,6 +205,7 @@ func (ptcp Participants) AllByUserID() map[int]*common.Player {
 	for k, v := range ptcp.playersByUserID {
 		res[k] = v
 	}
+
 	return res
 }
 
@@ -212,6 +216,7 @@ func (ptcp Participants) All() []*common.Player {
 	for _, p := range ptcp.playersByUserID {
 		res = append(res, p)
 	}
+
 	return res
 }
 
@@ -222,6 +227,7 @@ func (ptcp Participants) Connected() []*common.Player {
 	for _, p := range original {
 		res = append(res, p)
 	}
+
 	return res
 }
 
@@ -234,6 +240,7 @@ func (ptcp Participants) Playing() []*common.Player {
 			res = append(res, p)
 		}
 	}
+
 	return res
 }
 
@@ -246,6 +253,7 @@ func (ptcp Participants) TeamMembers(team common.Team) []*common.Player {
 			res = append(res, p)
 		}
 	}
+
 	return res
 }
 
@@ -273,6 +281,7 @@ func (ptcp Participants) SpottersOf(spotted *common.Player) (spotters []*common.
 			spotters = append(spotters, other)
 		}
 	}
+
 	return
 }
 
@@ -283,5 +292,6 @@ func (ptcp Participants) SpottedBy(spotter *common.Player) (spotted []*common.Pl
 			spotted = append(spotted, other)
 		}
 	}
+
 	return
 }

--- a/game_state.go
+++ b/game_state.go
@@ -193,6 +193,18 @@ func (ptcp Participants) ByEntityID() map[int]*common.Player {
 	return res
 }
 
+// AllByUserID returns all currently known players & spectators, including disconnected ones,
+// in a map where the key is the user-ID.
+// The returned map is a snapshot and is not updated on changes (not a reference to the actual, underlying map).
+// Includes spectators.
+func (ptcp Participants) AllByUserID() map[int]*common.Player {
+	res := make(map[int]*common.Player)
+	for k, v := range ptcp.playersByUserID {
+		res[k] = v
+	}
+	return res
+}
+
 // All returns all currently known players & spectators, including disconnected ones, of the demo.
 // The returned slice is a snapshot and is not updated on changes.
 func (ptcp Participants) All() []*common.Player {

--- a/game_state_test.go
+++ b/game_state_test.go
@@ -41,6 +41,7 @@ func TestGameState_Participants(t *testing.T) {
 	ptcp := gs.Participants()
 	byEntity := ptcp.ByEntityID()
 	byUserID := ptcp.ByUserID()
+	allByUserID := ptcp.AllByUserID()
 
 	// Should update ptcp as well since it uses the same map
 	gs.playersByEntityID[0] = newPlayer()
@@ -48,10 +49,23 @@ func TestGameState_Participants(t *testing.T) {
 
 	assert.Equal(t, gs.playersByEntityID, ptcp.ByEntityID())
 	assert.Equal(t, gs.playersByUserID, ptcp.ByUserID())
+	assert.Equal(t, gs.playersByUserID, ptcp.AllByUserID())
 
 	// But should not update byEntity or byUserID since they're copies
 	assert.NotEqual(t, byEntity, ptcp.ByEntityID())
-	assert.NotEqual(t, byUserID, ptcp.ByUserID())
+	byUserID2 := ptcp.ByUserID()
+	assert.NotEqual(t, byUserID, byUserID2)
+	assert.Equal(t, gs.playersByUserID, ptcp.AllByUserID())
+
+	gs.playersByEntityID[1] = newDisconnectedPlayer()
+	gs.playersByUserID[1] = newDisconnectedPlayer()
+
+	assert.Equal(t, gs.playersByUserID, ptcp.AllByUserID())
+
+	assert.NotEqual(t, byEntity, ptcp.ByEntityID())
+	// Should be equal since ByUserID() do not return disconnected users
+	assert.Equal(t, byUserID2, ptcp.ByUserID())
+	assert.NotEqual(t, allByUserID, ptcp.ByUserID())
 }
 
 func TestGameState_ConVars(t *testing.T) {
@@ -264,5 +278,11 @@ func newPlayer() *common.Player {
 	pl := common.NewPlayer(nil)
 	pl.Entity = new(st.Entity)
 	pl.IsConnected = true
+	return pl
+}
+
+func newDisconnectedPlayer() *common.Player {
+	pl := common.NewPlayer(nil)
+	pl.Entity = new(st.Entity)
 	return pl
 }

--- a/game_state_test.go
+++ b/game_state_test.go
@@ -278,11 +278,13 @@ func newPlayer() *common.Player {
 	pl := common.NewPlayer(nil)
 	pl.Entity = new(st.Entity)
 	pl.IsConnected = true
+
 	return pl
 }
 
 func newDisconnectedPlayer() *common.Player {
 	pl := common.NewPlayer(nil)
 	pl.Entity = new(st.Entity)
+
 	return pl
 }

--- a/participants_interface.go
+++ b/participants_interface.go
@@ -16,15 +16,15 @@ type IParticipants interface {
 	// The returned map is a snapshot and is not updated on changes (not a reference to the actual, underlying map).
 	// Includes spectators.
 	ByUserID() map[int]*common.Player
+	// ByEntityID returns all currently connected players in a map where the key is the entity-ID.
+	// The returned map is a snapshot and is not updated on changes (not a reference to the actual, underlying map).
+	// Includes spectators.
+	ByEntityID() map[int]*common.Player
 	// AllByUserID returns all currently known players & spectators, including disconnected ones,
 	// in a map where the key is the user-ID.
 	// The returned map is a snapshot and is not updated on changes (not a reference to the actual, underlying map).
 	// Includes spectators.
 	AllByUserID() map[int]*common.Player
-	// ByEntityID returns all currently connected players in a map where the key is the entity-ID.
-	// The returned map is a snapshot and is not updated on changes (not a reference to the actual, underlying map).
-	// Includes spectators.
-	ByEntityID() map[int]*common.Player
 	// All returns all currently known players & spectators, including disconnected ones, of the demo.
 	// The returned slice is a snapshot and is not updated on changes.
 	All() []*common.Player

--- a/participants_interface.go
+++ b/participants_interface.go
@@ -16,6 +16,11 @@ type IParticipants interface {
 	// The returned map is a snapshot and is not updated on changes (not a reference to the actual, underlying map).
 	// Includes spectators.
 	ByUserID() map[int]*common.Player
+	// AllByUserID returns all currently known players & spectators, including disconnected ones,
+	// in a map where the key is the user-ID.
+	// The returned map is a snapshot and is not updated on changes (not a reference to the actual, underlying map).
+	// Includes spectators.
+	AllByUserID() map[int]*common.Player
 	// ByEntityID returns all currently connected players in a map where the key is the entity-ID.
 	// The returned map is a snapshot and is not updated on changes (not a reference to the actual, underlying map).
 	// Includes spectators.


### PR DESCRIPTION
New method `IParticipants.AllByUserID()` gives read-only access to the all current players (including spectators etc.) by user id.