### PR TITLE
changing the existing weapon instead of creating a new one

### DIFF
--- a/datatables.go
+++ b/datatables.go
@@ -483,7 +483,7 @@ func (p *Parser) bindWeapon(entity *st.Entity, wepType common.EquipmentElement) 
 	if wep, ok := p.gameState.weapons[entityID]; ok {
 		currentOwner = wep.Owner
 
-		unassert.True(p.gameState.weapons[entityID].UniqueID() != 	0)
+		unassert.True(p.gameState.weapons[entityID].UniqueID() != 0)
 		// If we are here, we already have a player that holds this weapon
 		// so the zero-valued Equipment instance was already created in bindPlayer()
 		// In this case we should create a new Equipment instance with non-zero unique id

--- a/datatables.go
+++ b/datatables.go
@@ -483,18 +483,12 @@ func (p *Parser) bindWeapon(entity *st.Entity, wepType common.EquipmentElement) 
 	if wep, ok := p.gameState.weapons[entityID]; ok {
 		currentOwner = wep.Owner
 
-		if p.gameState.weapons[entityID].UniqueID() == 0 {
-			// If we are here, we already have a player that holds this weapon
-			// so the zero-valued Equipment instance was already created in bindPlayer()
-			// In this case we should create a new Equipment instance with non-zero unique id
-			// but having the same memory address so player's rawWeapons would still have a pointer to it
-			*wep = *(common.NewEquipment(wepType))
-		} else {
-			// Something horrible has happened
-			p.eventDispatcher.Dispatch(events.ParserWarn{
-				Message: "trying to bind a new weapon but its entity is already bound",
-			})
-		}
+		unassert.True(p.gameState.weapons[entityID].UniqueID() != 	0)
+		// If we are here, we already have a player that holds this weapon
+		// so the zero-valued Equipment instance was already created in bindPlayer()
+		// In this case we should create a new Equipment instance with non-zero unique id
+		// but having the same memory address so player's rawWeapons would still have a pointer to it
+		*wep = *(common.NewEquipment(wepType))
 	} else {
 		p.gameState.weapons[entityID] = common.NewEquipment(wepType)
 	}

--- a/datatables.go
+++ b/datatables.go
@@ -482,7 +482,7 @@ func (p *Parser) bindWeapon(entity *st.Entity, wepType common.EquipmentElement) 
 	var currentOwner *common.Player
 	if wep, ok := p.gameState.weapons[entityID]; ok {
 		currentOwner = wep.Owner
-		
+
 		if p.gameState.weapons[entityID].UniqueID() == 0 {
 			// If we are here, we already have a player that holds this weapon
 			// so the zero-valued Equipment instance was already created in bindPlayer()

--- a/datatables.go
+++ b/datatables.go
@@ -482,6 +482,7 @@ func (p *Parser) bindWeapon(entity *st.Entity, wepType common.EquipmentElement) 
 	var currentOwner *common.Player
 	if wep, ok := p.gameState.weapons[entityID]; ok {
 		currentOwner = wep.Owner
+		
 		if p.gameState.weapons[entityID].UniqueID() == 0 {
 			// If we are here, we already have a player that holds this weapon
 			// so the zero-valued Equipment instance was already created in bindPlayer()

--- a/datatables.go
+++ b/datatables.go
@@ -481,6 +481,10 @@ func (p *Parser) bindWeapon(entity *st.Entity, wepType common.EquipmentElement) 
 		eq = common.NewEquipment(wepType)
 		p.gameState.weapons[entityID] = eq
 	} else {
+		// If we are here, we already have a player that holds this weapon
+		// so the zero-valued Equipment instance was already created in bindPlayer().
+		// In this case we should create update the weapon type
+		// but keep the same memory address so player's rawWeapons would still have a pointer to it
 		eq.Weapon = wepType
 	}
 

--- a/datatables.go
+++ b/datatables.go
@@ -484,7 +484,12 @@ func (p *Parser) bindWeapon(entity *st.Entity, wepType common.EquipmentElement) 
 		currentOwner = wep.Owner
 	}
 
-	p.gameState.weapons[entityID] = common.NewEquipment(wepType)
+	if currentOwner == nil {
+		p.gameState.weapons[entityID] = common.NewEquipment(wepType)
+	} else {
+		p.gameState.weapons[entityID].Weapon = wepType
+	}
+
 	eq := p.gameState.weapons[entityID]
 	eq.Owner = currentOwner
 	eq.EntityID = entityID

--- a/datatables.go
+++ b/datatables.go
@@ -305,6 +305,7 @@ func (p *Parser) bindNewPlayer(playerEntity st.IEntity) {
 				wep := p.gameState.weapons[entityID]
 
 				if wep == nil {
+					// sometimes a weapon is assigned to a player before the weapon entity is created
 					wep = common.NewEquipment(common.EqUnknown)
 					p.gameState.weapons[entityID] = wep
 				}

--- a/datatables.go
+++ b/datatables.go
@@ -482,12 +482,20 @@ func (p *Parser) bindWeapon(entity *st.Entity, wepType common.EquipmentElement) 
 	var currentOwner *common.Player
 	if wep, ok := p.gameState.weapons[entityID]; ok {
 		currentOwner = wep.Owner
-	}
-
-	if currentOwner == nil {
-		p.gameState.weapons[entityID] = common.NewEquipment(wepType)
+		if p.gameState.weapons[entityID].UniqueID() == 0 {
+			// If we are here, we already have a player that holds this weapon
+			// so the zero-valued Equipment instance was already created in bindPlayer()
+			// In this case we should create a new Equipment instance with non-zero unique id
+			// but having the same memory address so player's rawWeapons would still have a pointer to it
+			*wep = *(common.NewEquipment(wepType))
+		} else {
+			// Something horrible has happened
+			p.eventDispatcher.Dispatch(events.ParserWarn{
+				Message: "trying to bind a new weapon but its entity is already bound",
+			})
+		}
 	} else {
-		p.gameState.weapons[entityID].Weapon = wepType
+		p.gameState.weapons[entityID] = common.NewEquipment(wepType)
 	}
 
 	eq := p.gameState.weapons[entityID]


### PR DESCRIPTION
Hotfix for the recent internal changes.

Without it we have many players with unknown weapons. Before the internal changes we had an actual array with fixed memory layout so every entity ID had a fixed pointer to an equipment, which doesn't hold now, so when we first have a player binded (with unknown weapons at the moment) and then we bind their weapons, the pointers we have in player's `rawWeapons` still point to the unknown weapons.