### PR TITLE
add planted_c4 weapon name to weapon mapping

### DIFF
--- a/pkg/demoinfocs/common/equipment.go
+++ b/pkg/demoinfocs/common/equipment.go
@@ -147,6 +147,7 @@ func initEqNameToWeapon() {
 	eqNameToWeapon["awp"] = EqAWP
 	eqNameToWeapon["bizon"] = EqBizon
 	eqNameToWeapon["c4"] = EqBomb
+	eqNameToWeapon["planted_c4"] = EqBomb
 	eqNameToWeapon["deagle"] = EqDeagle
 	eqNameToWeapon["decoy"] = EqDecoy
 	eqNameToWeapon["decoygrenade"] = EqDecoy


### PR DESCRIPTION
Just a small fix for the correct identification of a planted c4 as a weapon in (some?) Source 2 demos