### PR TITLE
FieldPath name cache

### DIFF
--- a/pkg/demoinfocs/sendtables2/class.go
+++ b/pkg/demoinfocs/sendtables2/class.go
@@ -8,8 +8,8 @@ import (
 )
 
 type fpNameTreeCache struct {
-	next        map[int]*fpNameTreeCache
-	cachedValue string
+	next map[int]*fpNameTreeCache
+	name string
 }
 
 type class struct {
@@ -94,11 +94,11 @@ func (c *class) getNameForFieldPath(fp *fieldPath) string {
 		currentCacheNode = next
 	}
 
-	if currentCacheNode.cachedValue == "" {
-		currentCacheNode.cachedValue = strings.Join(c.serializer.getNameForFieldPath(fp, 0), ".")
+	if currentCacheNode.name == "" {
+		currentCacheNode.name = strings.Join(c.serializer.getNameForFieldPath(fp, 0), ".")
 	}
 
-	return currentCacheNode.cachedValue
+	return currentCacheNode.name
 }
 
 func (c *class) getTypeForFieldPath(fp *fieldPath) *fieldType {

--- a/pkg/demoinfocs/sendtables2/parser.go
+++ b/pkg/demoinfocs/sendtables2/parser.go
@@ -126,6 +126,9 @@ func (p *Parser) OnDemoClassInfo(m *msgs2.CDemoClassInfo) error {
 			classId:    classId,
 			name:       networkName,
 			serializer: p.serializers[networkName],
+			fpNameCache: &fpNameTreeCache{
+				next: make(map[int]*fpNameTreeCache),
+			},
 		}
 		p.classesById[class.classId] = class
 		p.classesByName[class.name] = class


### PR DESCRIPTION
Another cache, provides noticeable performance increase and reduces memory usage:

Before: 
80 MB   2.72s
107 MB  3.82s
159 MB  8.27s
After: 
80 MB   2.18s
107 MB  2.99s
159 MB  6.49s

Memory before: 4754.88MB 
Memory after:   3495.16MB
(for one demo file - 159 MB)