### PR TITLE
Improve source 2 support

### DIFF
--- a/pkg/demoinfocs/datatables.go
+++ b/pkg/demoinfocs/datatables.go
@@ -687,7 +687,7 @@ func (p *parser) bindGameRules() {
 
 		entity.Property(grPrefix("m_gamePhase")).OnUpdate(func(val st.PropertyValue) {
 			oldGamePhase := p.gameState.gamePhase
-			p.gameState.gamePhase = common.GamePhase(val.IntVal)
+			p.gameState.gamePhase = common.GamePhase(val.Int())
 
 			p.eventDispatcher.Dispatch(events.GamePhaseChanged{
 				OldGamePhase: oldGamePhase,
@@ -705,7 +705,7 @@ func (p *parser) bindGameRules() {
 		entity.BindProperty(grPrefix("m_totalRoundsPlayed"), &p.gameState.totalRoundsPlayed, st.ValTypeInt)
 		entity.Property(grPrefix("m_bWarmupPeriod")).OnUpdate(func(val st.PropertyValue) {
 			oldIsWarmupPeriod := p.gameState.isWarmupPeriod
-			p.gameState.isWarmupPeriod = val.IntVal == 1
+			p.gameState.isWarmupPeriod = val.BoolVal()
 
 			p.eventDispatcher.Dispatch(events.IsWarmupPeriodChanged{
 				OldIsWarmupPeriod: oldIsWarmupPeriod,
@@ -715,7 +715,7 @@ func (p *parser) bindGameRules() {
 
 		entity.Property(grPrefix("m_bHasMatchStarted")).OnUpdate(func(val st.PropertyValue) {
 			oldMatchStarted := p.gameState.isMatchStarted
-			p.gameState.isMatchStarted = val.IntVal == 1
+			p.gameState.isMatchStarted = val.BoolVal()
 
 			p.eventDispatcher.Dispatch(events.MatchStartedChanged{
 				OldIsStarted: oldMatchStarted,
@@ -758,7 +758,7 @@ func (p *parser) bindHostages() {
 		var state common.HostageState
 		entity.Property("m_nHostageState").OnUpdate(func(val st.PropertyValue) {
 			oldState := state
-			state = common.HostageState(val.IntVal)
+			state = common.HostageState(val.Int())
 			if oldState != state {
 				p.eventDispatcher.Dispatch(events.HostageStateChanged{OldState: oldState, NewState: state, Hostage: p.gameState.hostages[entityID]})
 			}

--- a/pkg/demoinfocs/parsing.go
+++ b/pkg/demoinfocs/parsing.go
@@ -297,21 +297,22 @@ func (p *parser) parseFrameS1() bool {
 }
 
 var demoCommandMsgsCreators = map[msgs2.EDemoCommands]NetMessageCreator{
-	msgs2.EDemoCommands_DEM_Stop:         func() proto.Message { return &msgs2.CDemoStop{} },
-	msgs2.EDemoCommands_DEM_FileHeader:   func() proto.Message { return &msgs2.CDemoFileHeader{} },
-	msgs2.EDemoCommands_DEM_FileInfo:     func() proto.Message { return &msgs2.CDemoFileInfo{} },
-	msgs2.EDemoCommands_DEM_SyncTick:     func() proto.Message { return &msgs2.CDemoSyncTick{} },
-	msgs2.EDemoCommands_DEM_SendTables:   func() proto.Message { return &msgs2.CDemoSendTables{} },
-	msgs2.EDemoCommands_DEM_ClassInfo:    func() proto.Message { return &msgs2.CDemoClassInfo{} },
-	msgs2.EDemoCommands_DEM_StringTables: func() proto.Message { return &msgs2.CDemoStringTables{} },
-	msgs2.EDemoCommands_DEM_Packet:       func() proto.Message { return &msgs2.CDemoPacket{} },
-	msgs2.EDemoCommands_DEM_SignonPacket: func() proto.Message { return &msgs2.CDemoPacket{} },
-	msgs2.EDemoCommands_DEM_ConsoleCmd:   func() proto.Message { return &msgs2.CDemoConsoleCmd{} },
-	msgs2.EDemoCommands_DEM_CustomData:   func() proto.Message { return &msgs2.CDemoCustomData{} },
-	msgs2.EDemoCommands_DEM_UserCmd:      func() proto.Message { return &msgs2.CDemoUserCmd{} },
-	msgs2.EDemoCommands_DEM_FullPacket:   func() proto.Message { return &msgs2.CDemoFullPacket{} },
-	msgs2.EDemoCommands_DEM_SaveGame:     func() proto.Message { return &msgs2.CDemoSaveGame{} },
-	msgs2.EDemoCommands_DEM_SpawnGroups:  func() proto.Message { return &msgs2.CDemoSpawnGroups{} },
+	msgs2.EDemoCommands_DEM_Stop:          func() proto.Message { return &msgs2.CDemoStop{} },
+	msgs2.EDemoCommands_DEM_FileHeader:    func() proto.Message { return &msgs2.CDemoFileHeader{} },
+	msgs2.EDemoCommands_DEM_FileInfo:      func() proto.Message { return &msgs2.CDemoFileInfo{} },
+	msgs2.EDemoCommands_DEM_SyncTick:      func() proto.Message { return &msgs2.CDemoSyncTick{} },
+	msgs2.EDemoCommands_DEM_SendTables:    func() proto.Message { return &msgs2.CDemoSendTables{} },
+	msgs2.EDemoCommands_DEM_ClassInfo:     func() proto.Message { return &msgs2.CDemoClassInfo{} },
+	msgs2.EDemoCommands_DEM_StringTables:  func() proto.Message { return &msgs2.CDemoStringTables{} },
+	msgs2.EDemoCommands_DEM_Packet:        func() proto.Message { return &msgs2.CDemoPacket{} },
+	msgs2.EDemoCommands_DEM_SignonPacket:  func() proto.Message { return &msgs2.CDemoPacket{} },
+	msgs2.EDemoCommands_DEM_ConsoleCmd:    func() proto.Message { return &msgs2.CDemoConsoleCmd{} },
+	msgs2.EDemoCommands_DEM_CustomData:    func() proto.Message { return &msgs2.CDemoCustomData{} },
+	msgs2.EDemoCommands_DEM_UserCmd:       func() proto.Message { return &msgs2.CDemoUserCmd{} },
+	msgs2.EDemoCommands_DEM_FullPacket:    func() proto.Message { return &msgs2.CDemoFullPacket{} },
+	msgs2.EDemoCommands_DEM_SaveGame:      func() proto.Message { return &msgs2.CDemoSaveGame{} },
+	msgs2.EDemoCommands_DEM_SpawnGroups:   func() proto.Message { return &msgs2.CDemoSpawnGroups{} },
+	msgs2.EDemoCommands_DEM_AnimationData: func() proto.Message { return &msgs2.CDemoAnimationData{} },
 }
 
 func (p *parser) parseFrameS2() bool {

--- a/pkg/demoinfocs/parsing.go
+++ b/pkg/demoinfocs/parsing.go
@@ -371,6 +371,9 @@ func (p *parser) parseFrameS2() bool {
 
 	case *msgs2.CDemoStringTables:
 		p.handleStringTables(m)
+
+	case *msgs2.CDemoFileInfo:
+		p.handleFileInfo(m)
 	}
 
 	// Queue up some post processing

--- a/pkg/demoinfocs/s2_commands.go
+++ b/pkg/demoinfocs/s2_commands.go
@@ -20,8 +20,6 @@ func (p *parser) handleSendTables(msg *msgs2.CDemoSendTables) {
 	if err != nil {
 		panic(errors.Wrap(err, "failed to unmarshal flattened serializer"))
 	}
-
-	p.eventDispatcher.Dispatch(events.DataTablesParsed{})
 }
 
 func (p *parser) handleClassInfo(msg *msgs2.CDemoClassInfo) {
@@ -34,6 +32,8 @@ func (p *parser) handleClassInfo(msg *msgs2.CDemoClassInfo) {
 
 	p.mapEquipment()
 	p.bindEntities()
+
+	p.eventDispatcher.Dispatch(events.DataTablesParsed{})
 }
 
 var netMsgCreators = map[msgs2.NET_Messages]NetMessageCreator{

--- a/pkg/demoinfocs/s2_commands.go
+++ b/pkg/demoinfocs/s2_commands.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"fmt"
 	"sort"
+	"time"
 
 	"github.com/pkg/errors"
 	"google.golang.org/protobuf/proto"
@@ -355,4 +356,10 @@ func (p *parser) handleFullPacket(msg *msgs2.CDemoFullPacket) {
 	if msg.Packet.GetData() != nil {
 		p.handleDemoPacket(msg.Packet)
 	}
+}
+
+func (p *parser) handleFileInfo(msg *msgs2.CDemoFileInfo) {
+	p.header.PlaybackTicks = int(*msg.PlaybackTicks)
+	p.header.PlaybackFrames = int(*msg.PlaybackFrames)
+	p.header.PlaybackTime = time.Duration(*msg.PlaybackTime) * time.Second
 }

--- a/pkg/demoinfocs/sendtables2/entity.go
+++ b/pkg/demoinfocs/sendtables2/entity.go
@@ -90,7 +90,7 @@ var bindFactoryByType = map[st.PropertyValueType]bindFactory{
 	},
 	st.ValTypeInt: func(variable any) st.PropertyUpdateHandler {
 		return func(v st.PropertyValue) {
-			*variable.(*int) = v.IntVal
+			*variable.(*int) = v.Int()
 		}
 	},
 	st.ValTypeArray: func(variable any) st.PropertyUpdateHandler {
@@ -100,22 +100,22 @@ var bindFactoryByType = map[st.PropertyValueType]bindFactory{
 	},
 	st.ValTypeString: func(variable any) st.PropertyUpdateHandler {
 		return func(v st.PropertyValue) {
-			*variable.(*string) = v.StringVal
+			*variable.(*string) = v.String()
 		}
 	},
 	st.ValTypeBoolInt: func(variable any) st.PropertyUpdateHandler {
 		return func(v st.PropertyValue) {
-			*variable.(*bool) = v.IntVal != 0
+			*variable.(*bool) = v.BoolVal()
 		}
 	},
 	st.ValTypeFloat32: func(variable any) st.PropertyUpdateHandler {
 		return func(v st.PropertyValue) {
-			*variable.(*float32) = v.FloatVal
+			*variable.(*float32) = v.Float()
 		}
 	},
 	st.ValTypeFloat64: func(variable any) st.PropertyUpdateHandler {
 		return func(v st.PropertyValue) {
-			*variable.(*float64) = float64(v.FloatVal)
+			*variable.(*float64) = float64(v.Float())
 		}
 	},
 }

--- a/pkg/demoinfocs/sendtables2/quantizedfloat.go
+++ b/pkg/demoinfocs/sendtables2/quantizedfloat.go
@@ -123,7 +123,8 @@ func (qfd *quantizedFloatDecoder) quantize(val float32) float32 {
 	}
 
 	i := uint32((val - qfd.Low) * qfd.HighLowMul)
-	return qfd.Low + (qfd.High-qfd.Low)*(float32(i)*qfd.DecMul)
+	//nolint:unconvert
+	return qfd.Low + float32((qfd.High-qfd.Low)*float32(float32(i)*qfd.DecMul))
 }
 
 // Actual float decoding


### PR DESCRIPTION
Hi!

Trying to parse these 3 CS2 demos https://www.hltv.org/matches/2365256/faze-vs-legends-steelseries-cs2-legends-vs-champions-2023 on the `s2` branch currently results in errors.

Test code:

```go
package main

import (
	"errors"
	"fmt"
	"os"
	"time"

	demoinfocs "github.com/markus-wa/demoinfocs-golang/v3/pkg/demoinfocs"
	common "github.com/markus-wa/demoinfocs-golang/v3/pkg/demoinfocs/common"
	"github.com/markus-wa/demoinfocs-golang/v3/pkg/demoinfocs/events"
	"github.com/markus-wa/demoinfocs-golang/v3/pkg/demoinfocs/sendtables"
)

func main() {
	var err error
	f, err := os.Open("./faze-vs-legends-m3-dust2.dem")
	checkError(err)

	defer f.Close()

	p := demoinfocs.NewParser(f)
	defer p.Close()

	_, err = p.ParseHeader()
	checkError(err)

	p.RegisterEventHandler(func(e events.Kill) {
		var hs string
		if e.IsHeadshot {
			hs = " (HS)"
		}
		var wallBang string
		if e.PenetratedObjects > 0 {
			wallBang = " (WB)"
		}
		for _, player := range p.GameState().Participants().All() {
			if player.FlashDuration > 0 {
				fmt.Println(player.Name, player.FlashDuration)
			}
		}

		if e.Killer != nil {
			fmt.Printf("%s <%v%s%s> %s %d %d %d\n", formatPlayer(e.Killer), e.Weapon, hs, wallBang, formatPlayer(e.Victim), e.Killer.Health(), p.GameState().IngameTick(), p.CurrentFrame())
		} else {
			fmt.Println("killer is nil")
		}
	})

	p.RegisterEventHandler(func(e events.RoundStart) {
		fmt.Println("round_start")
	})

    p.RegisterEventHandler(func(e events.RoundEnd) {
		winner := p.GameState().Team(e.Winner)
		fmt.Println("round_end", e.Reason, e.Winner, len(winner.Members()), p.GameState().TotalRoundsPlayed())
	})

	p.RegisterEventHandler(func(e events.TeamSideSwitch) {
		fmt.Println("team_side_switch")
	})

	p.RegisterEventHandler(func(e events.GameHalfEnded) {
		fmt.Println("game_half_end")
	})

	p.RegisterEventHandler(func(e events.GamePhaseChanged) {
		fmt.Println("game_phase_changed", e.OldGamePhase, e.NewGamePhase)
	})

	p.RegisterEventHandler(func(e events.IsWarmupPeriodChanged) {
		fmt.Println("warmup_period_changed", e.OldIsWarmupPeriod, e.NewIsWarmupPeriod)
	})

	p.RegisterEventHandler(func(e events.MatchStartedChanged) {
		fmt.Println("match_start_changed", e.OldIsStarted, e.NewIsStarted, p.GameState().IsMatchStarted())
	})

	p.RegisterEventHandler(func(e events.BombPlanted) {
		fmt.Println("bomb_planted", e.Site)
	})

	p.RegisterEventHandler(func(e events.BombExplode) {
		fmt.Println("bomb_exploded", e.Site)
	})

	p.RegisterEventHandler(func(events.DataTablesParsed) {
		p.ServerClasses().FindByName("CCSTeam").OnEntityCreated(func(entity sendtables.Entity) {
			fmt.Println("Team created")
		})
	})

	now := time.Now()
	err = p.ParseToEnd()
	if errors.Is(err, demoinfocs.ErrUnexpectedEndOfDemo) {
		fmt.Println("Parsing done with unexpected EOF")
	} else {
		checkError(err)
	}
	fmt.Println(time.Since(now))
}

func formatPlayer(p *common.Player) string {
	if p == nil {
		return "?"
	}

	switch p.Team {
	case common.TeamTerrorists:
		return "[T]" + p.Name
	case common.TeamCounterTerrorists:
		return "[CT]" + p.Name
	}

	return p.Name
}

func checkError(err error) {
	if err != nil {
		panic(err)
	}
}
```

This PR fixes each error encountered with the demo on de_mirage, and all demos are now parsable (at least with the code snippet above).
Note: the de_nuke demo seems corrupted, the demo is fully parsed but the message `DEM_Stop` is not present.

Errors fixed (1 commit per fix):

1. Fix nil pointer when trying to access a server class after the `DataTablesParsed` event occurred.

```go
p.RegisterEventHandler(func(events.DataTablesParsed) {
	// The class CCSTeam was nil because the event DataTablesParsed was triggered too early -> crash
	p.ServerClasses().FindByName("CCSTeam").OnEntityCreated(func(entity sendtables.Entity) {
		fmt.Println("Team created")
	})
})
```

2. Fix nil pointer because `EDemoCommands_DEM_AnimationData` was missing in the msgs creators map.

3. Fix possible rounding/casting issue in `quantizedFloatDecoder#quantize` (`0.00000023655593` instead of `0` with the dust2 demo).
It would lead to not reading enough data in `quantizedFloatDecoder#decode` afterward because the field `Flags` would not have been properly mutated.
This problem occurred when reading entity "field paths" (`readFields`).

4. Calling some prop func such as `p.GameState().IsMatchStarted()` would return an incorrect value because values were not retrieved using the new methods such as `BoolVal()`.

This PR also updates the playback values in the header from the msg `CDemoFileInfo`.

Thank you for working on the source 2 support!