### PR TITLE
Adding LastPlaceName method for Player, adding new project to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,6 +216,7 @@ There is one caveat however: Beta features - which are marked as such via commen
 - [csgoverview](https://github.com/Linus4/csgoverview) - A 2D demo replay tool for CS:GO
 - [csgo-coach-bug-detector](https://github.com/softarn/csgo-coach-bug-detector) - Detects the abuse of an exploit used by some team coaches in professional matches
 - [megaclan3000](https://github.com/megaclan3000/megaclan3000) - A CS:GO stats page for clans with recent matches and player statistics
+- [csgo Python library](https://github.com/pnxenopoulos/csgo) - A wrapper for the Golang parser in Python
 
 If your project is using this library feel free to submit a PR or send a message in [Gitter](https://gitter.im/csgodemos/demoinfo-lib) to be included in the list.
 

--- a/pkg/demoinfocs/common/player.go
+++ b/pkg/demoinfocs/common/player.go
@@ -447,6 +447,14 @@ func (p *Player) MoneySpentThisRound() int {
 	return getInt(p.resourceEntity(), "m_iCashSpentThisRound."+p.entityIDStr())
 }
 
+// LastPlaceName returns the string value of the player's position.
+func (p *Player) LastPlaceName() string {
+	// if the property doesn't exist we return empty string by default
+	val, _ := p.resourceEntity().PropertyValue("m_szLastPlaceName."+p.entityIDStr())
+
+	return val.StringVal
+}
+
 type demoInfoProvider interface {
 	IngameTick() int   // current in-game tick, used for IsBlinded()
 	TickRate() float64 // in-game tick rate, used for Player.IsBlinded()

--- a/pkg/demoinfocs/common/player_test.go
+++ b/pkg/demoinfocs/common/player_test.go
@@ -465,6 +465,12 @@ func TestPlayer_SteamID32(t *testing.T) {
 	assert.Equal(t, uint32(52686539), pl.SteamID32())
 }
 
+func TestPlayer_LastPlaceName(t *testing.T) {
+	pl := playerWithResourceProperty("m_szLastPlaceName", st.PropertyValue{StringVal: "TopofMid"})
+
+	assert.Equal(t, "TopofMid", pl.LastPlaceName())
+}
+
 func newPlayer(tick int) *Player {
 	return NewPlayer(mockDemoInfoProvider(128, tick))
 }


### PR DESCRIPTION
Thought I'd hit two with one in this PR.

Added the `LastPlaceName` method as discussed in [issue 311](https://github.com/markus-wa/demoinfocs-golang/issues/311). I also updated the README to include the Python wrapper I wrote for your Go parser.