### PR TITLE
grenade trajectories: collect timings of each location

### DIFF
--- a/pkg/demoinfocs/common/common.go
+++ b/pkg/demoinfocs/common/common.go
@@ -67,9 +67,13 @@ func (h *DemoHeader) FrameTime() time.Duration {
 type GrenadeProjectile struct {
 	Entity         st.Entity
 	WeaponInstance *Equipment
-	Thrower        *Player     // Always seems to be the same as Owner, even if the grenade was picked up
-	Owner          *Player     // Always seems to be the same as Thrower, even if the grenade was picked up
-	Trajectory     []r3.Vector // List of all known locations of the grenade up to the current point
+	Thrower        *Player // Always seems to be the same as Owner, even if the grenade was picked up
+	Owner          *Player // Always seems to be the same as Thrower, even if the grenade was picked up
+
+	// Deprecated: use Trajectory2 instead
+	Trajectory []r3.Vector // List of all known locations of the grenade up to the current point
+
+	Trajectory2 []TrajectoryEntry // List of all known locations and the point in time of the grenade up to the current point
 
 	// uniqueID is used to distinguish different grenades (which potentially have the same, reused entityID) from each other.
 	uniqueID int64
@@ -223,6 +227,13 @@ func NewTeamState(team Team, membersCallback func(Team) []*Player, demoInfoProvi
 		membersCallback:  membersCallback,
 		demoInfoProvider: demoInfoProvider,
 	}
+}
+
+// TrajectoryEntry represents the location of a grenade's trajectory at a specific point in time.
+type TrajectoryEntry struct {
+	Position r3.Vector
+	FrameID  int
+	Time     time.Duration
 }
 
 // ConvertSteamIDTxtTo32 converts a Steam-ID in text format to a 32-bit variant.

--- a/pkg/demoinfocs/datatables.go
+++ b/pkg/demoinfocs/datatables.go
@@ -860,6 +860,12 @@ func (p *parser) bindGrenadeProjectiles(entity st.Entity) {
 
 	entity.OnPositionUpdate(func(newPos r3.Vector) {
 		proj.Trajectory = append(proj.Trajectory, newPos)
+
+		proj.Trajectory2 = append(proj.Trajectory2, common.TrajectoryEntry{
+			Position: newPos,
+			FrameID:  p.CurrentFrame(),
+			Time:     p.CurrentTime(),
+		})
 	})
 
 	// Some demos don't have this property as it seems


### PR DESCRIPTION
This PR adds the possibility to track the timings of a grenade trajectory. This can be useful if you e.g. want to be able to show the trajectory as-it-happens during a replay.

I didn't want to make an API breaking change, so I added it in a separate list that tracks the contents of `GrenadeProjectile.Trajectory`. 

I added the `PointInTime` struct instead of just logging the frame id or time in seconds s.t. the user can get whichever of the two values they want. This struct could alternatively be called e.g. `PointInDemo`, `Timing`, or something else