### PR TITLE
feat: warn and continue parsing on msg decompression failure

### DIFF
--- a/pkg/demoinfocs/parsing.go
+++ b/pkg/demoinfocs/parsing.go
@@ -345,7 +345,6 @@ func (p *parser) parseFrameS2() bool {
 		var err error
 
 		buf, err = snappy.Decode(nil, buf)
-
 		if err != nil {
 			if errors.Is(err, snappy.ErrCorrupt) {
 				p.eventDispatcher.Dispatch(events.ParserWarn{

--- a/pkg/demoinfocs/parsing.go
+++ b/pkg/demoinfocs/parsing.go
@@ -345,8 +345,15 @@ func (p *parser) parseFrameS2() bool {
 		var err error
 
 		buf, err = snappy.Decode(nil, buf)
+
 		if err != nil {
-			panic(err) // FIXME: avoid panic
+			if errors.Is(err, snappy.ErrCorrupt) {
+				p.eventDispatcher.Dispatch(events.ParserWarn{
+					Message: "compressed message is corrupt",
+				})
+			} else {
+				panic(err)
+			}
 		}
 	}
 


### PR DESCRIPTION
It looks like demos affected by https://github.com/markus-wa/demoinfocs-golang/issues/409 are still parsable even if a message decompression failed.
This PR replaces the panic with a warning.

Note: I had the issue with only 3 demos, maybe @Run1e you can try it with your affected demos?