### PR TITLE
Silenced weapon

### DIFF
--- a/pkg/demoinfocs/common/equipment.go
+++ b/pkg/demoinfocs/common/equipment.go
@@ -444,6 +444,18 @@ func (e *Equipment) RecoilIndex() float32 {
 	return val.Float()
 }
 
+// Silenced returns true if weapon is silenced.
+func (e *Equipment) Silenced() bool {
+	// If entity is nil returns false.
+	if e.Entity == nil {
+		return false
+	}
+
+	prop := e.Entity.Property("m_bSilencerOn")
+
+	return prop.Value().BoolVal()
+}
+
 // NewEquipment creates a new Equipment and sets the UniqueID.
 //
 // Intended for internal use only.

--- a/pkg/demoinfocs/common/equipment_test.go
+++ b/pkg/demoinfocs/common/equipment_test.go
@@ -156,6 +156,26 @@ func TestEquipment_ZoomLevel_EntityNil(t *testing.T) {
 	assert.Equal(t, ZoomLevel(0), wep.ZoomLevel())
 }
 
+func TestEquipment_Not_Silenced(t *testing.T) {
+	wep := &Equipment{
+		Type:   EqAK47,
+		Entity: entityWithProperty("m_bSilencerOn", st.PropertyValue{IntVal: 0}),
+	}
+
+	assert.Equal(t, false, wep.Silenced())
+}
+
+func TestEquipment_Silenced_On_Off(t *testing.T) {
+	wep := &Equipment{
+		Type:   EqUSP,
+		Entity: entityWithProperty("m_bSilencerOn", st.PropertyValue{IntVal: 1}),
+	}
+	assert.Equal(t, true, wep.Silenced(), "Weapon should be silenced after the property value has been set to 1.")
+
+	wep.Entity = entityWithProperty("m_bSilencerOn", st.PropertyValue{IntVal: 0})
+	assert.Equal(t, false, wep.Silenced(), "Weapon should not be silenced after the property value has been set to 0.")
+}
+
 func TestEquipmentAlternative(t *testing.T) {
 	assert.Equal(t, EqUSP, EquipmentAlternative(EqP2000))
 	assert.Equal(t, EqCZ, EquipmentAlternative(EqP250))


### PR DESCRIPTION
### Why this PR is needed
Currently it is not possible to check whether a weapon has a silencer attached or not.

### What this PR adds
* A new equipment method Silenced() which returns true if the entity value "m_bSilencerOn" is true.