### PR TITLE
check pawn entity health

### DIFF
--- a/pkg/demoinfocs/common/player.go
+++ b/pkg/demoinfocs/common/player.go
@@ -354,7 +354,7 @@ func (p *Player) ControlledBot() *Player {
 // Health returns the player's health points, normally 0-100.
 func (p *Player) Health() int {
 	if p.demoInfoProvider.IsSource2() {
-		return int(getInt(p.PlayerPawnEntity(), "m_iHealth"))
+		return getInt(p.PlayerPawnEntity(), "m_iHealth")
 	}
 
 	return getInt(p.Entity, "m_iHealth")

--- a/pkg/demoinfocs/common/player.go
+++ b/pkg/demoinfocs/common/player.go
@@ -354,7 +354,7 @@ func (p *Player) ControlledBot() *Player {
 // Health returns the player's health points, normally 0-100.
 func (p *Player) Health() int {
 	if p.demoInfoProvider.IsSource2() {
-		return int(getUInt64(p.Entity, "m_iPawnHealth"))
+		return int(getInt(p.PlayerPawnEntity(), "m_iHealth"))
 	}
 
 	return getInt(p.Entity, "m_iHealth")


### PR DESCRIPTION
It looks like in the past 12 hours almost every cs2 demo from Faceit (maybe even every single one, I'm not sure about that) crashes with `panic: interface conversion: interface {} is nil, not uint64` because of `Any` field of the `m_iPawnHealth` property of any player controller entity always being `nil`, so I'm proposing this as a hotfix.

Example match: https://www.faceit.com/en/cs2/room/1-f0438560-e84a-451b-b5f4-572917e9ad32