### PR TITLE
fix: bomb planter not found

### DIFF
--- a/pkg/demoinfocs/common/player.go
+++ b/pkg/demoinfocs/common/player.go
@@ -380,7 +380,9 @@ func (p *Player) Armor() int {
 // CS2 values:
 // -1 -> Not available, demo probably not coming from a Valve server
 // 0 -> None?
-// 11 -> Classic Competitive
+// 7 -> Wingman 2v2
+// 11 -> Premier mode
+// 12 -> Classic Competitive
 func (p *Player) RankType() int {
 	if p.demoInfoProvider.IsSource2() {
 		return getInt(p.Entity, "m_iCompetitiveRankType")

--- a/pkg/demoinfocs/datatables.go
+++ b/pkg/demoinfocs/datatables.go
@@ -159,9 +159,12 @@ func (p *parser) bindBomb() {
 		bomb.LastOnGroundPosition = bombEntity.Position()
 
 		if p.isSource2() {
-			isTicking := true
 			ownerProp := bombEntity.PropertyValueMust("m_hOwnerEntity")
 			planter := p.gameState.Participants().FindByPawnHandle(ownerProp.Handle())
+			if planter == nil {
+				return
+			}
+			isTicking := true
 			planter.IsPlanting = false
 
 			siteNumber := bombEntity.PropertyValueMust("m_nBombSite").Int()


### PR DESCRIPTION
fix https://github.com/markus-wa/demoinfocs-golang/issues/461

For some reason at tick 0 a `CPlantedC4` entity is created but players are spawning and the bomb is not planted.

Also update the rank type values in the comment.