### PR TITLE
use m_firePositions property in compatible demos

### DIFF
--- a/pkg/demoinfocs/common/inferno.go
+++ b/pkg/demoinfocs/common/inferno.go
@@ -74,15 +74,20 @@ func (inf *Inferno) Fires() Fires {
 	}
 	for i := 0; i < nFires; i++ {
 		iStr := fmt.Sprintf(iFormat, i)
-		offset := r3.Vector{
-			X: float64(entity.PropertyValueMust("m_fireXDelta." + iStr).Int()),
-			Y: float64(entity.PropertyValueMust("m_fireYDelta." + iStr).Int()),
-			Z: float64(entity.PropertyValueMust("m_fireZDelta." + iStr).Int()),
-		}
 
 		fire := Fire{
-			Vector:    origin.Add(offset),
 			IsBurning: entity.PropertyValueMust("m_bFireIsBurning." + iStr).BoolVal(),
+		}
+
+		if prop := entity.Property("m_firePositions." + iStr); prop != nil {
+			fire.Vector = prop.Value().R3Vec()
+		} else {
+			offset := r3.Vector{
+				X: float64(entity.PropertyValueMust("m_fireXDelta." + iStr).Int()),
+				Y: float64(entity.PropertyValueMust("m_fireYDelta." + iStr).Int()),
+				Z: float64(entity.PropertyValueMust("m_fireZDelta." + iStr).Int()),
+			}
+			fire.Vector = origin.Add(offset)
 		}
 
 		fires = append(fires, fire)


### PR DESCRIPTION
In the last 24 hours, I've been observing many demos that don't have `m_fire{X,Y,Z}Delta.XXXX` properties, and instead have `m_firePositions.XXXX` (older demos lack this property). This PR attempts to use the new property if the entity has it. I'm not 100% sure about the correctness of the data (see image: the CT died from the fire but the position of the death looks a bit off), but it looks good enough for now and is certainly better than crashing :)
<img width="450" alt="image" src="https://github.com/markus-wa/demoinfocs-golang/assets/24738447/19208e67-a7b8-42f0-a32c-befc9f40f1eb">
