### PR TITLE
core: add Parser.Close() to fix memory leak (#216) [backport to v1]

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ func main() {
 	defer f.Close()
 
 	p := dem.NewParser(f)
+	defer p.Close()
 
 	// Register handler on kill events
 	p.RegisterEventHandler(func(e events.Kill) {

--- a/examples/entities/entities.go
+++ b/examples/entities/entities.go
@@ -18,6 +18,7 @@ func main() {
 	defer f.Close()
 
 	p := dem.NewParser(f)
+	defer p.Close()
 
 	p.RegisterEventHandler(func(events.DataTablesParsed) {
 		p.ServerClasses().FindByName("CWeaponAWP").OnEntityCreated(func(ent *st.Entity) {

--- a/examples/heatmap/heatmap.go
+++ b/examples/heatmap/heatmap.go
@@ -34,6 +34,7 @@ func main() {
 	defer f.Close()
 
 	p := dem.NewParser(f)
+	defer p.Close()
 
 	// Parse header (contains map-name etc.)
 	header, err := p.ParseHeader()

--- a/examples/nade-trajectories/nade_trajectories.go
+++ b/examples/nade-trajectories/nade_trajectories.go
@@ -46,6 +46,7 @@ func main() {
 	defer f.Close()
 
 	p := dem.NewParser(f)
+	defer p.Close()
 
 	header, err := p.ParseHeader()
 	checkError(err)

--- a/examples/net-messages/netmessages.go
+++ b/examples/net-messages/netmessages.go
@@ -26,6 +26,7 @@ func main() {
 	}
 
 	p := dem.NewParserWithConfig(f, cfg)
+	defer p.Close()
 
 	// Register handler for BSPDecal messages
 	p.RegisterNetMessageHandler(func(m *msg.CSVCMsg_BSPDecal) {

--- a/examples/print-events/print_events.go
+++ b/examples/print-events/print_events.go
@@ -13,10 +13,12 @@ import (
 // Run like this: go run print_events.go -demo /path/to/demo.dem
 func main() {
 	f, err := os.Open(ex.DemoPathFromArgs())
-	defer f.Close()
 	checkError(err)
 
+	defer f.Close()
+
 	p := dem.NewParser(f)
+	defer p.Close()
 
 	// Parse header
 	header, err := p.ParseHeader()

--- a/examples_test.go
+++ b/examples_test.go
@@ -18,9 +18,11 @@ func ExampleParser() {
 	if err != nil {
 		panic(err)
 	}
+
 	defer f.Close()
 
 	p := dem.NewParser(f)
+	defer p.Close()
 
 	// Register handler on kill events
 	p.RegisterEventHandler(func(e events.Kill) {
@@ -28,10 +30,12 @@ func ExampleParser() {
 		if e.IsHeadshot {
 			hs = " (HS)"
 		}
+
 		var wallBang string
 		if e.PenetratedObjects > 0 {
 			wallBang = " (WB)"
 		}
+
 		fmt.Printf("%s <%v%s%s> %s\n", e.Killer, e.Weapon, hs, wallBang, e.Victim)
 	})
 
@@ -46,5 +50,6 @@ func TestExamplesWithoutOutput(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping long running test")
 	}
+
 	ExampleParser()
 }

--- a/fake/parser.go
+++ b/fake/parser.go
@@ -227,3 +227,9 @@ func max(numbers map[int][]interface{}) (maxNumber int) {
 func (p *Parser) Cancel() {
 	p.Called()
 }
+
+// Close is a mock-implementation of Parser.Close().
+// NOP implementation.
+func (p *Parser) Close() {
+	p.Called()
+}

--- a/parser.go
+++ b/parser.go
@@ -31,6 +31,7 @@ Example (without error handling):
 
 	f, _ := os.Open("/path/to/demo.dem")
 	p := dem.NewParser(f)
+	defer p.Close()
 	header := p.ParseHeader()
 	fmt.Println("Map:", header.MapName)
 	p.RegisterEventHandler(func(e events.BombExplode) {
@@ -201,6 +202,12 @@ func (p *Parser) RegisterNetMessageHandler(handler interface{}) dp.HandlerIdenti
 // The identifier is returned at registration by RegisterNetMessageHandler().
 func (p *Parser) UnregisterNetMessageHandler(identifier dp.HandlerIdentifier) {
 	p.msgDispatcher.UnregisterHandler(identifier)
+}
+
+// Close closes any open resources used by the Parser (go routines, file handles).
+// This must be called before discarding the Parser to avoid memory leaks.
+func (p *Parser) Close() {
+	p.msgDispatcher.RemoveAllQueues()
 }
 
 func (p *Parser) error() (err error) {

--- a/parser_interface.go
+++ b/parser_interface.go
@@ -24,6 +24,7 @@ import (
 //
 // 	f, _ := os.Open("/path/to/demo.dem")
 // 	p := dem.NewParser(f)
+// 	defer p.Close()
 // 	header := p.ParseHeader()
 // 	fmt.Println("Map:", header.MapName)
 // 	p.RegisterEventHandler(func(e events.BombExplode) {
@@ -92,6 +93,9 @@ type IParser interface {
 	//
 	// The identifier is returned at registration by RegisterNetMessageHandler().
 	UnregisterNetMessageHandler(identifier dp.HandlerIdentifier)
+	// Close closes any open resources used by the Parser (go routines, file handles).
+	// This must be called before discarding the Parser to avoid memory leaks.
+	Close()
 	// ParseHeader attempts to parse the header of the demo and returns it.
 	// If not done manually this will be called by Parser.ParseNextFrame() or Parser.ParseToEnd().
 	//

--- a/parser_test.go
+++ b/parser_test.go
@@ -114,3 +114,24 @@ func TestParser_SetError_Multiple(t *testing.T) {
 
 	assert.Same(t, err, p.error())
 }
+
+func TestParser_Close(t *testing.T) {
+	p := new(Parser)
+	q := make(chan interface{}, 1)
+
+	p.msgDispatcher.AddQueues(q)
+
+	called := false
+
+	p.msgDispatcher.RegisterHandler(func(interface{}) {
+		called = true
+	})
+
+	p.Close()
+
+	q <- "this should not trigger the handler"
+
+	p.msgDispatcher.SyncAllQueues()
+
+	assert.False(t, called)
+}

--- a/parsing.go
+++ b/parsing.go
@@ -91,6 +91,7 @@ func (p *Parser) ParseToEnd() (err error) {
 	defer func() {
 		// Make sure all the messages of the demo are handled
 		p.msgDispatcher.SyncAllQueues()
+		p.msgDispatcher.RemoveAllQueues()
 
 		// Close msgQueue
 		if p.msgQueue != nil {
@@ -166,6 +167,7 @@ func (p *Parser) ParseNextFrame() (moreFrames bool, err error) {
 
 		// Close msgQueue (only if we are done)
 		if p.msgQueue != nil && !moreFrames {
+			p.msgDispatcher.RemoveAllQueues()
 			close(p.msgQueue)
 		}
 


### PR DESCRIPTION
`Parser.Close()` will call `msgDispatcher.RemoveAllQueues()` to terminate the goroutine handling net-messages.
It needs to be called by the user before discarding the Parser.