### PR TITLE
Adding Recoil Index Property of Weapon

### DIFF
--- a/pkg/demoinfocs/common/equipment.go
+++ b/pkg/demoinfocs/common/equipment.go
@@ -384,6 +384,18 @@ func (e *Equipment) AmmoReserve() int {
 	return val.IntVal
 }
 
+// RecoilIndex returns the weapon's recoil index
+func (e *Equipment) RecoilIndex() float32 {
+	if e.Entity == nil {
+		return 0
+	}
+
+	// if the property doesn't exist we return 0 by default
+	val, _ := e.Entity.PropertyValue("m_flRecoilIndex")
+
+	return val.FloatVal
+}
+
 // NewEquipment creates a new Equipment and sets the UniqueID.
 //
 // Intended for internal use only.


### PR DESCRIPTION
This commit adds recoil index. This is easy to interpret: increasing recoil index means more recoil. Decreasing recoil index means player isn't holding fire button. 

Should I also add recoil vectors? I considered adding functions for `player.Entity.PropertyValueMust("localdata.m_Local.m_aimPunchAngle").VectorVal` and
`player.Entity.PropertyValueMust("localdata.m_Local.m_viewPunchAngle").VectorVal`, but decided against that because interpreting those vectors requires handling angle wrap around and scaling (see https://davidbdurst.com/blog/csknow_recoil.html). Thoughts? I wasn't sure if this amount of interpretation belongs in the parser.