### PR TITLE
fix nade counts for CS2

### DIFF
--- a/pkg/demoinfocs/common/equipment.go
+++ b/pkg/demoinfocs/common/equipment.go
@@ -405,13 +405,6 @@ func (e *Equipment) AmmoReserve() int {
 		return 0
 	}
 
-	if e.Class() == EqClassGrenade {
-		s2Prop := e.Entity.Property("m_pReserveAmmo.0001")
-		if s2Prop != nil {
-			return s2Prop.Value().Int()
-		}
-	}
-
 	s2Prop := e.Entity.Property("m_pReserveAmmo.0000")
 	if s2Prop != nil {
 		return s2Prop.Value().Int()


### PR DESCRIPTION
with this fix, `AmmoInMagazine() + AmmoReserve()` returns the correct amount of nades again with CS2