### PR TITLE
Remove for loop from getFieldPathForName

### DIFF
--- a/pkg/demoinfocs/sendtables2/parser.go
+++ b/pkg/demoinfocs/sendtables2/parser.go
@@ -210,7 +210,7 @@ func (p *Parser) ParsePacket(b []byte) error {
 			}
 
 			// add the field to the serializer
-			serializer.fields = append(serializer.fields, fields[i])
+			serializer.addField(fields[i])
 		}
 
 		// store the serializer for field reference

--- a/pkg/demoinfocs/sendtables2/serializer.go
+++ b/pkg/demoinfocs/sendtables2/serializer.go
@@ -5,7 +5,7 @@ import (
 	"strings"
 )
 
-type FieldIndex struct {
+type fieldIndex struct {
 	index int
 	field *field
 }
@@ -14,7 +14,7 @@ type serializer struct {
 	name         string
 	version      int32
 	fields       []*field
-	fieldIndexes map[string]*FieldIndex
+	fieldIndexes map[string]*fieldIndex
 }
 
 func (s *serializer) id() string {
@@ -75,12 +75,15 @@ func serializerId(name string, version int32) string {
 }
 
 func (s *serializer) addField(f *field) {
+	newFieldIndex := len(s.fields)
 	s.fields = append(s.fields, f)
+
 	if s.fieldIndexes == nil {
-		s.fieldIndexes = make(map[string]*FieldIndex)
+		s.fieldIndexes = make(map[string]*fieldIndex)
 	}
-	s.fieldIndexes[f.varName] = &FieldIndex{
-		index: len(s.fields) - 1,
+
+	s.fieldIndexes[f.varName] = &fieldIndex{
+		index: newFieldIndex,
 		field: f,
 	}
 }


### PR DESCRIPTION
This PR removes for loops from getFieldPathForName by introducing new map to serializer which helps to find fields by their name.
This results in ~25% faster parsing. Here are numbers from my machine for current master:
File size: 81 MB
Elapsed: 3.665982666s
File size: 107 MB
Elapsed: 4.7228615s
File size: 159 MB
Elapsed: 10.646743625s

And here is this branch results: 
File size: 81 MB
Elapsed: 2.72868975s
File size: 107 MB
Elapsed: 3.623294709s
File size: 159 MB
Elapsed: 7.519242125s