### PR TITLE
raise ParserWarn instead of error on bad net-message decryption key

### DIFF
--- a/examples/encrypted-net-messages/enc_net_msg.go
+++ b/examples/encrypted-net-messages/enc_net_msg.go
@@ -47,6 +47,10 @@ func main() {
 
 	p := dem.NewParserWithConfig(f, cfg)
 
+	p.RegisterEventHandler(func(warn events.ParserWarn) {
+		log.Println("WARNING:", warn.Message)
+	})
+
 	p.RegisterEventHandler(func(message events.ChatMessage) {
 		log.Println(message)
 	})

--- a/examples/encrypted-net-messages/enc_net_msg_test.go
+++ b/examples/encrypted-net-messages/enc_net_msg_test.go
@@ -15,3 +15,14 @@ func TestEncryptedNetMessages(t *testing.T) {
 
 	main()
 }
+
+// Make sure it doesn't error / crash
+func TestEncryptedNetMessages_BadKey(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping test")
+	}
+
+	os.Args = []string{"cmd", "-demo", "../../test/cs-demos/match730_003528806449641685104_1453182610_271.dem", "-info", "../../test/cs-demos/match730_003449478367177343081_1946274414_112.dem.info"}
+
+	main()
+}

--- a/pkg/demoinfocs/events/events.go
+++ b/pkg/demoinfocs/events/events.go
@@ -523,9 +523,14 @@ const (
 	WarnTypeTeamSwapPlayerNil          // TODO: figure out why this happens
 	WarnTypeGameEventBeforeDescriptors // may occur in POV demos
 
-	// WarnTypeMissingNetMessageDecryptionKey occurs when encrypted net-messages are encountered and the decryption key is missing
+	// WarnTypeMissingNetMessageDecryptionKey occurs when encrypted net-messages are encountered and the decryption key is missing.
 	// See ParserConfig.NetMessageDecryptionKey
 	WarnTypeMissingNetMessageDecryptionKey
+
+	// WarnTypeCantReadEncryptedNetMessage occurs when an encrypted net-messages can't be decrypted even though the decryption key is set.
+	// May occur because the decryption key used is incorrect.
+	// See ParserConfig.NetMessageDecryptionKey
+	WarnTypeCantReadEncryptedNetMessage
 )
 
 // ParserWarn signals that a non-fatal problem occurred during parsing.


### PR DESCRIPTION
fixes #326