### PR TITLE
core: don't suppress ConsumerCodePanic in recoverFromPanic

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/llgcode/ps v0.0.0-20150911083025-f1443b32eedb // indirect
 	github.com/markus-wa/go-unassert v0.1.1
 	github.com/markus-wa/gobitread v0.2.2
-	github.com/markus-wa/godispatch v1.1.0
+	github.com/markus-wa/godispatch v1.2.1
 	github.com/markus-wa/quickhull-go/v2 v2.1.0
 	github.com/stretchr/objx v0.1.1 // indirect
 	github.com/stretchr/testify v1.5.1

--- a/go.sum
+++ b/go.sum
@@ -25,6 +25,10 @@ github.com/markus-wa/gobitread v0.2.2 h1:4Z4oJ8Bf1XnOy6JZ2/9AdFKVAoxdq7awRjrb+j2
 github.com/markus-wa/gobitread v0.2.2/go.mod h1:PcWXMH4gx7o2CKslbkFkLyJB/aHW7JVRG3MRZe3PINg=
 github.com/markus-wa/godispatch v1.1.0 h1:J8O+hRkOCexDUQevaSKWDtKeZ3+HcmbEUKY1uYraAjY=
 github.com/markus-wa/godispatch v1.1.0/go.mod h1:6o18u24oo58yseMXYD0zQFI6LbSkjJSSBQ4YyDqFX5c=
+github.com/markus-wa/godispatch v1.2.0 h1:aB6epOoTbrsH3oaTE21L8/c+xiYSKOrsSDzl6YD0Xuw=
+github.com/markus-wa/godispatch v1.2.0/go.mod h1:GNzV7xdnZ9+VBi0z+hma9oUQrJmtqRrqyAuGKTTTcKY=
+github.com/markus-wa/godispatch v1.2.1 h1:Bj6blK4xJ/72pDi0rprVYluOGW9CV55FUDFPApyw91Q=
+github.com/markus-wa/godispatch v1.2.1/go.mod h1:GNzV7xdnZ9+VBi0z+hma9oUQrJmtqRrqyAuGKTTTcKY=
 github.com/markus-wa/quickhull-go/v2 v2.1.0 h1:DA2pzEzH0k5CEnlUsouRqNdD+jzNFb4DBhrX4Hpa5So=
 github.com/markus-wa/quickhull-go/v2 v2.1.0/go.mod h1:bOlBUpIzGSMMhHX0f9N8CQs0VZD4nnPeta0OocH7m4o=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=

--- a/parser.go
+++ b/parser.go
@@ -212,11 +212,13 @@ func (p *Parser) error() (err error) {
 }
 
 func (p *Parser) setError(err error) {
-	if err != nil {
-		p.errLock.Lock()
-		p.err = err
-		p.errLock.Unlock()
+	if err == nil || p.err != nil {
+		return
 	}
+
+	p.errLock.Lock()
+	p.err = err
+	p.errLock.Unlock()
 }
 
 // NewParser creates a new Parser with the default configuration.

--- a/parser_test.go
+++ b/parser_test.go
@@ -2,6 +2,7 @@ package demoinfocs
 
 import (
 	"errors"
+	"fmt"
 	"io"
 	"math"
 	"testing"
@@ -75,4 +76,42 @@ func TestRecoverFromPanic(t *testing.T) {
 
 	assert.Equal(t, "test", recoverFromPanic("test").Error())
 	assert.Equal(t, "unexpected error: 1", recoverFromPanic(1).Error())
+}
+
+type consumerCodePanicMock struct {
+	value interface{}
+}
+
+func (ucp consumerCodePanicMock) String() string {
+	return fmt.Sprint(ucp.value)
+}
+
+func (ucp consumerCodePanicMock) Value() interface{} {
+	return ucp.value
+}
+
+func TestRecoverFromPanic_ConsumerCodePanic(t *testing.T) {
+	assert.PanicsWithValue(t, 1, func() {
+		err := recoverFromPanic(consumerCodePanicMock{value: 1})
+		assert.Nil(t, err)
+	})
+}
+
+func TestParser_SetError(t *testing.T) {
+	err := errors.New("test")
+
+	p := new(Parser)
+	p.setError(err)
+
+	assert.Same(t, err, p.error())
+}
+
+func TestParser_SetError_Multiple(t *testing.T) {
+	err := errors.New("test")
+
+	p := new(Parser)
+	p.setError(err)
+	p.setError(errors.New("second error"))
+
+	assert.Same(t, err, p.error())
 }

--- a/parsing.go
+++ b/parsing.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/gogo/protobuf/proto"
 	"github.com/markus-wa/go-unassert"
+	dispatch "github.com/markus-wa/godispatch"
 
 	"github.com/markus-wa/demoinfocs-golang/common"
 	"github.com/markus-wa/demoinfocs-golang/events"
@@ -122,6 +123,8 @@ func recoverFromPanic(r interface{}) error {
 	}
 
 	switch err := r.(type) {
+	case dispatch.ConsumerCodePanic:
+		panic(err.Value())
 	case error:
 		return err
 	case string:


### PR DESCRIPTION
fixes #190
 
Example:
code:
```go
p := NewParser(demoFile)

p.RegisterEventHandler(func(e interface{}) {
	p.GameState().Entities()[-1].ID()
}

p.ParseToEnd()
```

output:
```
panic: runtime error: invalid memory address or nil pointer dereference [recovered]
	panic: runtime error: invalid memory address or nil pointer dereference [recovered]
	panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0xa53718]

goroutine 7 [running]:
github.com/markus-wa/godispatch.callConsumerCode.func1()
	/home/mark/go/pkg/mod/github.com/markus-wa/godispatch@v1.2.1/dispatch.go:104 +0x88
panic(0xb2f920, 0xc0001ae130)
	/opt/go/src/runtime/panic.go:679 +0x1b2
github.com/markus-wa/godispatch.callConsumerCode.func1()
	/home/mark/go/pkg/mod/github.com/markus-wa/godispatch@v1.2.1/dispatch.go:104 +0x88
panic(0xaf6180, 0x1169390)
	/opt/go/src/runtime/panic.go:679 +0x1b2
github.com/markus-wa/demoinfocs-golang/sendtables.(*Entity).ID(...)
	/home/mark/dev/demoinfocs-golang/sendtables/entity.go:33
github.com/markus-wa/demoinfocs-golang_test.TestDemoInfoCs.func2(0xb0cf60, 0xc000190330)
	/home/mark/dev/demoinfocs-golang/demoinfocs_test.go:58 +0x68
reflect.Value.call(0xab7680, 0xc00000ee00, 0x13, 0xbbcc0c, 0x4, 0xc000115ac0, 0x1, 0x1, 0x0, 0x0, ...)
	/opt/go/src/reflect/value.go:460 +0x5f6
reflect.Value.Call(0xab7680, 0xc00000ee00, 0x13, 0xc000062ac0, 0x1, 0x1, 0xae1601, 0xc000062a20, 0x40f6a6)
	/opt/go/src/reflect/value.go:321 +0xb4
github.com/markus-wa/godispatch.callConsumerCode(0xab7680, 0xc00000ee00, 0x13, 0xc000062ac0, 0x1, 0x1)
	/home/mark/go/pkg/mod/github.com/markus-wa/godispatch@v1.2.1/dispatch.go:107 +0xa7
github.com/markus-wa/godispatch.(*Dispatcher).Dispatch(0xc000136090, 0xb0cf60, 0xc000190330)
	/home/mark/go/pkg/mod/github.com/markus-wa/godispatch@v1.2.1/dispatch.go:93 +0x243
github.com/markus-wa/demoinfocs-golang.(*Parser).handleSetConVar(0xc000136000, 0xc000010080)
	/home/mark/dev/demoinfocs-golang/net_messages.go:62 +0x18f
reflect.Value.call(0xab6580, 0xc00006b400, 0x13, 0xbbcc0c, 0x4, 0xc000062f68, 0x1, 0x1, 0x0, 0x0, ...)
	/opt/go/src/reflect/value.go:460 +0x5f6
reflect.Value.Call(0xab6580, 0xc00006b400, 0x13, 0xc000062f68, 0x1, 0x1, 0xae1601, 0xc000062ec8, 0x40f6a6)
	/opt/go/src/reflect/value.go:321 +0xb4
github.com/markus-wa/godispatch.callConsumerCode(0xab6580, 0xc00006b400, 0x13, 0xc000062f68, 0x1, 0x1)
	/home/mark/go/pkg/mod/github.com/markus-wa/godispatch@v1.2.1/dispatch.go:107 +0xa7
github.com/markus-wa/godispatch.(*Dispatcher).Dispatch(0xc000136020, 0xb72d00, 0xc000010080)
	/home/mark/go/pkg/mod/github.com/markus-wa/godispatch@v1.2.1/dispatch.go:93 +0x243
github.com/markus-wa/godispatch.(*Dispatcher).dispatchQueue(0xc000136020, 0xc0000326c0)
	/home/mark/go/pkg/mod/github.com/markus-wa/godispatch@v1.2.1/dispatch.go:155 +0xf4
created by github.com/markus-wa/godispatch.(*Dispatcher).AddQueues
	/home/mark/go/pkg/mod/github.com/markus-wa/godispatch@v1.2.1/dispatch.go:141 +0x183

Process finished with exit code 1
```