### PR TITLE
Add otherdeath event handling

### DIFF
--- a/pkg/demoinfocs/events/events.go
+++ b/pkg/demoinfocs/events/events.go
@@ -504,6 +504,15 @@ type RankUpdate struct {
 	Player     *common.Player // may be nil if the player has already disconnected
 }
 
+// OtherDeath signals that there has occured a death of something that is not a player.
+// For example chickens.
+type OtherDeath struct {
+	Killer        *common.Player // May be nil
+	OtherType     string
+	OtherID       int32
+	OtherPosition r3.Vector
+}
+
 // SteamID64 converts SteamID32 to the 64-bit SteamID variant and returns the result.
 // See https://developer.valvesoftware.com/wiki/SteamID
 func (ru RankUpdate) SteamID64() uint64 {

--- a/pkg/demoinfocs/game_events.go
+++ b/pkg/demoinfocs/game_events.go
@@ -210,7 +210,7 @@ func newGameEventHandler(parser *parser, ignoreBombsiteIndexNotFound bool) gameE
 		"item_pickup_slerp":               nil,                                   // Not sure, only in locally recorded (POV) demos
 		"item_remove":                     geh.itemRemove,                        // Dropped?
 		"jointeam_failed":                 nil,                                   // Dunno, only in locally recorded (POV) demos
-		"other_death":                     nil,                                   // Dunno
+		"other_death":                     geh.otherDeath,                        // Dunno
 		"player_blind":                    delay(geh.playerBlind),                // Player got blinded by a flash. Delayed because Player.FlashDuration hasn't been updated yet
 		"player_changename":               nil,                                   // Name change
 		"player_connect":                  geh.playerConnect,                     // Bot connected or player reconnected, players normally come in via string tables & data tables
@@ -836,6 +836,20 @@ func (geh gameEventHandler) itemRemove(data map[string]*msg.CSVCMsg_GameEventKey
 	geh.dispatch(events.ItemDrop{
 		Player: player,
 		Weapon: weapon,
+	})
+}
+
+func (geh gameEventHandler) otherDeath(data map[string]*msg.CSVCMsg_GameEventKeyT) {
+	killer := geh.playerByUserID32(data["attacker"].GetValShort())
+	otherType := data["othertype"].GetValString()
+	otherID := data["otherid"].GetValShort()
+	otherPosition := geh.gameState().entities[int(otherID)].Position()
+
+	geh.dispatch(events.OtherDeath{
+		Killer:        killer,
+		OtherType:     otherType,
+		OtherID:       otherID,
+		OtherPosition: otherPosition,
 	})
 }
 

--- a/pkg/demoinfocs/game_events.go
+++ b/pkg/demoinfocs/game_events.go
@@ -210,7 +210,7 @@ func newGameEventHandler(parser *parser, ignoreBombsiteIndexNotFound bool) gameE
 		"item_pickup_slerp":               nil,                                   // Not sure, only in locally recorded (POV) demos
 		"item_remove":                     geh.itemRemove,                        // Dropped?
 		"jointeam_failed":                 nil,                                   // Dunno, only in locally recorded (POV) demos
-		"other_death":                     geh.otherDeath,                        // Dunno
+		"other_death":                     geh.otherDeath,                        // Other deaths, like chickens.
 		"player_blind":                    delay(geh.playerBlind),                // Player got blinded by a flash. Delayed because Player.FlashDuration hasn't been updated yet
 		"player_changename":               nil,                                   // Name change
 		"player_connect":                  geh.playerConnect,                     // Bot connected or player reconnected, players normally come in via string tables & data tables


### PR DESCRIPTION
### Why this is needed
As of now it is not possible to gather information about chickens killed.

### What this pr adds
Adds event handling of the "other_death" server event and dispatches an OtherEvent struct.