### PR TITLE
Fix typo

### DIFF
--- a/pkg/demoinfocs/events/events.go
+++ b/pkg/demoinfocs/events/events.go
@@ -362,8 +362,8 @@ type BombPickup struct {
 	Player *common.Player
 }
 
-// HostageRecued signals that a hostage has been rescued.
-type HostageRecued struct {
+// HostageRescued signals that a hostage has been rescued.
+type HostageRescued struct {
 	Player  *common.Player
 	Hostage *common.Hostage
 }

--- a/pkg/demoinfocs/game_events.go
+++ b/pkg/demoinfocs/game_events.go
@@ -597,7 +597,7 @@ func (geh gameEventHandler) hostageKilled(data map[string]*msg.CSVCMsg_GameEvent
 }
 
 func (geh gameEventHandler) hostageRescued(data map[string]*msg.CSVCMsg_GameEventKeyT) {
-	event := events.HostageRecued{
+	event := events.HostageRescued{
 		Player:  geh.playerByUserID32(data["userid"].GetValShort()),
 		Hostage: geh.gameState().hostages[int(data["hostage"].GetValShort())],
 	}


### PR DESCRIPTION
The event was named HostageRecued. I added a "s" so rescued is spelled correctly.