### PR TITLE
feat: more Source 2 support

### DIFF
--- a/pkg/demoinfocs/common/player.go
+++ b/pkg/demoinfocs/common/player.go
@@ -410,7 +410,7 @@ func (p *Player) PositionEyes() r3.Vector {
 // Velocity returns the player's velocity.
 func (p *Player) Velocity() r3.Vector {
 	if p.demoInfoProvider.IsSource2() {
-		// TODO Find out where the velocity is stored in Source 2 demos
+		// TODO Find out where we can find the velocity in Source 2 demos
 		return r3.Vector{}
 	}
 

--- a/pkg/demoinfocs/common/player.go
+++ b/pkg/demoinfocs/common/player.go
@@ -86,6 +86,11 @@ func (p *Player) IsBlinded() bool {
 
 // IsAirborne returns true if the player is jumping or falling.
 func (p *Player) IsAirborne() bool {
+	if p.demoInfoProvider.IsSource2() {
+		groundEntityHandle := getUInt64(p.PlayerPawnEntity(), "m_hGroundEntity")
+		return groundEntityHandle == constants.InvalidEntityHandleSource2
+	}
+
 	if p.Entity == nil {
 		return false
 	}
@@ -201,21 +206,37 @@ func (p *Player) HasSpotted(other *Player) bool {
 
 // IsInBombZone returns whether the player is currently in the bomb zone or not.
 func (p *Player) IsInBombZone() bool {
+	if p.demoInfoProvider.IsSource2() {
+		return getBool(p.PlayerPawnEntity(), "m_bInBombZone")
+	}
+
 	return getBool(p.Entity, "m_bInBombZone")
 }
 
 // IsInBuyZone returns whether the player is currently in the buy zone or not.
 func (p *Player) IsInBuyZone() bool {
+	if p.demoInfoProvider.IsSource2() {
+		return getBool(p.PlayerPawnEntity(), "m_bInBuyZone")
+	}
+
 	return getBool(p.Entity, "m_bInBuyZone")
 }
 
 // IsWalking returns whether the player is currently walking (sneaking) in or not.
 func (p *Player) IsWalking() bool {
+	if p.demoInfoProvider.IsSource2() {
+		return getBool(p.PlayerPawnEntity(), "m_bIsWalking")
+	}
+
 	return getBool(p.Entity, "m_bIsWalking")
 }
 
 // IsScoped returns whether the player is currently scoped in or not.
 func (p *Player) IsScoped() bool {
+	if p.demoInfoProvider.IsSource2() {
+		return getBool(p.PlayerPawnEntity(), "m_bIsScoped")
+	}
+
 	return getBool(p.Entity, "m_bIsScoped")
 }
 
@@ -245,17 +266,29 @@ func (p *Player) IsStanding() bool {
 
 // HasDefuseKit returns true if the player currently has a defuse kit in his inventory.
 func (p *Player) HasDefuseKit() bool {
+	if p.demoInfoProvider.IsSource2() {
+		return getBool(p.PlayerPawnEntity(), "m_pItemServices.m_bHasDefuser")
+	}
+
 	return getBool(p.Entity, "m_bHasDefuser")
 }
 
 // HasHelmet returns true if the player is currently wearing head armor.
 func (p *Player) HasHelmet() bool {
+	if p.demoInfoProvider.IsSource2() {
+		return getBool(p.PlayerPawnEntity(), "m_pItemServices.m_bHasHelmet")
+	}
+
 	return getBool(p.Entity, "m_bHasHelmet")
 }
 
 // IsControllingBot returns true if the player is currently controlling a bot.
 // See also ControlledBot().
 func (p *Player) IsControllingBot() bool {
+	if p.demoInfoProvider.IsSource2() {
+		return getBool(p.Entity, "m_bControllingBot")
+	}
+
 	return getBool(p.Entity, "m_bIsControllingBot")
 }
 
@@ -300,6 +333,10 @@ func (p *Player) Money() int {
 
 // EquipmentValueCurrent returns the current value of equipment in the player's inventory.
 func (p *Player) EquipmentValueCurrent() int {
+	if p.demoInfoProvider.IsSource2() {
+		return int(getUInt64(p.PlayerPawnEntity(), "m_unCurrentEquipmentValue"))
+	}
+
 	return getInt(p.Entity, "m_unCurrentEquipmentValue")
 }
 
@@ -372,6 +409,11 @@ func (p *Player) PositionEyes() r3.Vector {
 
 // Velocity returns the player's velocity.
 func (p *Player) Velocity() r3.Vector {
+	if p.demoInfoProvider.IsSource2() {
+		// TODO Find out where the velocity is stored in Source 2 demos
+		return r3.Vector{}
+	}
+
 	if p.Entity == nil {
 		return r3.Vector{}
 	}
@@ -429,6 +471,10 @@ func (pf PlayerFlags) DuckingKeyPressed() bool {
 
 // Flags returns flags currently set on m_fFlags.
 func (p *Player) Flags() PlayerFlags {
+	if p.demoInfoProvider.IsSource2() {
+		return PlayerFlags(getUInt64(p.PlayerPawnEntity(), "m_fFlags"))
+	}
+
 	return PlayerFlags(getInt(p.Entity, "m_fFlags"))
 }
 

--- a/pkg/demoinfocs/datatables.go
+++ b/pkg/demoinfocs/datatables.go
@@ -831,12 +831,21 @@ func (p *parser) bindGameRules() {
 			})
 		})
 
+		// Incremented at the beginning of a new overtime.
+		entity.Property(grPrefix("m_nOvertimePlaying")).OnUpdate(func(val st.PropertyValue) {
+			overtimeCount := val.Int()
+			p.eventDispatcher.Dispatch(events.OvertimeNumberChanged{
+				OldCount: p.gameState.overtimeCount,
+				NewCount: overtimeCount,
+			})
+			p.gameState.overtimeCount = overtimeCount
+		})
+
 		// TODO: seems like this is more reliable than RoundEnd events
 		// "m_eRoundWinReason"
 
 		// TODO: future fields to use
 		// "m_iRoundWinStatus"
-		// "m_nOvertimePlaying"
 		// "m_bGameRestart"
 		// "m_MatchDevice"
 		// "m_bHasMatchStarted"

--- a/pkg/demoinfocs/datatables.go
+++ b/pkg/demoinfocs/datatables.go
@@ -334,6 +334,11 @@ func (p *parser) bindNewPlayerControllerS2(controllerEntity st.Entity) {
 	pl.Entity = controllerEntity
 	pl.IsConnected = true
 
+	controllerEntity.Property("m_iTeamNum").OnUpdate(func(val st.PropertyValue) {
+		pl.Team = common.Team(val.S2UInt64())
+		pl.TeamState = p.gameState.Team(pl.Team)
+	})
+
 	controllerEntity.OnDestroy(func() {
 		delete(p.gameState.playersByEntityID, controllerEntityID)
 		pl.Entity = nil

--- a/pkg/demoinfocs/events/events.go
+++ b/pkg/demoinfocs/events/events.go
@@ -642,3 +642,9 @@ type PlayerInfo struct {
 	Index int
 	Info  common.PlayerInfo
 }
+
+// OvertimeNumberChanged signals that the number of overtime periods has changed.
+type OvertimeNumberChanged struct {
+	OldCount int
+	NewCount int
+}

--- a/pkg/demoinfocs/game_state.go
+++ b/pkg/demoinfocs/game_state.go
@@ -33,6 +33,7 @@ type gameState struct {
 	gamePhase            common.GamePhase
 	isWarmupPeriod       bool
 	isMatchStarted       bool
+	overtimeCount        int
 	lastFlash            lastFlash                              // Information about the last flash that exploded, used to find the attacker and projectile for player_blind events
 	currentDefuser       *common.Player                         // Player currently defusing the bomb, if any
 	currentPlanter       *common.Player                         // Player currently planting the bomb, if any
@@ -167,6 +168,11 @@ func (gs gameState) IsWarmupPeriod() bool {
 // IsMatchStarted returns whether the match has started according to CCSGameRulesProxy.
 func (gs gameState) IsMatchStarted() bool {
 	return gs.isMatchStarted
+}
+
+// OvertimeCount returns the number of overtime according to CCSGameRulesProxy.
+func (gs gameState) OvertimeCount() int {
+	return gs.overtimeCount
 }
 
 // PlayerResourceEntity returns the game's CCSPlayerResource entity.


### PR DESCRIPTION
* fix: more player's props access without crash using `IsSource2` added by @BestAwperEver in https://github.com/markus-wa/demoinfocs-golang/pull/395 👍 
* fix: update player's team based on `m_iTeamNum` prop changes (was based on `player_team` game events)
* feat: add OvertimeCount that indicates how many overtime started