### PR TITLE
core: return errors in ParseToEnd() that happen during SyncAllQueues()

### DIFF
--- a/pkg/demoinfocs/parsing.go
+++ b/pkg/demoinfocs/parsing.go
@@ -101,6 +101,11 @@ func (p *parser) ParseToEnd() (err error) {
 		if err == nil {
 			err = recoverFromUnexpectedEOF(recover())
 		}
+
+		// any errors that happened during SyncAllQueues()
+		if err == nil {
+			err = p.error()
+		}
 	}()
 
 	if p.header == nil {


### PR DESCRIPTION
fix `ParseToEnd()` not returning errors that happen during `SyncAllQueues()`