### PR TITLE
fix: dispatch freezetime events after round start events

### DIFF
--- a/pkg/demoinfocs/datatables.go
+++ b/pkg/demoinfocs/datatables.go
@@ -1121,10 +1121,21 @@ func (p *parser) bindGameRules() {
 
 		entity.Property(grPrefix("m_bFreezePeriod")).OnUpdate(func(val st.PropertyValue) {
 			newIsFreezetime := val.BoolVal()
-			p.eventDispatcher.Dispatch(events.RoundFreezetimeChanged{
+			freezetimeEvent := events.RoundFreezetimeChanged{
 				OldIsFreezetime: p.gameState.isFreezetime,
 				NewIsFreezetime: newIsFreezetime,
-			})
+			}
+
+			if p.isSource2() {
+				if p.disableMimicSource1GameEvents {
+					p.eventDispatcher.Dispatch(freezetimeEvent)
+				} else {
+					p.gameState.lastFreezeTimeChangedEvent = &freezetimeEvent
+				}
+			} else {
+				p.eventDispatcher.Dispatch(freezetimeEvent)
+			}
+
 			p.gameState.isFreezetime = newIsFreezetime
 		})
 

--- a/pkg/demoinfocs/game_events.go
+++ b/pkg/demoinfocs/game_events.go
@@ -1023,13 +1023,20 @@ func (p *parser) dispatchMatchStartedEventIfNecessary() {
 // Dispatch round progress events in the following order:
 // 1. MatchStartedChanged
 // 2. RoundStart
-// 3. RoundEnd
-// 4. MatchStartedChanged
+// 3. FreezeTimeStart
+// 4. FreezetimeEnd
+// 5. RoundEnd
+// 6. MatchStartedChanged
 func (p *parser) processRoundProgressEvents() {
 	if p.gameState.lastRoundStartEvent != nil {
 		p.dispatchMatchStartedEventIfNecessary()
 		p.gameEventHandler.dispatch(*p.gameState.lastRoundStartEvent)
 		p.gameState.lastRoundStartEvent = nil
+	}
+
+	if p.gameState.lastFreezeTimeChangedEvent != nil {
+		p.gameEventHandler.dispatch(*p.gameState.lastFreezeTimeChangedEvent)
+		p.gameState.lastFreezeTimeChangedEvent = nil
 	}
 
 	if p.gameState.lastRoundEndEvent != nil {

--- a/pkg/demoinfocs/game_state.go
+++ b/pkg/demoinfocs/game_state.go
@@ -43,9 +43,10 @@ type gameState struct {
 	thrownGrenades               map[*common.Player][]*common.Equipment // Information about every player's thrown grenades (from the moment they are thrown to the moment their effect is ended)
 	rules                        gameRules
 	demoInfo                     demoInfoProvider
-	lastRoundStartEvent          *events.RoundStart          // Used to dispatch this event after a possible MatchStartedChanged event
-	lastRoundEndEvent            *events.RoundEnd            // Used to dispatch this event before a possible MatchStartedChanged event
-	lastMatchStartedChangedEvent *events.MatchStartedChanged // Used to dispatch this event before a possible RoundStart event and after a possible RoundEnd event
+	lastRoundStartEvent          *events.RoundStart             // Used to dispatch this event after a possible MatchStartedChanged event
+	lastFreezeTimeChangedEvent   *events.RoundFreezetimeChanged // Used to dispatch this event after a possible RoundStart event
+	lastRoundEndEvent            *events.RoundEnd               // Used to dispatch this event before a possible RoundFreezetimeChanged event
+	lastMatchStartedChangedEvent *events.MatchStartedChanged    // Used to dispatch this event before a possible RoundStart event and after a possible RoundEnd event
 	// Used to mimic missing player_blind events for CS2 demos.
 	//
 	// When a player throws a flashbang the following happens:


### PR DESCRIPTION
When `disableMimicSource1GameEvents` is `false` (the default), the events `RoundFreezetimeChanged` were dispatched before `RoundStart` events.