### PR TITLE
cache fieldName checks

### DIFF
--- a/pkg/demoinfocs/sendtables2/entity.go
+++ b/pkg/demoinfocs/sendtables2/entity.go
@@ -126,7 +126,7 @@ func (p property) Bind(variable any, t st.PropertyValueType) {
 }
 
 func (e *Entity) Property(name string) st.Property {
-	ok := e.class.serializer.getFieldPathForName(newFieldPath(), name)
+	ok := e.class.serializer.checkFieldName(name)
 	if !ok {
 		return nil
 	}

--- a/pkg/demoinfocs/sendtables2/parser.go
+++ b/pkg/demoinfocs/sendtables2/parser.go
@@ -158,11 +158,10 @@ func (p *Parser) ParsePacket(b []byte) error {
 	fieldTypes := map[string]*fieldType{}
 
 	for _, s := range msg.GetSerializers() {
-		serializer := &serializer{
-			name:    msg.GetSymbols()[s.GetSerializerNameSym()],
-			version: s.GetSerializerVersion(),
-			fields:  []*field{},
-		}
+		serializer := newSerializer(
+			msg.GetSymbols()[s.GetSerializerNameSym()],
+			s.GetSerializerVersion(),
+		)
 
 		for _, i := range s.GetFieldsIndex() {
 			if _, ok := fields[i]; !ok {

--- a/pkg/demoinfocs/sendtables2/serializer.go
+++ b/pkg/demoinfocs/sendtables2/serializer.go
@@ -11,10 +11,21 @@ type fieldIndex struct {
 }
 
 type serializer struct {
-	name         string
-	version      int32
-	fields       []*field
-	fieldIndexes map[string]*fieldIndex
+	name            string
+	version         int32
+	fields          []*field
+	fieldIndexes    map[string]*fieldIndex
+	fieldNameChecks map[string]bool
+}
+
+func newSerializer(name string, version int32) *serializer {
+	return &serializer{
+		name:            name,
+		version:         version,
+		fields:          []*field{},
+		fieldIndexes:    make(map[string]*fieldIndex),
+		fieldNameChecks: make(map[string]bool),
+	}
 }
 
 func (s *serializer) id() string {
@@ -78,12 +89,18 @@ func (s *serializer) addField(f *field) {
 	newFieldIndex := len(s.fields)
 	s.fields = append(s.fields, f)
 
-	if s.fieldIndexes == nil {
-		s.fieldIndexes = make(map[string]*fieldIndex)
-	}
-
 	s.fieldIndexes[f.varName] = &fieldIndex{
 		index: newFieldIndex,
 		field: f,
 	}
+}
+
+func (s *serializer) checkFieldName(name string) bool {
+	ok, exists := s.fieldNameChecks[name]
+	if !exists {
+		ok = s.getFieldPathForName(newFieldPath(), name)
+		s.fieldNameChecks[name] = ok
+	}
+
+	return ok
 }


### PR DESCRIPTION
Cache indeed provides the same performance increase as just removing the check.
But I have decided to put in on serializer object, cause the check does not seem to be dependant on entity and there are far less serializer objects created than entities.