### PR TITLE
Adds new methods for getting total damage, and utility damage

### DIFF
--- a/pkg/demoinfocs/common/player.go
+++ b/pkg/demoinfocs/common/player.go
@@ -470,6 +470,16 @@ func (p *Player) MVPs() int {
 	return getInt(p.resourceEntity(), "m_iMVPs."+p.entityIDStr())
 }
 
+// TotalDamage returns the total health damage done by the player.
+func (p *Player) TotalDamage() int {
+	return getInt(p.resourceEntity(), "m_iMatchStats_Damage_Total."+p.entityIDStr())
+}
+
+// UtilityDamage returns the total damage done by the player with grenades.
+func (p *Player) UtilityDamage() int {
+	return getInt(p.resourceEntity(), "m_iMatchStats_UtilityDamage_Total."+p.entityIDStr())
+}
+
 // MoneySpentTotal returns the total amount of money the player has spent in the current match.
 func (p *Player) MoneySpentTotal() int {
 	return getInt(p.resourceEntity(), "m_iTotalCashSpent."+p.entityIDStr())

--- a/pkg/demoinfocs/common/player_test.go
+++ b/pkg/demoinfocs/common/player_test.go
@@ -486,6 +486,18 @@ func TestPlayer_MVPs(t *testing.T) {
 	assert.Equal(t, 4, pl.MVPs())
 }
 
+func TestPlayer_TotalDamage(t *testing.T) {
+	pl := playerWithResourceProperty("m_iMatchStats_Damage_Total", st.PropertyValue{IntVal: 2900})
+
+	assert.Equal(t, 2900, pl.TotalDamage())
+}
+
+func TestPlayer_UtilityDamage(t *testing.T) {
+	pl := playerWithResourceProperty("m_iMatchStats_UtilityDamage_Total", st.PropertyValue{IntVal: 420})
+
+	assert.Equal(t, 420, pl.UtilityDamage())
+}
+
 func TestPlayer_SteamID32(t *testing.T) {
 	pl := &Player{SteamID64: 76561198012952267}
 


### PR DESCRIPTION
Spent some time working out the most consistent way to calculate ADR, and kept running into issues. But found that the game tracked m_iMatchStats_Damage_Total. So added methods for pulling that as well as utility damage.

This makes really trivial to create those damage line graphs, for total damage, and utility damage. 

I added automated tests for these as well. 