### PR TITLE
feat: update header info from CDemoFileHeader and detect POV demos

### DIFF
--- a/pkg/demoinfocs/common/player.go
+++ b/pkg/demoinfocs/common/player.go
@@ -594,20 +594,20 @@ func NewPlayer(demoInfoProvider demoInfoProvider) *Player {
 // PlayerInfo contains information about a player such as their name and SteamID.
 // Primarily intended for internal use.
 type PlayerInfo struct {
-	Version     int64
+	Version     int64  // Not available with CS2 demos
 	XUID        uint64 // SteamID64
 	Name        string
-	UserID      int
-	GUID        string
-	FriendsID   int
-	FriendsName string
-	// Custom files stuff (CRC)
+	UserID      int    // Not available with CS2 demos
+	GUID        string // Not available with CS2 demos
+	FriendsID   int    // Not available with CS2 demos
+	FriendsName string // Not available with CS2 demos
+	// Custom files stuff (CRC). Not available with CS2 demos
 	CustomFiles0 int
 	CustomFiles1 int
 	CustomFiles2 int
 	CustomFiles3 int
 	// Amount of downloaded files from the server
-	FilesDownloaded byte
+	FilesDownloaded byte // Not available with CS2 demos
 	// Bots
 	IsFakePlayer bool
 	// HLTV Proxy

--- a/pkg/demoinfocs/parsing.go
+++ b/pkg/demoinfocs/parsing.go
@@ -357,6 +357,9 @@ func (p *parser) parseFrameS2() bool {
 	p.msgQueue <- msg
 
 	switch m := msg.(type) {
+	case *msgs2.CDemoFileHeader:
+		p.handleDemoFileHeader(m)
+
 	case *msgs2.CDemoPacket:
 		p.handleDemoPacket(m)
 

--- a/pkg/demoinfocs/s2_commands.go
+++ b/pkg/demoinfocs/s2_commands.go
@@ -363,3 +363,11 @@ func (p *parser) handleFileInfo(msg *msgs2.CDemoFileInfo) {
 	p.header.PlaybackFrames = int(*msg.PlaybackFrames)
 	p.header.PlaybackTime = time.Duration(*msg.PlaybackTime) * time.Second
 }
+
+func (p *parser) handleDemoFileHeader(msg *msgs2.CDemoFileHeader) {
+	p.header.ClientName = msg.GetClientName()
+	p.header.ServerName = msg.GetServerName()
+	p.header.GameDirectory = msg.GetGameDirectory()
+	p.header.MapName = msg.GetMapName()
+	p.header.NetworkProtocol = int(msg.GetNetworkProtocol())
+}


### PR DESCRIPTION
- Update header fields from the `CDemoFileHeader` message (should be the first message received)
- Detect POV demos the same way as CSGO demos
- Dispatch `PlayerInfo` events on `userinfo` string table updates

Thank you