### PR TITLE
added *_projectile equipment mapping for grenades

### DIFF
--- a/common/equipment.go
+++ b/common/equipment.go
@@ -136,6 +136,7 @@ func initEqNameToWeapon() {
 	eqNameToWeapon["decoy"] = EqDecoy
 	eqNameToWeapon["decoygrenade"] = EqDecoy
 	eqNameToWeapon["decoyprojectile"] = EqDecoy
+	eqNameToWeapon["decoy_projectile"] = EqDecoy
 	eqNameToWeapon["elite"] = EqDualBerettas
 	eqNameToWeapon["famas"] = EqFamas
 	eqNameToWeapon["fiveseven"] = EqFiveSeven
@@ -155,6 +156,7 @@ func initEqNameToWeapon() {
 	eqNameToWeapon["molotov"] = EqMolotov
 	eqNameToWeapon["molotovgrenade"] = EqMolotov
 	eqNameToWeapon["molotovprojectile"] = EqMolotov
+	eqNameToWeapon["molotov_projectile"] = EqMolotov
 	eqNameToWeapon["mp7"] = EqMP7
 	eqNameToWeapon["mp5sd"] = EqMP5
 	eqNameToWeapon["mp9"] = EqMP9
@@ -167,6 +169,7 @@ func initEqNameToWeapon() {
 	eqNameToWeapon["sg556"] = EqSG556
 	eqNameToWeapon["smokegrenade"] = EqSmoke
 	eqNameToWeapon["smokegrenadeprojectile"] = EqSmoke
+	eqNameToWeapon["smokegrenade_projectile"] = EqSmoke
 	eqNameToWeapon["ssg08"] = EqScout
 	eqNameToWeapon["taser"] = EqZeus
 	eqNameToWeapon["tec9"] = EqTec9


### PR DESCRIPTION
[HLTV link](https://www.hltv.org/matches/2329006/clg-red-vs-star-spangled-fraggers-wesg-2018-united-states-regional-finals-female)
clg-red-vs-star-spangled-fraggers-m2-train-p1.dem

At tick number 118792 there is a `PlayerHurt` event with `EqUnknown` weapon. In the game the player was hurt with molotov projectile, which is stored as `"molotov_projectile"` in the raw event data. However, in the library we don't have mapping for this string (although we have it for `"molotovprojectile"`). I assumed that the similar problem may arise with other types of projectiles so I added appropriate mapping for them as well.