### PR TITLE
inferno/Fires: add List() to return raw list of fires

### DIFF
--- a/pkg/demoinfocs/common/inferno.go
+++ b/pkg/demoinfocs/common/inferno.go
@@ -105,6 +105,12 @@ func (f Fires) Active() Fires {
 	return Fires{s: active}
 }
 
+// List returns fires a list of the raw Fire entities. This can be useful
+// if you need to do custom calculations on the fires.
+func (f Fires) List() []Fire {
+	return f.s
+}
+
 // ConvexHull2D returns clockwise sorted corner points making up the 2D convex hull of all the fires in the inferno.
 // Useful for drawing on 2D maps.
 func (f Fires) ConvexHull2D() []r2.Point {

--- a/pkg/demoinfocs/common/inferno_test.go
+++ b/pkg/demoinfocs/common/inferno_test.go
@@ -121,3 +121,26 @@ func TestInferno_Thrower(t *testing.T) {
 
 	assert.Equal(t, player, NewInferno(provider, entity, nil).Thrower())
 }
+
+func TestInferno_List(t *testing.T) {
+	expected := []Fire{
+		{
+			Vector: r3.Vector{X: 1, Y: 2, Z: 3},
+		},
+		{
+			Vector: r3.Vector{X: 4, Y: 7, Z: 6},
+		},
+		{
+			Vector: r3.Vector{X: 7, Y: 2, Z: 9},
+		},
+		{
+			Vector: r3.Vector{X: 4, Y: 4, Z: 12},
+		},
+	}
+	fires := Fires{
+		s: expected,
+	}
+
+	got := fires.List()
+	assert.ElementsMatch(t, expected, got, "List() should return the fires contained in Fires")
+}


### PR DESCRIPTION
This PR lets users to extract the raw list of individual fires, allowing them to perform custom calculations on the raw data. This can be very useful when e.g. wishing to visualize the data with higher fidelity than convex hull, and for doing statistics