### PR TITLE
Using map for handlers instead of arrays

### DIFF
--- a/pkg/demoinfocs/datatables.go
+++ b/pkg/demoinfocs/datatables.go
@@ -526,6 +526,7 @@ func (p *parser) bindNewPlayerControllerS2(controllerEntity st.Entity) {
 
 func (p *parser) bindNewPlayerPawnS2(pawnEntity st.Entity) {
 	var prevControllerHandle uint64
+	handlerId := int64(pawnEntity.ID())
 
 	pawnEntity.Property("m_hController").OnUpdate(func(controllerHandleVal st.PropertyValue) {
 		controllerHandle := controllerHandleVal.Handle()
@@ -551,13 +552,13 @@ func (p *parser) bindNewPlayerPawnS2(pawnEntity st.Entity) {
 		}
 
 		// Position
-		pawnEntity.OnPositionUpdate(func(pos r3.Vector) {
+		pawnEntity.OnPositionUpdateWithId(func(pos r3.Vector) {
 			if pl.IsAlive() {
 				pl.LastAlivePosition = pos
 			}
-		})
+		}, handlerId)
 
-		pawnEntity.Property("m_flFlashDuration").OnUpdate(func(val st.PropertyValue) {
+		pawnEntity.Property("m_flFlashDuration").OnUpdateWithId(func(val st.PropertyValue) {
 			if val.Float() == 0 {
 				pl.FlashTick = 0
 			} else {
@@ -574,17 +575,17 @@ func (p *parser) bindNewPlayerPawnS2(pawnEntity st.Entity) {
 				flashbang := p.gameState.flyingFlashbangs[0]
 				flashbang.flashedEntityIDs = append(flashbang.flashedEntityIDs, pl.EntityID)
 			}
-		})
+		}, handlerId)
 
 		p.bindPlayerWeaponsS2(pawnEntity, pl)
 
-		pawnEntity.Property("m_pWeaponServices.m_hActiveWeapon").OnUpdate(func(val st.PropertyValue) {
+		pawnEntity.Property("m_pWeaponServices.m_hActiveWeapon").OnUpdateWithId(func(val st.PropertyValue) {
 			pl.IsReloading = false
-		})
+		}, handlerId)
 
-		pawnEntity.Property("m_bIsDefusing").OnUpdate(func(val st.PropertyValue) {
+		pawnEntity.Property("m_bIsDefusing").OnUpdateWithId(func(val st.PropertyValue) {
 			pl.IsDefusing = val.BoolVal()
-		})
+		}, handlerId)
 
 		spottedByMaskProp := pawnEntity.Property("m_bSpottedByMask.0000")
 		if spottedByMaskProp != nil {
@@ -592,13 +593,13 @@ func (p *parser) bindNewPlayerPawnS2(pawnEntity st.Entity) {
 				p.eventDispatcher.Dispatch(events.PlayerSpottersChanged{Spotted: pl})
 			}
 
-			spottedByMaskProp.OnUpdate(spottersChanged)
-			pawnEntity.Property("m_bSpottedByMask.0001").OnUpdate(spottersChanged)
+			spottedByMaskProp.OnUpdateWithId(spottersChanged, handlerId)
+			pawnEntity.Property("m_bSpottedByMask.0001").OnUpdateWithId(spottersChanged, handlerId)
 		}
 
-		pawnEntity.OnDestroy(func() {
+		pawnEntity.OnDestroyWithId(func() {
 			pl.IsConnected = false
-		})
+		}, handlerId)
 	})
 }
 

--- a/pkg/demoinfocs/datatables_test.go
+++ b/pkg/demoinfocs/datatables_test.go
@@ -97,7 +97,7 @@ func testPlayerSpotted(t *testing.T, propName string) {
 	var spottedByUpdateHandler st.PropertyUpdateHandler
 	spottedByProp0.On("OnUpdate", mock.Anything).Run(func(args mock.Arguments) {
 		spottedByUpdateHandler = args.Get(0).(st.PropertyUpdateHandler)
-	})
+	}).Return(int64(0))
 
 	spotted.On("Property", propName).Return(spottedByProp0)
 	configurePlayerEntityMock(1, spotted)
@@ -155,13 +155,13 @@ func configurePlayerEntityMock(id int, entity *stfake.Entity) {
 	var destroyCallback func()
 	entity.On("OnDestroy", mock.Anything).Run(func(args mock.Arguments) {
 		destroyCallback = args.Get(0).(func())
-	})
+	}).Return(int64(0))
 
-	entity.On("OnPositionUpdate", mock.Anything).Return()
+	entity.On("OnPositionUpdate", mock.Anything).Return(int64(0))
 	prop := new(stfake.Property)
-	prop.On("OnUpdate", mock.Anything).Return()
+	prop.On("OnUpdate", mock.Anything).Return(int64(0))
 	entity.On("Property", mock.Anything).Return(prop)
-	entity.On("BindProperty", mock.Anything, mock.Anything, mock.Anything)
+	entity.On("BindProperty", mock.Anything, mock.Anything, mock.Anything).Return(int64(0))
 	entity.On("Destroy").Run(func(mock.Arguments) {
 		destroyCallback()
 	})

--- a/pkg/demoinfocs/sendtables/entity_interface.go
+++ b/pkg/demoinfocs/sendtables/entity_interface.go
@@ -8,7 +8,7 @@ import (
 )
 
 // Entity is an auto-generated interface for entity, intended to be used when mockability is needed.
-// entity stores a entity in the game (e.g. players etc.) with its properties.
+// entity stores an entity in the game (e.g. players etc.) with its properties.
 type Entity interface {
 	// ServerClass returns the entity's server-class.
 	ServerClass() ServerClass
@@ -25,7 +25,7 @@ type Entity interface {
 	// BindProperty combines Property() & Property.Bind() into one.
 	// Essentially binds a property's value to a pointer.
 	// See the docs of the two individual functions for more info.
-	BindProperty(name string, variable any, valueType PropertyValueType)
+	BindProperty(name string, variable any, valueType PropertyValueType) int64
 	// PropertyValue finds a property on the entity by name and returns its value.
 	//
 	// Returns false as second value if the property was not found.
@@ -41,13 +41,20 @@ type Entity interface {
 	ApplyUpdate(reader *bit.BitReader)
 	// Position returns the entity's position in world coordinates.
 	Position() r3.Vector
-	// OnPositionUpdate registers a handler for the entity's position update.
+	// OnPositionUpdateWithId registers a handler for the entity's position update with the given id.
+	// The handler is called with the new position every time a position-relevant property is updated.
+	//
+	// See also Position()
+	OnPositionUpdateWithId(h func(pos r3.Vector), id int64)
+	// OnPositionUpdate registers a handler for the entity's position update and returns a randomly-generated handler id.
 	// The handler is called with the new position every time a position-relevant property is updated.
 	//
 	// See also Position()
 	OnPositionUpdate(h func(pos r3.Vector))
-	// OnDestroy registers a function to be called on the entity's destruction.
-	OnDestroy(delegate func())
+	// OnDestroyWithId registers a function to be called on the entity's destruction with a given id.
+	OnDestroyWithId(delegate func(), id int64)
+	// OnDestroy registers a function to be called on the entity's destruction and returns a randomly-generated handler id.
+	OnDestroy(delegate func()) (delegateId int64)
 	// Destroy triggers all via OnDestroy() registered functions.
 	//
 	// Intended for internal use only.

--- a/pkg/demoinfocs/sendtables/fake/entity.go
+++ b/pkg/demoinfocs/sendtables/fake/entity.go
@@ -61,8 +61,8 @@ func (e *Entity) Property(name string) st.Property {
 }
 
 // BindProperty is a mock-implementation of Entity.BindProperty().
-func (e *Entity) BindProperty(name string, variable any, valueType st.PropertyValueType) {
-	e.Called(name, variable, valueType)
+func (e *Entity) BindProperty(name string, variable any, valueType st.PropertyValueType) int64 {
+	return e.Called(name, variable, valueType).Get(0).(int64)
 }
 
 // PropertyValue is a mock-implementation of Entity.PropertyValue().
@@ -89,6 +89,11 @@ func (e *Entity) Position() r3.Vector {
 	return e.Called().Get(0).(r3.Vector)
 }
 
+// OnPositionUpdateWithId is a mock-implementation of Entity.OnPositionUpdate().
+func (e *Entity) OnPositionUpdateWithId(handler func(pos r3.Vector), id int64) {
+	e.Called(handler, id)
+}
+
 // OnPositionUpdate is a mock-implementation of Entity.OnPositionUpdate().
 func (e *Entity) OnPositionUpdate(handler func(pos r3.Vector)) {
 	e.Called(handler)
@@ -99,9 +104,14 @@ func (e *Entity) BindPosition(pos *r3.Vector) {
 	e.Called(pos)
 }
 
+// OnDestroyWithId is a mock-implementation of Entity.OnDestroy().
+func (e *Entity) OnDestroyWithId(delegate func(), id int64) {
+	e.Called(delegate, id)
+}
+
 // OnDestroy is a mock-implementation of Entity.OnDestroy().
-func (e *Entity) OnDestroy(delegate func()) {
-	e.Called(delegate)
+func (e *Entity) OnDestroy(delegate func()) int64 {
+	return e.Called(delegate).Get(0).(int64)
 }
 
 // Destroy is a mock-implementation of Entity.Destroy().

--- a/pkg/demoinfocs/sendtables/fake/property.go
+++ b/pkg/demoinfocs/sendtables/fake/property.go
@@ -28,6 +28,11 @@ func (p *Property) Type() st.PropertyType {
 	return p.Called().Get(0).(st.PropertyType)
 }
 
+// OnUpdateWithId is a mock-implementation of Property.OnUpdateWithId().
+func (p *Property) OnUpdateWithId(handler st.PropertyUpdateHandler, id int64) {
+	p.Called(handler, id)
+}
+
 // OnUpdate is a mock-implementation of Property.OnUpdate().
 func (p *Property) OnUpdate(handler st.PropertyUpdateHandler) int64 {
 	return p.Called(handler).Get(0).(int64)

--- a/pkg/demoinfocs/sendtables/fake/property.go
+++ b/pkg/demoinfocs/sendtables/fake/property.go
@@ -29,13 +29,13 @@ func (p *Property) Type() st.PropertyType {
 }
 
 // OnUpdate is a mock-implementation of Property.OnUpdate().
-func (p *Property) OnUpdate(handler st.PropertyUpdateHandler) {
-	p.Called(handler)
+func (p *Property) OnUpdate(handler st.PropertyUpdateHandler) int64 {
+	return p.Called(handler).Get(0).(int64)
 }
 
 // Bind is a mock-implementation of Property.Bind().
-func (p *Property) Bind(variable any, valueType st.PropertyValueType) {
-	p.Called(variable, valueType)
+func (p *Property) Bind(variable any, valueType st.PropertyValueType) int64 {
+	return p.Called(variable, valueType).Get(0).(int64)
 }
 
 // ArrayElementType is a mock-implementation of Property.ArrayElementType().

--- a/pkg/demoinfocs/sendtables/property_interface.go
+++ b/pkg/demoinfocs/sendtables/property_interface.go
@@ -4,7 +4,7 @@ package sendtables
 
 // Property is an auto-generated interface for property, intended to be used when mockability is needed.
 // property wraps a flattenedPropEntry and allows registering handlers
-// that can be triggered on a update of the property.
+// that can be triggered on an update of the property.
 type Property interface {
 	// Name returns the property's name.
 	Name() string
@@ -14,10 +14,14 @@ type Property interface {
 	Type() PropertyType
 	// ArrayElementType returns the data type of array entries, if Property.Type() is PropTypeArray.
 	ArrayElementType() PropertyType
-	// OnUpdate registers a handler for updates of the property's value.
+	// OnUpdate registers a handler for updates of the property's value and returns a randomly-generated handler id.
 	//
 	// The handler will be called with the current value upon registration.
-	OnUpdate(handler PropertyUpdateHandler)
+	OnUpdate(handler PropertyUpdateHandler) (handlerId int64)
+	// OnUpdateWithId registers a handler for updates of the property's value with the given handler id.
+	//
+	// The handler will be called with the current value upon registration.
+	OnUpdateWithId(handler PropertyUpdateHandler, handlerId int64)
 	/*
 	   Bind binds a property's value to a pointer.
 
@@ -30,5 +34,5 @@ type Property interface {
 
 	   The valueType indicates which field of the PropertyValue to use for the binding.
 	*/
-	Bind(variable any, valueType PropertyValueType)
+	Bind(variable any, valueType PropertyValueType) int64
 }


### PR DESCRIPTION
In [this match](https://www.faceit.com/en/cs2/room/1-6908fbf4-d043-4ae4-9b40-16010def50b0) `xddxxxddxdx` disconnects during the match, and `BOT Rebel` in his place takes control over a pawn entity that previously belonged to `tiasaid`. Then `xddxxxddxdx` reconnects (as a side note, their nickname changes to `.`, which is their steam nickname -- I'm yet to investigate the case), which disconnects the bot, but because the pawn entity now has two `OnDestroy` handlers, `tiasaid` also gets marked as disconnected for the rest of the match. This also has other side-effects, because other properties also have two `OnUpdate` handlers.

This PR fixes the behaviour by replacing array of handlers with maps and adding an option to use a fixed handler id, which helps with overriding handlers rather than adding new.

I think this deserves having its own test suit, but probably due to inexperience I failed to wrap my head around calling handlers from the mocked entity on mocked property update :disappointed: