### PR TITLE
feat: add ItemRefund event

### DIFF
--- a/pkg/demoinfocs/datatables.go
+++ b/pkg/demoinfocs/datatables.go
@@ -898,10 +898,12 @@ func (p *parser) bindWeaponS2(entity st.Entity) {
 	// This happens when:
 	// - The player is inside the buy zone
 	// - The player's money has increased AND the weapon entity is destroyed at the same tick (unfortunately the money is updated first)
-	var owner *common.Player
-	var oldOwnerMoney int
-	var lastMoneyUpdateTick int
-	var lastMoneyIncreased bool
+	var (
+		owner *common.Player
+		oldOwnerMoney int
+		lastMoneyUpdateTick int
+		lastMoneyIncreased bool
+	)
 
 	entity.Property("m_hOwnerEntity").OnUpdate(func(val st.PropertyValue) {
 		weaponOwner := p.GameState().Participants().FindByPawnHandle(val.Handle())

--- a/pkg/demoinfocs/events/events.go
+++ b/pkg/demoinfocs/events/events.go
@@ -659,3 +659,10 @@ type OvertimeNumberChanged struct {
 	OldCount int
 	NewCount int
 }
+
+// ItemRefund signals a player was refunded for an item.
+// Available with CS2 demos only.
+type ItemRefund struct {
+	Player *common.Player
+	Weapon *common.Equipment
+}


### PR DESCRIPTION
Hi!

This PR adds an `ItemRefund` event.
It's dispatched when a player refunds his purchase during the buy time and is available only with CS2 demos.

Thanks