### PR TITLE
CS2: Player Inventory now includes initial loadout at the beginning of the game

### DIFF
--- a/pkg/demoinfocs/datatables.go
+++ b/pkg/demoinfocs/datatables.go
@@ -655,7 +655,7 @@ func (p *parser) bindPlayerWeaponsS2(pawnEntity st.Entity, pl *common.Player) {
 	var cache [maxWeapons]uint64
 	for i := range cache {
 		i2 := i // Copy for passing to handler
-		pawnEntity.Property(playerWeaponPrefixS2 + fmt.Sprintf("%04d", i)).OnUpdate(func(val st.PropertyValue) {
+		updateWeapon := func(val st.PropertyValue) {
 			if val.Any == nil {
 				return
 			}
@@ -691,7 +691,10 @@ func (p *parser) bindPlayerWeaponsS2(pawnEntity st.Entity, pl *common.Player) {
 
 				cache[i2] = 0
 			}
-		})
+		}
+		property := pawnEntity.Property(playerWeaponPrefixS2 + fmt.Sprintf("%04d", i))
+		updateWeapon(property.Value())
+		property.OnUpdate(updateWeapon)
 	}
 }
 


### PR DESCRIPTION
Fixed an issue in CS2 where Player.Inventory would not include any weapons with which the player started.

As a simple test run the following program (for my own test, I used https://www.hltv.org/matches/2367165/rhyno-vs-perroflautas-aveiro-techdays-cup-2023 map 2 anubis):
```
func main() {
	demoFilePath := flag.String("demo", "", "path to demo file")
	flag.Parse()

	demoFile, err := os.Open(*demoFilePath)
	if err != nil {
		panic(err)
	}

	parser := demoinfocs.NewParser(demoFile)
	if err != nil {
		panic(err)
	}

	parser.RegisterEventHandler(func(_ events.RoundStart) {
		fmt.Printf("Round start: %d\n", parser.GameState().TotalRoundsPlayed()+1)
		var players []*common.Player
		players = append(players, parser.GameState().TeamTerrorists().Members()...)
		players = append(players, parser.GameState().TeamCounterTerrorists().Members()...)
		for _, player := range players {
			fmt.Print(player.Name, "has the following weapons:")
			for _, weapon := range player.Weapons() {
				fmt.Print(" " + weapon.String())
			}
			fmt.Println()
		}
		fmt.Println()
	})

	err = parser.ParseToEnd()
	if err != nil {
		panic(err)
	}
}
```
For round 1, it will print completely empty inventories for everybody. For round 2, it will not include any weapons that any surviving players had through the entire round 1.