### PR TITLE
core: add Parser.Close() to fix memory leak

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@ func main() {
 	defer f.Close()
 
 	p := dem.NewParser(f)
+	defer p.Close()
 
 	// Register handler on kill events
 	p.RegisterEventHandler(func(e events.Kill) {

--- a/examples/entities/entities.go
+++ b/examples/entities/entities.go
@@ -18,6 +18,7 @@ func main() {
 	defer f.Close()
 
 	p := demoinfocs.NewParser(f)
+	defer p.Close()
 
 	p.RegisterEventHandler(func(events.DataTablesParsed) {
 		p.ServerClasses().FindByName("CWeaponAWP").OnEntityCreated(func(ent st.Entity) {

--- a/examples/heatmap/heatmap.go
+++ b/examples/heatmap/heatmap.go
@@ -34,6 +34,7 @@ func main() {
 	defer f.Close()
 
 	p := demoinfocs.NewParser(f)
+	defer p.Close()
 
 	// Parse header (contains map-name etc.)
 	header, err := p.ParseHeader()

--- a/examples/nade-trajectories/nade_trajectories.go
+++ b/examples/nade-trajectories/nade_trajectories.go
@@ -46,6 +46,7 @@ func main() {
 	defer f.Close()
 
 	p := demoinfocs.NewParser(f)
+	defer p.Close()
 
 	header, err := p.ParseHeader()
 	checkError(err)

--- a/examples/net-messages/netmessages.go
+++ b/examples/net-messages/netmessages.go
@@ -26,6 +26,7 @@ func main() {
 	}
 
 	p := demoinfocs.NewParserWithConfig(f, cfg)
+	defer p.Close()
 
 	// Register handler for BSPDecal messages
 	p.RegisterNetMessageHandler(func(m *msg.CSVCMsg_BSPDecal) {

--- a/examples/print-events/print_events.go
+++ b/examples/print-events/print_events.go
@@ -18,6 +18,7 @@ func main() {
 	defer f.Close()
 
 	p := demoinfocs.NewParser(f)
+	defer p.Close()
 
 	// Parse header
 	header, err := p.ParseHeader()

--- a/pkg/demoinfocs/examples_test.go
+++ b/pkg/demoinfocs/examples_test.go
@@ -22,6 +22,7 @@ func ExampleParser() {
 	defer f.Close()
 
 	p := demoinfocs.NewParser(f)
+	defer p.Close()
 
 	// Register handler on kill events
 	p.RegisterEventHandler(func(e events.Kill) {

--- a/pkg/demoinfocs/fake/parser.go
+++ b/pkg/demoinfocs/fake/parser.go
@@ -226,3 +226,9 @@ func max(numbers map[int][]interface{}) (maxNumber int) {
 func (p *Parser) Cancel() {
 	p.Called()
 }
+
+// Close is a mock-implementation of Parser.Close().
+// NOP implementation.
+func (p *Parser) Close() {
+	p.Called()
+}

--- a/pkg/demoinfocs/parser.go
+++ b/pkg/demoinfocs/parser.go
@@ -33,6 +33,7 @@ Example (without error handling):
 
 	f, _ := os.Open("/path/to/demo.dem")
 	p := dem.NewParser(f)
+	defer p.Close()
 	header := p.ParseHeader()
 	fmt.Println("Map:", header.MapName)
 	p.RegisterEventHandler(func(e events.BombExplode) {
@@ -233,6 +234,12 @@ func (p *parser) RegisterNetMessageHandler(handler interface{}) dp.HandlerIdenti
 // The identifier is returned at registration by RegisterNetMessageHandler().
 func (p *parser) UnregisterNetMessageHandler(identifier dp.HandlerIdentifier) {
 	p.msgDispatcher.UnregisterHandler(identifier)
+}
+
+// Close closes any open resources used by the Parser (go routines, file handles).
+// This must be called before discarding the Parser to avoid memory leaks.
+func (p *parser) Close() {
+	p.msgDispatcher.RemoveAllQueues()
 }
 
 func (p *parser) error() error {

--- a/pkg/demoinfocs/parser_interface.go
+++ b/pkg/demoinfocs/parser_interface.go
@@ -24,6 +24,7 @@ import (
 //
 // 	f, _ := os.Open("/path/to/demo.dem")
 // 	p := dem.NewParser(f)
+// 	defer p.Close()
 // 	header := p.ParseHeader()
 // 	fmt.Println("Map:", header.MapName)
 // 	p.RegisterEventHandler(func(e events.BombExplode) {
@@ -98,6 +99,9 @@ type Parser interface {
 	//
 	// The identifier is returned at registration by RegisterNetMessageHandler().
 	UnregisterNetMessageHandler(identifier dp.HandlerIdentifier)
+	// Close closes any open resources used by the Parser (go routines, file handles).
+	// This must be called before discarding the Parser to avoid memory leaks.
+	Close()
 	// ParseHeader attempts to parse the header of the demo and returns it.
 	// If not done manually this will be called by Parser.ParseNextFrame() or Parser.ParseToEnd().
 	//

--- a/pkg/demoinfocs/parser_test.go
+++ b/pkg/demoinfocs/parser_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 	"time"
 
+	dispatch "github.com/markus-wa/godispatch"
 	"github.com/stretchr/testify/assert"
 
 	common "github.com/markus-wa/demoinfocs-golang/v2/pkg/demoinfocs/common"
@@ -113,4 +114,25 @@ func TestParser_SetError_Multiple(t *testing.T) {
 	p.setError(errors.New("second error"))
 
 	assert.Same(t, err, p.error())
+}
+
+func TestParser_Close(t *testing.T) {
+	p := new(parser)
+	q := make(chan interface{}, 1)
+
+	p.msgDispatcher = new(dispatch.Dispatcher)
+	p.msgDispatcher.AddQueues(q)
+
+	called := false
+	p.msgDispatcher.RegisterHandler(func(interface{}) {
+		called = true
+	})
+
+	p.Close()
+
+	q <- "this should not trigger the handler"
+
+	p.msgDispatcher.SyncAllQueues()
+
+	assert.False(t, called)
 }

--- a/pkg/demoinfocs/parsing.go
+++ b/pkg/demoinfocs/parsing.go
@@ -91,6 +91,7 @@ func (p *parser) ParseToEnd() (err error) {
 	defer func() {
 		// Make sure all the messages of the demo are handled
 		p.msgDispatcher.SyncAllQueues()
+		p.msgDispatcher.RemoveAllQueues()
 
 		// Close msgQueue
 		if p.msgQueue != nil {
@@ -166,6 +167,7 @@ func (p *parser) ParseNextFrame() (moreFrames bool, err error) {
 
 		// Close msgQueue (only if we are done)
 		if p.msgQueue != nil && !moreFrames {
+			p.msgDispatcher.RemoveAllQueues()
 			close(p.msgQueue)
 		}
 


### PR DESCRIPTION
Parser.Close() will call msgDispatcher.RemoveAllQueues() to terminate the goroutine handling net-messages.
It needs to be called by the user before discarding the Parser.

fixes #216