### PR TITLE
added "CKnife" server class mapping to EqKnife

### DIFF
--- a/datatables.go
+++ b/datatables.go
@@ -37,6 +37,10 @@ func (p *Parser) mapEquipment() {
 		case "CWeaponXM1014":
 			p.equipmentMapping[sc] = common.MapEquipment(strings.ToLower(sc.Name()[7:]))
 			continue
+
+		case "CKnife":
+			p.equipmentMapping[sc] = common.EqKnife
+			continue
 		}
 
 		baseClasses := sc.BaseClasses()


### PR DESCRIPTION
Recently in newer demos I faced a strange issue when all players' knives were recognized as `EqUnknown` by the library. I'm not sure why it suddenly stopped working properly (is it possible that some csgo internals have changed?), but this fixed it for me 🙂