### PR TITLE
add S2 method to Entity

### DIFF
--- a/pkg/demoinfocs/common/common.go
+++ b/pkg/demoinfocs/common/common.go
@@ -136,12 +136,21 @@ func (ts *TeamState) Team() Team {
 
 // ID returns the team ID, this stays the same even after switching sides.
 func (ts *TeamState) ID() int {
+	if ts.Entity.S2() {
+		return int(getUInt64(ts.Entity, "m_iTeamNum"))
+	}
 	return getInt(ts.Entity, "m_iTeamNum")
 }
 
 // Score returns the current score of the team (usually 0-16 without overtime).
 func (ts *TeamState) Score() int {
-	return getInt(ts.Entity, "m_scoreTotal")
+	var propName string
+	if ts.Entity.S2() {
+		propName = "m_iScore"
+	} else {
+		propName = "m_scoreTotal"
+	}
+	return getInt(ts.Entity, propName)
 }
 
 // ClanName returns the team name (e.g. Fnatic).

--- a/pkg/demoinfocs/common/entity_util.go
+++ b/pkg/demoinfocs/common/entity_util.go
@@ -10,6 +10,14 @@ func getInt(entity st.Entity, propName string) int {
 	return entity.PropertyValueMust(propName).Int()
 }
 
+func getUInt64(entity st.Entity, propName string) uint64 {
+	if entity == nil {
+		return 0
+	}
+
+	return entity.PropertyValueMust(propName).S2UInt64()
+}
+
 func getFloat(entity st.Entity, propName string) float32 {
 	if entity == nil {
 		return 0

--- a/pkg/demoinfocs/sendtables/entity.go
+++ b/pkg/demoinfocs/sendtables/entity.go
@@ -11,7 +11,7 @@ import (
 //go:generate ifacemaker -f entity.go -s entity -i Entity -p sendtables -D -y "Entity is an auto-generated interface for entity, intended to be used when mockability is needed." -c "DO NOT EDIT: Auto generated" -o entity_interface.go
 //go:generate ifacemaker -f entity.go -s property -i Property -p sendtables -D -y "Property is an auto-generated interface for property, intended to be used when mockability is needed." -c "DO NOT EDIT: Auto generated" -o property_interface.go
 
-// entity stores a entity in the game (e.g. players etc.) with its properties.
+// entity stores an entity in the game (e.g. players etc.) with its properties.
 type entity struct {
 	serverClass *serverClass
 	id          int
@@ -23,6 +23,11 @@ type entity struct {
 	position           func() r3.Vector
 	positionPropNameXY string
 	positionPropNameZ  string
+}
+
+// S2 returns whether this is a Source 2 entity.
+func (e *entity) S2() bool {
+	return false
 }
 
 // ServerClass returns the entity's server-class.

--- a/pkg/demoinfocs/sendtables/entity_interface.go
+++ b/pkg/demoinfocs/sendtables/entity_interface.go
@@ -8,8 +8,10 @@ import (
 )
 
 // Entity is an auto-generated interface for entity, intended to be used when mockability is needed.
-// entity stores a entity in the game (e.g. players etc.) with its properties.
+// entity stores an entity in the game (e.g. players etc.) with its properties.
 type Entity interface {
+	// S2 returns whether this is a Source 2 entity.
+	S2() bool
 	// ServerClass returns the entity's server-class.
 	ServerClass() ServerClass
 	// ID returns the entity's ID.

--- a/pkg/demoinfocs/sendtables/fake/entity.go
+++ b/pkg/demoinfocs/sendtables/fake/entity.go
@@ -19,6 +19,8 @@ func NewEntityWithProperty(name string, val st.PropertyValue) *Entity {
 	entity.On("PropertyValue").Return(val, true)
 	entity.On("PropertyValueMust").Return(val)
 
+	entity.On("S2", name).Return(false)
+
 	return entity
 }
 
@@ -27,6 +29,11 @@ var _ st.Entity = new(Entity)
 // Entity is a mock for of sendtables.Entity.
 type Entity struct {
 	mock.Mock
+}
+
+// S2 returns whether this is a Source 2 entity.
+func (e *Entity) S2() bool {
+	return e.Called().Bool(0)
 }
 
 // ServerClass is a mock-implementation of Entity.ServerClass().

--- a/pkg/demoinfocs/sendtables2/entity.go
+++ b/pkg/demoinfocs/sendtables2/entity.go
@@ -26,6 +26,11 @@ type Entity struct {
 	updateHandlers   map[string][]st.PropertyUpdateHandler
 }
 
+// S2 returns whether this is a Source 2 entity.
+func (e *Entity) S2() bool {
+	return true
+}
+
 func (e *Entity) ServerClass() st.ServerClass {
 	return e.class
 }


### PR DESCRIPTION
Hi! I encountered some errors while trying to parse a Source 2 demo file in `TeamStats` methods (since some properties have changed their names/hierarchy in S2), and decided that adding an `S2()` method to the `Entity` interface would be an acceptable solution. But then today I saw a PR #392 from @akiver, which solves the same problem just by looking for both the S1 and S2 property names in an `Entity`, and thus, if my change is accepted, those should be rewritten for consistency, so now I'm not so sure about the legitimacy of my suggestion. Anyway, I'm filing this PR as a place to discuss this. My take is that the `S2()` method and its usage clearly communicates to a user/developer that the properties are different specifically because of the engine, like this:
```go
// Score returns the current score of the team (usually 0-16 without overtime).
func (ts *TeamState) Score() int {
	var propName string
	if ts.Entity.S2() {
		propName = "m_iScore"
	} else {
		propName = "m_scoreTotal"
	}
	return getInt(ts.Entity, propName)
}
```