### PR TITLE
feat: add neck hitbox

### DIFF
--- a/pkg/demoinfocs/events/events.go
+++ b/pkg/demoinfocs/events/events.go
@@ -390,6 +390,7 @@ const (
 	HitGroupRightArm HitGroup = 5
 	HitGroupLeftLeg  HitGroup = 6
 	HitGroupRightLeg HitGroup = 7
+	HitGroupNeck     HitGroup = 8
 	HitGroupGear     HitGroup = 10
 )
 


### PR DESCRIPTION
Hi @markus-wa!

A tiny PR to add the hit group value for the neck.
It has been noticed in this [issue](https://github.com/akiver/CSGO-Demos-Manager/issues/598) that it's possible to have a hit group value set to `8`, which seems to correspond to the neck.

Thank you, and happy new year!