### PR TITLE
get player m_bPawnIsAlive property when pawn entity is nil

### DIFF
--- a/pkg/demoinfocs/common/player.go
+++ b/pkg/demoinfocs/common/player.go
@@ -75,7 +75,10 @@ func (p *Player) IsAlive() bool {
 	}
 
 	if p.demoInfoProvider.IsSource2() {
-		return p.PlayerPawnEntity().PropertyValueMust("m_lifeState").S2UInt64() == 0
+		if pawnEntity := p.PlayerPawnEntity(); pawnEntity != nil {
+			return pawnEntity.PropertyValueMust("m_lifeState").S2UInt64() == 0
+		}
+		return getBool(p.Entity, "m_bPawnIsAlive")
 	}
 
 	return getInt(p.Entity, "m_lifeState") == 0


### PR DESCRIPTION
At least sometimes `p.PlayerPawnEntity()` returns `nil`, so, in that case, we could still fall back to the `m_bPawnIsAlive` player property. I can't say anything about the accuracy but at least we don't crash :)