### PR TITLE
fix: possible panic hostage.Leader() with CS2 demos

### DIFF
--- a/pkg/demoinfocs/common/hostage.go
+++ b/pkg/demoinfocs/common/hostage.go
@@ -53,6 +53,10 @@ func (hostage *Hostage) Health() int {
 // Leader returns the possible player leading the hostage.
 // Returns nil if the hostage is not following a player.
 func (hostage *Hostage) Leader() *Player {
+	if hostage.demoInfoProvider.IsSource2() {
+		return hostage.demoInfoProvider.FindPlayerByPawnHandle(getUInt64(hostage.Entity, "m_leader"))
+	}
+
 	return hostage.demoInfoProvider.FindPlayerByHandle(getInt(hostage.Entity, "m_leader"))
 }
 

--- a/pkg/demoinfocs/common/player.go
+++ b/pkg/demoinfocs/common/player.go
@@ -774,6 +774,15 @@ func (p *Player) LastPlaceName() string {
 	return getString(p.Entity, "m_szLastPlaceName")
 }
 
+// IsGrabbingHostage returns true if the player is currently grabbing a hostage.
+func (p *Player) IsGrabbingHostage() bool {
+	if p.demoInfoProvider.IsSource2() {
+		return getBool(p.PlayerPawnEntity(), "m_bIsGrabbingHostage")
+	}
+
+	return getBool(p.Entity, "m_bIsGrabbingHostage")
+}
+
 type demoInfoProvider interface {
 	IngameTick() int   // current in-game tick, used for IsBlinded()
 	TickRate() float64 // in-game tick rate, used for Player.IsBlinded()

--- a/pkg/demoinfocs/common/player_test.go
+++ b/pkg/demoinfocs/common/player_test.go
@@ -579,6 +579,18 @@ func TestPlayer_CompetitiveWins(t *testing.T) {
 	assert.Equal(t, 190, pl.CompetitiveWins())
 }
 
+func TestPlayer_IsGrabbingHostage(t *testing.T) {
+	pl := playerWithProperty("m_bIsGrabbingHostage", st.PropertyValue{IntVal: 0})
+	pl.demoInfoProvider = s1DemoInfoProvider
+
+	assert.False(t, pl.IsGrabbingHostage())
+
+	pl = playerWithProperty("m_bIsGrabbingHostage", st.PropertyValue{IntVal: 1})
+	pl.demoInfoProvider = s1DemoInfoProvider
+
+	assert.True(t, pl.IsGrabbingHostage())
+}
+
 func newPlayer(tick int) *Player {
 	return NewPlayer(mockDemoInfoProvider(128, tick))
 }


### PR DESCRIPTION
- Fix panic when calling `hostage.Leader()` with CS2 demos
- Add `IsGrabbingHostage` to `Player`

Thx!