### PR TITLE
feat: weapons support

### DIFF
--- a/pkg/demoinfocs/constants/constants.go
+++ b/pkg/demoinfocs/constants/constants.go
@@ -3,9 +3,15 @@ package constants
 
 // Various constants that are used internally.
 const (
-	MaxEdictBits                 = 11
-	EntityHandleIndexMask        = (1 << MaxEdictBits) - 1
 	EntityHandleSerialNumberBits = 10
-	EntityHandleBits             = MaxEdictBits + EntityHandleSerialNumberBits
-	InvalidEntityHandle          = (1 << EntityHandleBits) - 1
+
+	MaxEdictBits          = 11
+	EntityHandleIndexMask = (1 << MaxEdictBits) - 1
+	EntityHandleBits      = MaxEdictBits + EntityHandleSerialNumberBits
+	InvalidEntityHandle   = (1 << EntityHandleBits) - 1
+
+	MaxEdictBitsSource2          = 14
+	EntityHandleIndexMaskSource2 = (1 << MaxEdictBitsSource2) - 1
+	EntityHandleBitsSource2      = MaxEdictBitsSource2 + EntityHandleSerialNumberBits
+	InvalidEntityHandleSource2   = (1 << EntityHandleBitsSource2) - 1
 )

--- a/pkg/demoinfocs/events/events.go
+++ b/pkg/demoinfocs/events/events.go
@@ -549,6 +549,8 @@ const (
 	// May occur because the decryption key used is incorrect.
 	// See ParserConfig.NetMessageDecryptionKey
 	WarnTypeCantReadEncryptedNetMessage
+
+	WarnTypeUnknownEquipmentIndex
 )
 
 // ParserWarn signals that a non-fatal problem occurred during parsing.

--- a/pkg/demoinfocs/parser.go
+++ b/pkg/demoinfocs/parser.go
@@ -94,7 +94,7 @@ type parser struct {
 	bombsiteB            bombsite
 	equipmentMapping     map[st.ServerClass]common.EquipmentType         // Maps server classes to equipment-types
 	rawPlayers           map[int]*common.PlayerInfo                      // Maps entity IDs to 'raw' player info
-	modelPreCache        []string                                        // Used to find out whether a weapon is a p250 or cz for example (same id)
+	modelPreCache        []string                                        // Used to find out whether a weapon is a p250 or cz for example (same id) for Source 1 demos only
 	triggers             map[int]*boundingBoxInformation                 // Maps entity IDs to triggers (used for bombsites)
 	gameEventDescs       map[int32]*msg.CSVCMsg_GameEventListDescriptorT // Maps game-event IDs to descriptors
 	grenadeModelIndices  map[int]common.EquipmentType                    // Used to map model indices to grenades (used for grenade projectiles)

--- a/pkg/demoinfocs/parsing.go
+++ b/pkg/demoinfocs/parsing.go
@@ -26,6 +26,7 @@ const maxOsPath = 260
 
 const (
 	playerWeaponPrefix    = "m_hMyWeapons."
+	playerWeaponPrefixS2  = "m_pWeaponServices.m_hMyWeapons."
 	playerWeaponPrePrefix = "bcc_nonlocaldata."
 	gameRulesPrefix       = "cs_gamerules_data"
 	gameRulesPrefixS2     = "m_pGameRules"

--- a/pkg/demoinfocs/sendtables/propdecoder.go
+++ b/pkg/demoinfocs/sendtables/propdecoder.go
@@ -134,6 +134,10 @@ func (v PropertyValue) S2UInt64() uint64 {
 	return v.Any.(uint64)
 }
 
+func (v PropertyValue) S2UInt32() uint32 {
+	return v.Any.(uint32)
+}
+
 func (v PropertyValue) Handle() uint64 {
 	if v.S2 {
 		return v.S2UInt64()

--- a/pkg/demoinfocs/sendtables2/class.go
+++ b/pkg/demoinfocs/sendtables2/class.go
@@ -35,7 +35,7 @@ func (c *class) BaseClasses() (res []st.ServerClass) {
 }
 
 func (c *class) PropertyEntries() []string {
-	panic("not implemented")
+	return c.collectFieldsEntries(c.serializer.fields, "")
 }
 
 func (c *class) PropertyEntryDefinitions() []st.PropertyEntry {
@@ -54,6 +54,21 @@ func (c *class) String() string {
 	}
 
 	return fmt.Sprintf("%d %s\n %s", c.classId, c.name, strings.Join(props, "\n "))
+}
+
+func (c *class) collectFieldsEntries(fields []*field, prefix string) []string {
+	paths := make([]string, 0)
+
+	for _, field := range fields {
+		if field.serializer != nil {
+			subPaths := c.collectFieldsEntries(field.serializer.fields, prefix+field.serializer.name+".")
+			paths = append(paths, subPaths...)
+		} else {
+			paths = append(paths, prefix+field.varName)
+		}
+	}
+
+	return paths
 }
 
 func (c *class) getNameForFieldPath(fp *fieldPath) string {

--- a/pkg/demoinfocs/sendtables2/entity.go
+++ b/pkg/demoinfocs/sendtables2/entity.go
@@ -7,6 +7,7 @@ import (
 	"github.com/golang/geo/r3"
 
 	bit "github.com/markus-wa/demoinfocs-golang/v3/internal/bitread"
+	"github.com/markus-wa/demoinfocs-golang/v3/pkg/demoinfocs/constants"
 	"github.com/markus-wa/demoinfocs-golang/v3/pkg/demoinfocs/msgs2"
 	st "github.com/markus-wa/demoinfocs-golang/v3/pkg/demoinfocs/sendtables"
 )
@@ -374,18 +375,12 @@ func (p *Parser) FindEntity(index int32) *Entity {
 	return p.entities[index]
 }
 
-const (
-	// SOURCE2
-	indexBits  uint64 = 14
-	handleMask uint64 = (1 << indexBits) - 1
-)
-
 func handle2idx(handle uint64) int32 {
-	return int32(handle & handleMask)
+	return int32(handle & constants.EntityHandleIndexMaskSource2)
 }
 
 func serialForHandle(handle uint64) int32 {
-	return int32(handle >> indexBits)
+	return int32(handle >> constants.MaxEdictBitsSource2)
 }
 
 // FindEntityByHandle finds a given Entity by handle

--- a/pkg/demoinfocs/sendtables2/field_decoder.go
+++ b/pkg/demoinfocs/sendtables2/field_decoder.go
@@ -36,7 +36,9 @@ var fieldTypeFactories = map[string]fieldFactory{
 	"QAngle":        qangleFactory,
 }
 
-var fieldNameDecoders = map[string]fieldDecoder{}
+var fieldNameDecoders = map[string]fieldDecoder{
+	"m_iClip1": ammoDecoder,
+}
 
 var fieldTypeDecoders = map[string]fieldDecoder{
 	/*
@@ -310,6 +312,10 @@ func signedDecoder(r *reader) interface{} {
 
 func floatCoordDecoder(r *reader) interface{} {
 	return r.readCoord()
+}
+
+func ammoDecoder(r *reader) interface{} {
+	return r.readVarUint32() - 1
 }
 
 func noscaleDecoder(r *reader) interface{} {

--- a/pkg/demoinfocs/stringtables.go
+++ b/pkg/demoinfocs/stringtables.go
@@ -428,9 +428,6 @@ func (p *parser) processStringTableS2(tab createStringTable, br *bit.BitReader) 
 			}
 
 			p.stParser.SetInstanceBaseline(classID, item.Value)
-
-		case stNameModelPreCache:
-			p.modelPreCache[item.Index] = item.Key
 		case stNameUserInfo:
 			p.parseUserInfo(item.Value, int(item.Index))
 		}
@@ -601,7 +598,7 @@ func (p *parser) parseUserInfo(data []byte, playerIndex int) {
 	xuid := userInfo.GetXuid() // TODO: what to do with userInfo.GetSteamid()? (seems to be the same, but maybe not in China?)
 	name := userInfo.GetName()
 	// When the userinfo ST is created its data contains 1 message for each possible player slot (up to 64).
-	// We ignore messages that empty, i.e. not related to a real player, a BOT or GOTV.
+	// We ignore messages that are empty, i.e. not related to a real player, a BOT or GOTV.
 	if xuid == 0 && name == "" {
 		return
 	}


### PR DESCRIPTION
This PR adds support for weapons accessible through `player.Weapons()` or `player.ActiveWeapon()`.

I don't use the same technique as for Source 1 to retrieve weapons entities and their `EquipmentType` mapping to populate `gameState.weapons`.
Instead of using ServerClass names and/or 3D model names, I use the prop `m_iItemDefinitionIndex`.  
This prop corresponds to the unique equipment index. They are located in the game file `scripts/items/items_game.txt` and are never changed.
I think this way feels less hacky than checking for model/server class names. The only downside is that if a new weapon is added to the game, we must add it to our internal `map`.
Also I'm not sure we could use the same technique with Source 2 demos as the string table `modelprecache` is not present with Source 2 demos.

Notes:
- An entity is considered a weapon entity if the props `m_iItemDefinitionIndex` and `m_iClip1` exist (there may be a better way?)
- I added an `EquipmentType` for all missing equipment indexes from the latest CS:GO file, I don't have access to CS2 but it looks like indexes didn't change
- The prop `m_iPrimaryAmmoType` used to retrieve `AmmoReserve` is not present, but there is a new prop `m_pReserveAmmo` as a replacement
- I didn't find a replacement for `AmmoType` (the prop `LocalWeaponData.m_iPrimaryAmmoType` doesn't exist). I think it's ok since it was mainly used only to compute `AmmoReserve`
- The parser emits a warning if an equipment index is unknown
- I think we could use the same index-based approach with source 1 demos

Test code: 
```go
package main

import (
	"errors"
	"fmt"
	"os"
	"time"

	demoinfocs "github.com/markus-wa/demoinfocs-golang/v3/pkg/demoinfocs"
	"github.com/markus-wa/demoinfocs-golang/v3/pkg/demoinfocs/events"
)

func main() {
	var err error
	f, err := os.Open("./faze-vs-legends-m3-dust2.dem")
	checkError(err)

	defer f.Close()

	p := demoinfocs.NewParser(f)
	defer p.Close()

	_, err = p.ParseHeader()
	checkError(err)

	p.RegisterEventHandler(func(e events.Kill) {
		if e.Killer == nil {
			return
		}

		activeWeapon := e.Killer.ActiveWeapon()
		if activeWeapon != nil {
			fmt.Printf("killer:%s event weapon:%s active weapon:%s\n", e.Killer.Name, e.Weapon, activeWeapon)
		}

		for _, pl := range p.GameState().Participants().Playing() {
			weapons := pl.Weapons()
			if len(weapons) > 0 {
				fmt.Printf("----- %s (%d weapons) -----\n", pl.Name, len(weapons))
				for _, wp := range weapons {
					fmt.Printf("%s class:%d reserve:%d magazine:%d zoom:%d\n", wp.Type, wp.Class(), wp.AmmoReserve(), wp.AmmoInMagazine(), wp.ZoomLevel())
				}
				fmt.Println("---------------------")
			}
		}
	})

	now := time.Now()
	err = p.ParseToEnd()
	if errors.Is(err, demoinfocs.ErrUnexpectedEndOfDemo) {
		fmt.Println("Parsing done with unexpected EOF")
	} else {
		checkError(err)
	}
	fmt.Println(time.Since(now))
}

func checkError(err error) {
	if err != nil {
		panic(err)
	}
}

```

I also run a "stress" test where I log weapons every frame without issue:
```go
p.RegisterEventHandler(func(e events.FrameDone) {
		for _, pl := range p.GameState().Participants().Playing() {
			weapons := pl.Weapons()
			if len(weapons) > 0 {
				fmt.Printf("----- %s (%d weapons) -----\n", pl.Name, len(weapons))
				for _, wp := range weapons {
					fmt.Printf("%s class:%d reserve:%d magazine:%d zoom:%d\n", wp.Type, wp.Class(), wp.AmmoReserve(), wp.AmmoInMagazine(), wp.ZoomLevel())
				}
				fmt.Println("---------------------")
			}
		}
	})
```

Thank you

