### PR TITLE
add IsSource2 method to demoInfoProvider

### DIFF
--- a/pkg/demoinfocs/common/common_test.go
+++ b/pkg/demoinfocs/common/common_test.go
@@ -67,8 +67,8 @@ func TestDemoHeader_FrameTime_PlaybackFrames_Zero(t *testing.T) {
 }
 
 func TestTeamState_Team(t *testing.T) {
-	tState := NewTeamState(TeamTerrorists, nil)
-	ctState := NewTeamState(TeamCounterTerrorists, nil)
+	tState := NewTeamState(TeamTerrorists, nil, demoInfoProviderMock{})
+	ctState := NewTeamState(TeamCounterTerrorists, nil, demoInfoProviderMock{})
 
 	assert.Equal(t, TeamTerrorists, tState.Team())
 	assert.Equal(t, TeamCounterTerrorists, ctState.Team())
@@ -76,7 +76,7 @@ func TestTeamState_Team(t *testing.T) {
 
 func TestTeamState_Members(t *testing.T) {
 	members := []*Player{new(Player), new(Player)}
-	state := NewTeamState(TeamTerrorists, func(Team) []*Player { return members })
+	state := NewTeamState(TeamTerrorists, func(Team) []*Player { return members }, demoInfoProviderMock{})
 
 	assert.Equal(t, members, state.Members())
 }
@@ -86,7 +86,7 @@ func TestTeamState_EquipmentValueCurrent(t *testing.T) {
 		playerWithProperty("m_unCurrentEquipmentValue", st.PropertyValue{IntVal: 100}),
 		playerWithProperty("m_unCurrentEquipmentValue", st.PropertyValue{IntVal: 200}),
 	}
-	state := NewTeamState(TeamTerrorists, func(Team) []*Player { return members })
+	state := NewTeamState(TeamTerrorists, func(Team) []*Player { return members }, demoInfoProviderMock{})
 
 	assert.Equal(t, 300, state.CurrentEquipmentValue())
 }
@@ -96,7 +96,7 @@ func TestTeamState_EquipmentValueRoundStart(t *testing.T) {
 		playerWithProperty("m_unRoundStartEquipmentValue", st.PropertyValue{IntVal: 100}),
 		playerWithProperty("m_unRoundStartEquipmentValue", st.PropertyValue{IntVal: 200}),
 	}
-	state := NewTeamState(TeamTerrorists, func(Team) []*Player { return members })
+	state := NewTeamState(TeamTerrorists, func(Team) []*Player { return members }, demoInfoProviderMock{})
 
 	assert.Equal(t, 300, state.RoundStartEquipmentValue())
 }
@@ -106,7 +106,7 @@ func TestTeamState_EquipmentValueFreezeTimeEnd(t *testing.T) {
 		playerWithProperty("m_unFreezetimeEndEquipmentValue", st.PropertyValue{IntVal: 100}),
 		playerWithProperty("m_unFreezetimeEndEquipmentValue", st.PropertyValue{IntVal: 200}),
 	}
-	state := NewTeamState(TeamTerrorists, func(Team) []*Player { return members })
+	state := NewTeamState(TeamTerrorists, func(Team) []*Player { return members }, demoInfoProviderMock{})
 
 	assert.Equal(t, 300, state.FreezeTimeEndEquipmentValue())
 }
@@ -116,7 +116,7 @@ func TestTeamState_MoneySpentThisRound(t *testing.T) {
 		NewPlayer(demoInfoProviderMock{playerResourceEntity: entityWithProperty("m_iCashSpentThisRound.000", st.PropertyValue{IntVal: 100})}),
 		NewPlayer(demoInfoProviderMock{playerResourceEntity: entityWithProperty("m_iCashSpentThisRound.000", st.PropertyValue{IntVal: 200})}),
 	}
-	state := NewTeamState(TeamTerrorists, func(Team) []*Player { return members })
+	state := NewTeamState(TeamTerrorists, func(Team) []*Player { return members }, demoInfoProviderMock{})
 
 	assert.Equal(t, 300, state.MoneySpentThisRound())
 }
@@ -126,7 +126,7 @@ func TestTeamState_MoneySpentTotal(t *testing.T) {
 		NewPlayer(demoInfoProviderMock{playerResourceEntity: entityWithProperty("m_iTotalCashSpent.000", st.PropertyValue{IntVal: 100})}),
 		NewPlayer(demoInfoProviderMock{playerResourceEntity: entityWithProperty("m_iTotalCashSpent.000", st.PropertyValue{IntVal: 200})}),
 	}
-	state := NewTeamState(TeamTerrorists, func(Team) []*Player { return members })
+	state := NewTeamState(TeamTerrorists, func(Team) []*Player { return members }, demoInfoProviderMock{})
 
 	assert.Equal(t, 300, state.MoneySpentTotal())
 }
@@ -178,10 +178,15 @@ type demoInfoProviderMock struct {
 	playersByHandle      map[int]*Player
 	playerResourceEntity st.Entity
 	equipment            *Equipment
+	isSource2            bool
 }
 
 func (p demoInfoProviderMock) FindEntityByHandle(handle uint64) st.Entity {
 	panic("implement me")
+}
+
+func (p demoInfoProviderMock) IsSource2() bool {
+	return p.isSource2
 }
 
 func (p demoInfoProviderMock) TickRate() float64 {

--- a/pkg/demoinfocs/common/entity_util.go
+++ b/pkg/demoinfocs/common/entity_util.go
@@ -10,6 +10,14 @@ func getInt(entity st.Entity, propName string) int {
 	return entity.PropertyValueMust(propName).Int()
 }
 
+func getUInt64(entity st.Entity, propName string) uint64 {
+	if entity == nil {
+		return 0
+	}
+
+	return entity.PropertyValueMust(propName).S2UInt64()
+}
+
 func getFloat(entity st.Entity, propName string) float32 {
 	if entity == nil {
 		return 0

--- a/pkg/demoinfocs/common/player.go
+++ b/pkg/demoinfocs/common/player.go
@@ -320,10 +320,11 @@ func (p *Player) ViewDirectionY() float32 {
 // See also PositionEyes().
 func (p *Player) Position() r3.Vector {
 	if p.demoInfoProvider.IsSource2() {
-		pawnEntity := p.PlayerPawnEntity()
-		if pawnEntity != nil {
+		if pawnEntity := p.PlayerPawnEntity(); pawnEntity != nil {
 			return pawnEntity.Position()
 		}
+
+		return r3.Vector{}
 	}
 
 	if p.Entity == nil {

--- a/pkg/demoinfocs/common/player.go
+++ b/pkg/demoinfocs/common/player.go
@@ -263,10 +263,8 @@ func (p *Player) ControlledBot() *Player {
 
 // Health returns the player's health points, normally 0-100.
 func (p *Player) Health() int {
-	s2Prop := p.Entity.Property("m_iPawnHealth")
-
-	if s2Prop != nil {
-		return int(s2Prop.Value().S2UInt64())
+	if p.demoInfoProvider.IsSource2() {
+		return int(getUInt64(p.Entity, "m_iPawnHealth"))
 	}
 
 	return getInt(p.Entity, "m_iHealth")
@@ -274,10 +272,8 @@ func (p *Player) Health() int {
 
 // Armor returns the player's armor points, normally 0-100.
 func (p *Player) Armor() int {
-	s2Prop := p.Entity.Property("m_iPawnArmor")
-
-	if s2Prop != nil {
-		return s2Prop.Value().Int()
+	if p.demoInfoProvider.IsSource2() {
+		return getInt(p.Entity, "m_iPawnArmor")
 	}
 
 	return getInt(p.Entity, "m_ArmorValue")
@@ -285,10 +281,8 @@ func (p *Player) Armor() int {
 
 // Money returns the amount of money in the player's bank.
 func (p *Player) Money() int {
-	s2Prop := p.Entity.Property("m_pInGameMoneyServices.m_iAccount")
-
-	if s2Prop != nil {
-		return s2Prop.Value().Int()
+	if p.demoInfoProvider.IsSource2() {
+		return getInt(p.Entity, "m_pInGameMoneyServices.m_iAccount")
 	}
 
 	return getInt(p.Entity, "m_iAccount")
@@ -325,9 +319,11 @@ func (p *Player) ViewDirectionY() float32 {
 // Note: the Z value is not on the player's eye height but instead at his feet.
 // See also PositionEyes().
 func (p *Player) Position() r3.Vector {
-	pawnEntity := p.PlayerPawnEntity()
-	if pawnEntity != nil {
-		return pawnEntity.Position()
+	if p.demoInfoProvider.IsSource2() {
+		pawnEntity := p.PlayerPawnEntity()
+		if pawnEntity != nil {
+			return pawnEntity.Position()
+		}
 	}
 
 	if p.Entity == nil {
@@ -444,10 +440,9 @@ func (p *Player) CrosshairCode() string {
 
 // Ping returns the players latency to the game server.
 func (p *Player) Ping() int {
-	s2Prop := p.Entity.Property("m_iPing")
-	if s2Prop != nil {
-		// TODO change this func return type to uint64? (small BC)
-		return int(s2Prop.Value().S2UInt64())
+	// TODO change this func return type to uint64? (small BC)
+	if p.demoInfoProvider.IsSource2() {
+		return int(getUInt64(p.Entity, "m_iPing"))
 	}
 
 	return getInt(p.resourceEntity(), "m_iPing."+p.entityIDStr())
@@ -455,9 +450,8 @@ func (p *Player) Ping() int {
 
 // Score returns the players score as shown on the scoreboard.
 func (p *Player) Score() int {
-	s2Prop := p.Entity.Property("m_iScore")
-	if s2Prop != nil {
-		return s2Prop.Value().Int()
+	if p.demoInfoProvider.IsSource2() {
+		return getInt(p.Entity, "m_iScore")
 	}
 
 	return getInt(p.resourceEntity(), "m_iScore."+p.entityIDStr())
@@ -489,9 +483,8 @@ var (
 // Returns ErrDataNotAvailable if the resource entity does not exist (it may exist later during parsing).
 // Returns ErrNotSupportedByDemo if the demo does not support player colors (e.g. very old demos).
 func (p *Player) ColorOrErr() (Color, error) {
-	s2Prop := p.Entity.Property("m_iCompTeammateColor")
-	if s2Prop != nil {
-		return Color(s2Prop.Value().Int()), nil
+	if p.demoInfoProvider.IsSource2() {
+		return Color(getInt(p.Entity, "m_iCompTeammateColor")), nil
 	}
 
 	resourceEnt := p.resourceEntity()
@@ -509,9 +502,8 @@ func (p *Player) ColorOrErr() (Color, error) {
 
 // Kills returns the amount of kills the player has as shown on the scoreboard.
 func (p *Player) Kills() int {
-	s2Prop := p.Entity.Property("m_pActionTrackingServices.m_iKills")
-	if s2Prop != nil {
-		return s2Prop.Value().Int()
+	if p.demoInfoProvider.IsSource2() {
+		return getInt(p.Entity, "m_pActionTrackingServices.m_iKills")
 	}
 
 	return getInt(p.resourceEntity(), "m_iKills."+p.entityIDStr())
@@ -519,9 +511,8 @@ func (p *Player) Kills() int {
 
 // Deaths returns the amount of deaths the player has as shown on the scoreboard.
 func (p *Player) Deaths() int {
-	s2Prop := p.Entity.Property("m_pActionTrackingServices.m_iDeaths")
-	if s2Prop != nil {
-		return s2Prop.Value().Int()
+	if p.demoInfoProvider.IsSource2() {
+		return getInt(p.Entity, "m_pActionTrackingServices.m_iDeaths")
 	}
 
 	return getInt(p.resourceEntity(), "m_iDeaths."+p.entityIDStr())
@@ -529,9 +520,8 @@ func (p *Player) Deaths() int {
 
 // Assists returns the amount of assists the player has as shown on the scoreboard.
 func (p *Player) Assists() int {
-	s2Prop := p.Entity.Property("m_pActionTrackingServices.m_iAssists")
-	if s2Prop != nil {
-		return s2Prop.Value().Int()
+	if p.demoInfoProvider.IsSource2() {
+		return getInt(p.Entity, "m_pActionTrackingServices.m_iAssists")
 	}
 
 	return getInt(p.resourceEntity(), "m_iAssists."+p.entityIDStr())
@@ -539,9 +529,8 @@ func (p *Player) Assists() int {
 
 // MVPs returns the amount of Most-Valuable-Player awards the player has as shown on the scoreboard.
 func (p *Player) MVPs() int {
-	s2Prop := p.Entity.Property("m_iMVPs")
-	if s2Prop != nil {
-		return s2Prop.Value().Int()
+	if p.demoInfoProvider.IsSource2() {
+		return getInt(p.Entity, "m_iMVPs")
 	}
 
 	return getInt(p.resourceEntity(), "m_iMVPs."+p.entityIDStr())
@@ -579,6 +568,7 @@ type demoInfoProvider interface {
 	PlayerResourceEntity() st.Entity
 	FindWeaponByEntityID(id int) *Equipment
 	FindEntityByHandle(handle uint64) st.Entity
+	IsSource2() bool
 }
 
 // NewPlayer creates a *Player with an initialized equipment map.

--- a/pkg/demoinfocs/events/events_test.go
+++ b/pkg/demoinfocs/events/events_test.go
@@ -56,6 +56,7 @@ func TestKill_IsWallBang(t *testing.T) {
 }
 
 type demoInfoProviderMock struct {
+	isSource2 bool
 }
 
 func (p demoInfoProviderMock) FindEntityByHandle(handle uint64) st.Entity {
@@ -64,6 +65,10 @@ func (p demoInfoProviderMock) FindEntityByHandle(handle uint64) st.Entity {
 
 func (p demoInfoProviderMock) IngameTick() int {
 	return 0
+}
+
+func (p demoInfoProviderMock) IsSource2() bool {
+	return p.isSource2
 }
 
 func (p demoInfoProviderMock) TickRate() float64 {

--- a/pkg/demoinfocs/game_state.go
+++ b/pkg/demoinfocs/game_state.go
@@ -208,8 +208,8 @@ func newGameState(demoInfo demoInfoProvider) *gameState {
 		demoInfo: demoInfo,
 	}
 
-	gs.tState = common.NewTeamState(common.TeamTerrorists, gs.Participants().TeamMembers)
-	gs.ctState = common.NewTeamState(common.TeamCounterTerrorists, gs.Participants().TeamMembers)
+	gs.tState = common.NewTeamState(common.TeamTerrorists, gs.Participants().TeamMembers, gs.demoInfo)
+	gs.ctState = common.NewTeamState(common.TeamCounterTerrorists, gs.Participants().TeamMembers, gs.demoInfo)
 	gs.tState.Opponent = &gs.ctState
 	gs.ctState.Opponent = &gs.tState
 

--- a/pkg/demoinfocs/parser.go
+++ b/pkg/demoinfocs/parser.go
@@ -424,6 +424,10 @@ type demoInfoProvider struct {
 	parser *parser
 }
 
+func (p demoInfoProvider) IsSource2() bool {
+	return p.parser.isSource2()
+}
+
 func (p demoInfoProvider) IngameTick() int {
 	return p.parser.gameState.IngameTick()
 }


### PR DESCRIPTION
- add `IsSource2` method to `demoInfoProvider`, which calls `isSource2` method of `parser`
- add `demoInfoProvider` to `TeamState` (we will probably need to add it to other places as well)
- use `IsSource2` in `Player` and `TeamStats` to control which property of which entity should be used (there is still much to do in that regard)