### PR TITLE
Add Player.CrosshairCode() to pull players current crosshair code

### DIFF
--- a/pkg/demoinfocs/common/player.go
+++ b/pkg/demoinfocs/common/player.go
@@ -375,6 +375,20 @@ func (p *Player) ClanTag() string {
 	return getString(p.resourceEntity(), "m_szClan."+p.entityIDStr())
 }
 
+// CrosshairCode returns the player's crosshair code or an empty string if there isn't one.
+func (p *Player) CrosshairCode() string {
+
+	if p.resourceEntity() == nil {
+		return ""
+	}
+	crosshairCodeValue, found := p.resourceEntity().PropertyValue("m_szCrosshairCodes." + p.entityIDStr())
+
+	if !found {
+		return ""
+	}
+	return crosshairCodeValue.StringVal
+}
+
 // Ping returns the players latency to the game server.
 func (p *Player) Ping() int {
 	return getInt(p.resourceEntity(), "m_iPing."+p.entityIDStr())

--- a/pkg/demoinfocs/common/player.go
+++ b/pkg/demoinfocs/common/player.go
@@ -377,16 +377,14 @@ func (p *Player) ClanTag() string {
 
 // CrosshairCode returns the player's crosshair code or an empty string if there isn't one.
 func (p *Player) CrosshairCode() string {
-
 	if p.resourceEntity() == nil {
 		return ""
 	}
-	crosshairCodeValue, found := p.resourceEntity().PropertyValue("m_szCrosshairCodes." + p.entityIDStr())
 
-	if !found {
-		return ""
-	}
-	return crosshairCodeValue.StringVal
+	// if the property doesn't exist we return empty string by default
+	val, _ := p.resourceEntity().PropertyValue("m_szCrosshairCodes." + p.entityIDStr())
+
+	return val.StringVal
 }
 
 // Ping returns the players latency to the game server.

--- a/pkg/demoinfocs/common/player_test.go
+++ b/pkg/demoinfocs/common/player_test.go
@@ -376,11 +376,13 @@ func TestPlayer_ClanTag(t *testing.T) {
 
 	assert.Equal(t, "SuperClan", pl.ClanTag())
 }
+
 func TestPlayer_CrosshairCode(t *testing.T) {
 	pl := playerWithResourceProperty("m_szCrosshairCodes", st.PropertyValue{StringVal: "CSGO-jvnbx-S3xFK-iEJXD-Y27Nd-AO6FP"})
 
 	assert.Equal(t, "CSGO-jvnbx-S3xFK-iEJXD-Y27Nd-AO6FP", pl.CrosshairCode())
 }
+
 func TestPlayer_WithoutCrosshairCode(t *testing.T) {
 	pl := newPlayer(0)
 

--- a/pkg/demoinfocs/common/player_test.go
+++ b/pkg/demoinfocs/common/player_test.go
@@ -376,6 +376,16 @@ func TestPlayer_ClanTag(t *testing.T) {
 
 	assert.Equal(t, "SuperClan", pl.ClanTag())
 }
+func TestPlayer_CrosshairCode(t *testing.T) {
+	pl := playerWithResourceProperty("m_szCrosshairCodes", st.PropertyValue{StringVal: "CSGO-jvnbx-S3xFK-iEJXD-Y27Nd-AO6FP"})
+
+	assert.Equal(t, "CSGO-jvnbx-S3xFK-iEJXD-Y27Nd-AO6FP", pl.CrosshairCode())
+}
+func TestPlayer_WithoutCrosshairCode(t *testing.T) {
+	pl := newPlayer(0)
+
+	assert.Equal(t, pl.CrosshairCode(), "")
+}
 
 func TestPlayer_Ping(t *testing.T) {
 	pl := playerWithResourceProperty("m_iPing", st.PropertyValue{IntVal: 45})


### PR DESCRIPTION
Adds the ability to get a player's crosshair code. 
If the player doesn't have a crosshair (legacy demo) an empty string is returned