### PR TITLE
parser: add Parser.FrameRate() and Parser.FrameTime() for demos with corrupt headers (#235)

### DIFF
--- a/pkg/demoinfocs/common/common.go
+++ b/pkg/demoinfocs/common/common.go
@@ -42,8 +42,8 @@ type DemoHeader struct {
 // Not necessarily the tick-rate the server ran on during the game.
 //
 // Returns 0 if PlaybackTime or PlaybackFrames are 0 (corrupt demo headers).
-// Deprecated, see Parser.FrameRate() for a more resilient implementation that should work with corrupt demo headers.
-func (h *DemoHeader) FrameRate() float64 {
+// Deprecated, see Parser.FrameRatePow2() for a more resilient implementation that should work with corrupt demo headers.
+func (h DemoHeader) FrameRate() float64 {
 	if h.PlaybackTime == 0 {
 		return 0
 	}
@@ -54,8 +54,8 @@ func (h *DemoHeader) FrameRate() float64 {
 // FrameTime returns the time a frame / demo-tick takes in seconds.
 //
 // Returns 0 if PlaybackTime or PlaybackFrames are 0 (corrupt demo headers).
-// Deprecated, see Parser.FrameTime() for a more resilient implementation that should work with corrupt demo headers.
-func (h *DemoHeader) FrameTime() time.Duration {
+// Deprecated, see Parser.FrameTimePow2() for a more resilient implementation that should work with corrupt demo headers.
+func (h DemoHeader) FrameTime() time.Duration {
 	if h.PlaybackFrames == 0 {
 		return 0
 	}

--- a/pkg/demoinfocs/common/common.go
+++ b/pkg/demoinfocs/common/common.go
@@ -42,6 +42,7 @@ type DemoHeader struct {
 // Not necessarily the tick-rate the server ran on during the game.
 //
 // Returns 0 if PlaybackTime or PlaybackFrames are 0 (corrupt demo headers).
+// Deprecated, see Parser.FrameRate() for a more resilient implementation that should work with corrupt demo headers.
 func (h *DemoHeader) FrameRate() float64 {
 	if h.PlaybackTime == 0 {
 		return 0
@@ -53,6 +54,7 @@ func (h *DemoHeader) FrameRate() float64 {
 // FrameTime returns the time a frame / demo-tick takes in seconds.
 //
 // Returns 0 if PlaybackTime or PlaybackFrames are 0 (corrupt demo headers).
+// Deprecated, see Parser.FrameTime() for a more resilient implementation that should work with corrupt demo headers.
 func (h *DemoHeader) FrameTime() time.Duration {
 	if h.PlaybackFrames == 0 {
 		return 0

--- a/pkg/demoinfocs/common/common.go
+++ b/pkg/demoinfocs/common/common.go
@@ -42,7 +42,7 @@ type DemoHeader struct {
 // Not necessarily the tick-rate the server ran on during the game.
 //
 // Returns 0 if PlaybackTime or PlaybackFrames are 0 (corrupt demo headers).
-// Deprecated, see Parser.FrameRatePow2() for a more resilient implementation that should work with corrupt demo headers.
+// Deprecated: see Parser.FrameRate() for a more resilient implementation that should work with corrupt demo headers.
 func (h DemoHeader) FrameRate() float64 {
 	if h.PlaybackTime == 0 {
 		return 0
@@ -54,7 +54,7 @@ func (h DemoHeader) FrameRate() float64 {
 // FrameTime returns the time a frame / demo-tick takes in seconds.
 //
 // Returns 0 if PlaybackTime or PlaybackFrames are 0 (corrupt demo headers).
-// Deprecated, see Parser.FrameTimePow2() for a more resilient implementation that should work with corrupt demo headers.
+// Deprecated: see Parser.FrameTime() for a more resilient implementation that should work with corrupt demo headers.
 func (h DemoHeader) FrameTime() time.Duration {
 	if h.PlaybackFrames == 0 {
 		return 0

--- a/pkg/demoinfocs/events/events.go
+++ b/pkg/demoinfocs/events/events.go
@@ -454,6 +454,17 @@ type TickRateInfoAvailable struct {
 	TickTime time.Duration // See Parser.TickTime()
 }
 
+// FrameRateCalibrated signals that the demo's frame rate is available.
+// This can happen either by reading the demo header,
+// or if that is corrupt then once enough frames have passed to calibrate th frame-rate manually.
+// See also ParserConfig.FrameRateCalibrationFrames.
+type FrameRateCalibrated struct {
+	FrameRatePow2       float64       // The frame rate as a power of two, this is likely to be more accurate than FrameRateCalculated for most demos
+	FrameTimePow2       time.Duration // The frame time calculated with FrameRatePow2, this is likely to be more accurate than FrameTimeCalculated for most demos
+	FrameRateCalculated float64       // FrameRatePow2 might be more accurate
+	FrameTimeCalculated time.Duration // FrameTimePow2 might be more accurate
+}
+
 // ChatMessage signals a player generated chat message.
 // Since team chat is generally not recorded IsChatAll will probably always be false.
 // See SayText for admin / console messages and SayText2 for raw network package data.

--- a/pkg/demoinfocs/events/events.go
+++ b/pkg/demoinfocs/events/events.go
@@ -447,22 +447,41 @@ type SayText2 struct {
 	IsChatAll bool     // Seems to always be false, team chat might not be recorded
 }
 
-// TickRateInfoAvailable signals that the tick-rate information has been received via CSVCMsg_ServerInfo.
+// TickRateSource is the type for TickRateInfo.Source.
+// Useful for when you have a preference of which tick-rate you'd like to use over others.
+type TickRateSource byte
+
+const (
+	TickRateSourceHeader TickRateSource = iota
+	TickRateSourceServerInfo
+)
+
+// TickRateInfo signals that the tick-rate information has been received via CSVCMsg_ServerInfo.
 // This can be useful for corrupt demo headers where the tick-rate is missing in the beginning of the demo.
-type TickRateInfoAvailable struct {
+type TickRateInfo struct {
+	Source   TickRateSource
 	TickRate float64       // See Parser.TickRate()
 	TickTime time.Duration // See Parser.TickTime()
 }
 
-// FrameRateCalibrated signals that the demo's frame rate is available.
+// FrameRateSource is the type for FrameRateInfo.Source.
+// Useful for when you have a preference of which frame-rate you'd like to use over others.
+type FrameRateSource byte
+
+const (
+	FrameRateSourceHeader FrameRateSource = iota
+	FrameRateSourceConVars
+	FrameRateSourceCalibration
+)
+
+// FrameRateInfo signals that the demo's frame rate is available.
 // This can happen either by reading the demo header,
 // or if that is corrupt then once enough frames have passed to calibrate th frame-rate manually.
 // See also ParserConfig.FrameRateCalibrationFrames.
-type FrameRateCalibrated struct {
-	FrameRatePow2       float64       // The frame rate as a power of two, this is likely to be more accurate than FrameRateCalculated for most demos
-	FrameTimePow2       time.Duration // The frame time calculated with FrameRatePow2, this is likely to be more accurate than FrameTimeCalculated for most demos
-	FrameRateCalculated float64       // FrameRatePow2 might be more accurate
-	FrameTimeCalculated time.Duration // FrameTimePow2 might be more accurate
+type FrameRateInfo struct {
+	Source    FrameRateSource // specifies from where the frame-rate (or the estimation of it) comes. see FrameRateSource.
+	FrameRate float64
+	FrameTime time.Duration
 }
 
 // ChatMessage signals a player generated chat message.

--- a/pkg/demoinfocs/fake/parser.go
+++ b/pkg/demoinfocs/fake/parser.go
@@ -130,16 +130,6 @@ func (p *Parser) FrameTimeCalculated() time.Duration {
 	return p.Called().Get(0).(time.Duration)
 }
 
-// FrameRatePow2 is a mock-implementation of Parser.FrameRatePow2().
-func (p *Parser) FrameRatePow2() float64 {
-	return p.Called().Get(0).(float64)
-}
-
-// FrameTimePow2 is a mock-implementation of Parser.FrameTimePow2().
-func (p *Parser) FrameTimePow2() time.Duration {
-	return p.Called().Get(0).(time.Duration)
-}
-
 // Progress is a mock-implementation of Parser.Progress().
 func (p *Parser) Progress() float32 {
 	return p.Called().Get(0).(float32)

--- a/pkg/demoinfocs/fake/parser.go
+++ b/pkg/demoinfocs/fake/parser.go
@@ -120,6 +120,26 @@ func (p *Parser) TickTime() time.Duration {
 	return p.Called().Get(0).(time.Duration)
 }
 
+// FrameRateCalculated is a mock-implementation of Parser.FrameRateCalculated().
+func (p *Parser) FrameRateCalculated() float64 {
+	return p.Called().Get(0).(float64)
+}
+
+// FrameTimeCalculated is a mock-implementation of Parser.FrameTimeCalculated().
+func (p *Parser) FrameTimeCalculated() time.Duration {
+	return p.Called().Get(0).(time.Duration)
+}
+
+// FrameRatePow2 is a mock-implementation of Parser.FrameRatePow2().
+func (p *Parser) FrameRatePow2() float64 {
+	return p.Called().Get(0).(float64)
+}
+
+// FrameTimePow2 is a mock-implementation of Parser.FrameTimePow2().
+func (p *Parser) FrameTimePow2() time.Duration {
+	return p.Called().Get(0).(time.Duration)
+}
+
 // Progress is a mock-implementation of Parser.Progress().
 func (p *Parser) Progress() float32 {
 	return p.Called().Get(0).(float32)

--- a/pkg/demoinfocs/game_state.go
+++ b/pkg/demoinfocs/game_state.go
@@ -45,13 +45,6 @@ type lastFlash struct {
 	projectileByPlayer map[*common.Player]*common.GrenadeProjectile
 }
 
-type ingameTickNumber int
-
-func (gs *gameState) handleIngameTickNumber(n ingameTickNumber) {
-	gs.ingameTick = int(n)
-	debugIngameTick(gs.ingameTick)
-}
-
 // IngameTick returns the latest actual tick number of the server during the game.
 //
 // Watch out, I've seen this return wonky negative numbers at the start of demos.

--- a/pkg/demoinfocs/net_messages.go
+++ b/pkg/demoinfocs/net_messages.go
@@ -2,6 +2,8 @@ package demoinfocs
 
 import (
 	"bytes"
+	"strconv"
+	"time"
 
 	bit "github.com/markus-wa/demoinfocs-golang/v2/internal/bitread"
 	events "github.com/markus-wa/demoinfocs-golang/v2/pkg/demoinfocs/events"
@@ -57,16 +59,36 @@ func (p *parser) handleSetConVar(setConVar *msg.CNETMsg_SetConVar) {
 		p.gameState.rules.conVars[cvar.Name] = cvar.Value
 	}
 
+	// note we should only update the frame rate if it's not determinable from the header
+	// this is because changing the frame rate mid game has no effect on the active recording
+	if rate, ok := updated["tv_snapshotrate"]; ok && p.frameRate == 0 {
+		tvSnapshotRate, err := strconv.Atoi(rate)
+		if err != nil {
+			p.setError(err)
+		} else {
+			p.setFrameRate(float64(tvSnapshotRate), events.FrameRateSourceConVars)
+		}
+	}
+
 	p.eventDispatcher.Dispatch(events.ConVarsUpdated{
 		UpdatedConVars: updated,
 	})
+}
+
+func frameRateInfoAvailableEvent(rate float64, source events.FrameRateSource) events.FrameRateInfo {
+	return events.FrameRateInfo{
+		Source:    source,
+		FrameRate: rate,
+		FrameTime: time.Duration(float64(time.Second) / rate),
+	}
 }
 
 func (p *parser) handleServerInfo(srvInfo *msg.CSVCMsg_ServerInfo) {
 	// srvInfo.MapCrc might be interesting as well
 	p.tickInterval = srvInfo.TickInterval
 
-	p.eventDispatcher.Dispatch(events.TickRateInfoAvailable{
+	p.eventDispatcher.Dispatch(events.TickRateInfo{
+		Source:   events.TickRateSourceServerInfo,
 		TickRate: p.TickRate(),
 		TickTime: p.TickTime(),
 	})

--- a/pkg/demoinfocs/parser_interface.go
+++ b/pkg/demoinfocs/parser_interface.go
@@ -60,30 +60,19 @@ type Parser interface {
 	TickTime() time.Duration
 	// FrameRateCalculated returns the frame rate of the demo (frames aka. demo-ticks per second).
 	// Not necessarily the tick-rate the server ran on during the game.
-	// See FrameRatePow2() for a possibly more accurate number.
 	//
 	// Returns frame rate from DemoHeader if it's not corrupt.
-	// Otherwise returns frame rate that has automatically bee calibrated.
+	// Otherwise returns frame rate that has automatically bee calibrated or read from tv_snapshotrate.
 	// May also return -1 before calibration has finished.
-	// See also events.FrameRateCalibrated.
+	// See also events.FrameRateInfo.
 	FrameRateCalculated() float64
-	// FrameRatePow2 returns the frame rate of the demo (frames aka. demo-ticks per second) as a power of 2 (16, 32, 64 ...).
-	// Returns -1 before calibration has finished.
-	FrameRatePow2() float64
 	// FrameTimeCalculated returns the time a frame / demo-tick takes in seconds.
-	// See FrameTimePow2() for a possibly more accurate number.
 	//
 	// Returns frame time from DemoHeader if it's not corrupt.
-	// Otherwise returns frame time that has automatically bee calibrated.
+	// Otherwise returns frame time that has automatically bee calibrated or calculated from tv_snapshotrate.
 	// May also return -1 before calibration has finished.
-	// See also events.FrameRateCalibrated.
+	// See also events.FrameRateInfo.
 	FrameTimeCalculated() time.Duration
-	// FrameTimePow2 returns the time a frame / demo-tick takes in seconds.
-	//
-	// Returns -1 before calibration has finished.
-	// See also events.FrameRateCalibrated.
-	// See also FrameRatePow2().
-	FrameTimePow2() time.Duration
 	// Progress returns the parsing progress from 0 to 1.
 	// Where 0 means nothing has been parsed yet and 1 means the demo has been parsed to the end.
 	//

--- a/pkg/demoinfocs/parser_interface.go
+++ b/pkg/demoinfocs/parser_interface.go
@@ -58,19 +58,32 @@ type Parser interface {
 	// Returns tick time based on CSVCMsg_ServerInfo if possible.
 	// Otherwise returns tick time based on demo header or -1 if the header info isn't available.
 	TickTime() time.Duration
-	// FrameRate returns the frame rate of the demo (frames / demo-ticks per second).
+	// FrameRateCalculated returns the frame rate of the demo (frames aka. demo-ticks per second).
 	// Not necessarily the tick-rate the server ran on during the game.
+	// See FrameRatePow2() for a possibly more accurate number.
 	//
-	// Returns frame rate based on GameState.IngameTick() if possible.
-	// Otherwise returns tick rate based on demo header or -1 if the header info isn't available.
-	// May also return 0 before parsing has started if DemoHeader.PlaybackTime or DemoHeader.PlaybackFrames are 0 (corrupt demo headers).
-	FrameRate() float64
-	// FrameTime returns the time a frame / demo-tick takes in seconds.
+	// Returns frame rate from DemoHeader if it's not corrupt.
+	// Otherwise returns frame rate that has automatically bee calibrated.
+	// May also return -1 before calibration has finished.
+	// See also events.FrameRateCalibrated.
+	FrameRateCalculated() float64
+	// FrameRatePow2 returns the frame rate of the demo (frames aka. demo-ticks per second) as a power of 2 (16, 32, 64 ...).
+	// Returns -1 before calibration has finished.
+	FrameRatePow2() float64
+	// FrameTimeCalculated returns the time a frame / demo-tick takes in seconds.
+	// See FrameTimePow2() for a possibly more accurate number.
 	//
-	// Returns frame rate based on GameState.IngameTick() if possible.
-	// Otherwise returns tick rate based on demo header or -1 if the header info isn't available.
-	// May also return 0 before parsing has started if DemoHeader.PlaybackTime or DemoHeader.PlaybackFrames are 0 (corrupt demo headers).
-	FrameTime() time.Duration
+	// Returns frame time from DemoHeader if it's not corrupt.
+	// Otherwise returns frame time that has automatically bee calibrated.
+	// May also return -1 before calibration has finished.
+	// See also events.FrameRateCalibrated.
+	FrameTimeCalculated() time.Duration
+	// FrameTimePow2 returns the time a frame / demo-tick takes in seconds.
+	//
+	// Returns -1 before calibration has finished.
+	// See also events.FrameRateCalibrated.
+	// See also FrameRatePow2().
+	FrameTimePow2() time.Duration
 	// Progress returns the parsing progress from 0 to 1.
 	// Where 0 means nothing has been parsed yet and 1 means the demo has been parsed to the end.
 	//

--- a/pkg/demoinfocs/parser_interface.go
+++ b/pkg/demoinfocs/parser_interface.go
@@ -58,6 +58,19 @@ type Parser interface {
 	// Returns tick time based on CSVCMsg_ServerInfo if possible.
 	// Otherwise returns tick time based on demo header or -1 if the header info isn't available.
 	TickTime() time.Duration
+	// FrameRate returns the frame rate of the demo (frames / demo-ticks per second).
+	// Not necessarily the tick-rate the server ran on during the game.
+	//
+	// Returns frame rate based on GameState.IngameTick() if possible.
+	// Otherwise returns tick rate based on demo header or -1 if the header info isn't available.
+	// May also return 0 before parsing has started if DemoHeader.PlaybackTime or DemoHeader.PlaybackFrames are 0 (corrupt demo headers).
+	FrameRate() float64
+	// FrameTime returns the time a frame / demo-tick takes in seconds.
+	//
+	// Returns frame rate based on GameState.IngameTick() if possible.
+	// Otherwise returns tick rate based on demo header or -1 if the header info isn't available.
+	// May also return 0 before parsing has started if DemoHeader.PlaybackTime or DemoHeader.PlaybackFrames are 0 (corrupt demo headers).
+	FrameTime() time.Duration
 	// Progress returns the parsing progress from 0 to 1.
 	// Where 0 means nothing has been parsed yet and 1 means the demo has been parsed to the end.
 	//

--- a/pkg/demoinfocs/parser_test.go
+++ b/pkg/demoinfocs/parser_test.go
@@ -62,6 +62,72 @@ func TestParser_TickTime_FallbackToHeader(t *testing.T) {
 	assert.Equal(t, time.Duration(200)*time.Millisecond, p.TickTime())
 }
 
+func TestParser_FrameRate(t *testing.T) {
+	p := &parser{
+		header: &common.DemoHeader{
+			PlaybackTime:  time.Second,
+			PlaybackTicks: 128,
+		},
+		currentFrame: 1,
+		gameState: &gameState{
+			ingameTick: 1,
+		},
+	}
+
+	assert.Equal(t, float64(128), p.FrameRate())
+}
+
+func TestParser_FrameRate_FallbackToHeader(t *testing.T) {
+	p := &parser{
+		header: &common.DemoHeader{
+			PlaybackTime:   time.Second,
+			PlaybackFrames: 128,
+		},
+		gameState: new(gameState),
+	}
+
+	assert.Equal(t, float64(128), p.FrameRate())
+}
+
+func TestParser_FrameRate_Minus1(t *testing.T) {
+	p := &parser{gameState: new(gameState)}
+
+	assert.Equal(t, float64(-1), p.FrameRate())
+}
+
+func TestParser_FrameTime(t *testing.T) {
+	p := &parser{
+		header: &common.DemoHeader{
+			PlaybackTime:  time.Second,
+			PlaybackTicks: 5,
+		},
+		currentFrame: 1,
+		gameState: &gameState{
+			ingameTick: 1,
+		},
+	}
+
+	assert.Equal(t, 200*time.Millisecond, p.FrameTime())
+}
+
+func TestParser_FrameTime_FallbackToHeader(t *testing.T) {
+	p := &parser{
+		header: &common.DemoHeader{
+			PlaybackTime:   time.Second,
+			PlaybackFrames: 5,
+		},
+		gameState: new(gameState),
+	}
+
+	assert.Equal(t, 200*time.Millisecond, p.FrameTime())
+}
+
+func TestParser_FrameTime_Minus1(t *testing.T) {
+	p := &parser{gameState: new(gameState)}
+
+	assert.Equal(t, time.Duration(-1), p.FrameTime())
+}
+
 func TestParser_Progress_NoHeader(t *testing.T) {
 	assert.Zero(t, new(parser).Progress())
 	assert.Zero(t, (&parser{header: &common.DemoHeader{}}).Progress())

--- a/pkg/demoinfocs/parser_test.go
+++ b/pkg/demoinfocs/parser_test.go
@@ -74,7 +74,7 @@ func TestParser_FrameRate(t *testing.T) {
 		},
 	}
 
-	assert.Equal(t, float64(128), p.FrameRate())
+	assert.Equal(t, float64(128), p.FrameRateCalculated())
 }
 
 func TestParser_FrameRate_FallbackToHeader(t *testing.T) {
@@ -86,13 +86,13 @@ func TestParser_FrameRate_FallbackToHeader(t *testing.T) {
 		gameState: new(gameState),
 	}
 
-	assert.Equal(t, float64(128), p.FrameRate())
+	assert.Equal(t, float64(128), p.FrameRateCalculated())
 }
 
 func TestParser_FrameRate_Minus1(t *testing.T) {
 	p := &parser{gameState: new(gameState)}
 
-	assert.Equal(t, float64(-1), p.FrameRate())
+	assert.Equal(t, float64(-1), p.FrameRateCalculated())
 }
 
 func TestParser_FrameTime(t *testing.T) {
@@ -107,7 +107,7 @@ func TestParser_FrameTime(t *testing.T) {
 		},
 	}
 
-	assert.Equal(t, 200*time.Millisecond, p.FrameTime())
+	assert.Equal(t, 200*time.Millisecond, p.FrameTimeCalculated())
 }
 
 func TestParser_FrameTime_FallbackToHeader(t *testing.T) {
@@ -119,13 +119,13 @@ func TestParser_FrameTime_FallbackToHeader(t *testing.T) {
 		gameState: new(gameState),
 	}
 
-	assert.Equal(t, 200*time.Millisecond, p.FrameTime())
+	assert.Equal(t, 200*time.Millisecond, p.FrameTimeCalculated())
 }
 
 func TestParser_FrameTime_Minus1(t *testing.T) {
 	p := &parser{gameState: new(gameState)}
 
-	assert.Equal(t, time.Duration(-1), p.FrameTime())
+	assert.Equal(t, time.Duration(-1), p.FrameTimeCalculated())
 }
 
 func TestParser_Progress_NoHeader(t *testing.T) {

--- a/pkg/demoinfocs/parsing.go
+++ b/pkg/demoinfocs/parsing.go
@@ -261,8 +261,10 @@ func (p *parser) parseFrame() bool {
 		panic(fmt.Sprintf("I haven't programmed that pathway yet (command %v unknown)", cmd))
 	}
 
-	// Queue up some post processing
-	p.msgQueue <- frameParsedToken
+	if cmd == dcPacket {
+		// Queue up some post processing, see parser.handleFrameParsed()
+		p.msgQueue <- &frameParsedTokenType{}
+	}
 
 	return true
 }

--- a/pkg/demoinfocs/parsing_test.go
+++ b/pkg/demoinfocs/parsing_test.go
@@ -1,0 +1,78 @@
+package demoinfocs
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_calculateFrameRates(t *testing.T) {
+	type args struct {
+		tickDiffs    map[int]int
+		tickInterval float32
+	}
+	tests := []struct {
+		name              string
+		args              args
+		wantFrameRate     float64
+		wantFrameRatePow2 float64
+	}{
+		{
+			name:              "simple 128",
+			wantFrameRate:     128,
+			wantFrameRatePow2: 128,
+			args: args{
+				tickDiffs: map[int]int{
+					1: 10,
+				},
+				tickInterval: 1.0 / 128.0,
+			},
+		},
+		{
+			name:              "ignore 0 128",
+			wantFrameRate:     128,
+			wantFrameRatePow2: 128,
+			args: args{
+				tickDiffs: map[int]int{
+					0: 100,
+					1: 10,
+				},
+				tickInterval: 1.0 / 128.0,
+			},
+		},
+		{
+			name:              "ignore high 128",
+			wantFrameRate:     128,
+			wantFrameRatePow2: 128,
+			args: args{
+				tickDiffs: map[int]int{
+					17: 100,
+					1:  10,
+				},
+				tickInterval: 1.0 / 128.0,
+			},
+		},
+		{
+			name:              "calc 96, pow2 128",
+			wantFrameRate:     96,
+			wantFrameRatePow2: 128,
+			args: args{
+				tickDiffs: map[int]int{
+					17: 100,
+					2:  5,
+					1:  10,
+				},
+				tickInterval: 1.0 / 128.0,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotFrameRate, gotFrameRatePow2 := calculateFrameRates(tt.args.tickDiffs, tt.args.tickInterval)
+
+			assert.Equal(t, tt.wantFrameRate, gotFrameRate)
+			assert.Equal(t, tt.wantFrameRatePow2, gotFrameRatePow2)
+		})
+	}
+}

--- a/pkg/demoinfocs/parsing_test.go
+++ b/pkg/demoinfocs/parsing_test.go
@@ -12,15 +12,13 @@ func Test_calculateFrameRates(t *testing.T) {
 		tickInterval float32
 	}
 	tests := []struct {
-		name              string
-		args              args
-		wantFrameRate     float64
-		wantFrameRatePow2 float64
+		name          string
+		args          args
+		wantFrameRate float64
 	}{
 		{
-			name:              "simple 128",
-			wantFrameRate:     128,
-			wantFrameRatePow2: 128,
+			name:          "simple 128",
+			wantFrameRate: 128,
 			args: args{
 				tickDiffs: map[int]int{
 					1: 10,
@@ -29,9 +27,8 @@ func Test_calculateFrameRates(t *testing.T) {
 			},
 		},
 		{
-			name:              "ignore 0 128",
-			wantFrameRate:     128,
-			wantFrameRatePow2: 128,
+			name:          "ignore 0 128",
+			wantFrameRate: 128,
 			args: args{
 				tickDiffs: map[int]int{
 					0: 100,
@@ -41,9 +38,8 @@ func Test_calculateFrameRates(t *testing.T) {
 			},
 		},
 		{
-			name:              "ignore high 128",
-			wantFrameRate:     128,
-			wantFrameRatePow2: 128,
+			name:          "ignore high 128",
+			wantFrameRate: 128,
 			args: args{
 				tickDiffs: map[int]int{
 					17: 100,
@@ -53,9 +49,8 @@ func Test_calculateFrameRates(t *testing.T) {
 			},
 		},
 		{
-			name:              "calc 96, pow2 128",
-			wantFrameRate:     96,
-			wantFrameRatePow2: 128,
+			name:          "calc 96, pow2 128",
+			wantFrameRate: 128,
 			args: args{
 				tickDiffs: map[int]int{
 					17: 100,
@@ -69,10 +64,9 @@ func Test_calculateFrameRates(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			gotFrameRate, gotFrameRatePow2 := calculateFrameRates(tt.args.tickDiffs, tt.args.tickInterval)
+			gotFrameRate := calculateFrameRateBestGuess(tt.args.tickDiffs, tt.args.tickInterval)
 
 			assert.Equal(t, tt.wantFrameRate, gotFrameRate)
-			assert.Equal(t, tt.wantFrameRatePow2, gotFrameRatePow2)
 		})
 	}
 }


### PR DESCRIPTION
see #235 