### PR TITLE
Fix NewEntityWithProperty (sendtables/fake)

### DIFF
--- a/pkg/demoinfocs/sendtables/fake/entity.go
+++ b/pkg/demoinfocs/sendtables/fake/entity.go
@@ -16,8 +16,8 @@ func NewEntityWithProperty(name string, val st.PropertyValue) *Entity {
 	prop.On("Value").Return(val)
 	entity.On("Property", name).Return(prop)
 
-	entity.On("PropertyValue").Return(val, true)
-	entity.On("PropertyValueMust").Return(val)
+	entity.On("PropertyValue", name).Return(val, true)
+	entity.On("PropertyValueMust", name).Return(val)
 
 	return entity
 }


### PR DESCRIPTION
Hello

This PR fixes `NewEntityWithProperty`. This function can't work properly because the methods `PropertyValue` and `PropertyValueMust` need the name of the property as a parameter.