### PR TITLE
Source 2: Fix Player.Armor() sometimes being a few ticks outdated

### DIFF
--- a/pkg/demoinfocs/common/player.go
+++ b/pkg/demoinfocs/common/player.go
@@ -363,7 +363,7 @@ func (p *Player) Health() int {
 // Armor returns the player's armor points, normally 0-100.
 func (p *Player) Armor() int {
 	if p.demoInfoProvider.IsSource2() {
-		return getInt(p.Entity, "m_iPawnArmor")
+		return getInt(p.PlayerPawnEntity(), "m_ArmorValue")
 	}
 
 	return getInt(p.Entity, "m_ArmorValue")


### PR DESCRIPTION
Experiments show that m_iPawnArmor of the Player entity tends to be updated a few ticks later than m_ArmorValue of the Pawn entity.