### PR TITLE
stringtables: capture player name changes and raise new PlayerNameChange event

### DIFF
--- a/pkg/demoinfocs/demoinfocs_test.go
+++ b/pkg/demoinfocs/demoinfocs_test.go
@@ -371,7 +371,7 @@ func TestDemoSet(t *testing.T) {
 						}
 
 					case events.WarnTypeTeamSwapPlayerNil:
-						t.Log("expected known issue with team swaps occurred", warn.Message)
+						t.Log("expected known issue with team swaps occurred:", warn.Message)
 						return
 
 					case events.WarnTypeGameEventBeforeDescriptors:

--- a/pkg/demoinfocs/events/events.go
+++ b/pkg/demoinfocs/events/events.go
@@ -417,6 +417,13 @@ type PlayerDisconnected struct {
 	Player *common.Player
 }
 
+// PlayerNameChange signals that a player's name has changed
+type PlayerNameChange struct {
+	Player  *common.Player
+	OldName string
+	NewName string
+}
+
 // SayText signals a chat message. It contains the raw
 // network message data for admin / console messages.
 // EntIdx will probably always be 0


### PR DESCRIPTION
fixes regression introduced in 0515f18b2e9fdeea6b7a549adfd9c902a1eac19f where we lost player name changes