### PR TITLE
fix: retrieve and update correct player after disconnection/bot take over

### DIFF
--- a/pkg/demoinfocs/datatables.go
+++ b/pkg/demoinfocs/datatables.go
@@ -527,6 +527,15 @@ func (p *parser) bindNewPlayerControllerS2(controllerEntity st.Entity) {
 func (p *parser) bindNewPlayerPawnS2(pawnEntity st.Entity) {
 	var prevControllerHandle uint64
 
+	getPlayerFromPawnEntity := func(pawnEntity st.Entity) *common.Player {
+		controllerProp, hasProp := pawnEntity.PropertyValue("m_hController")
+		if !hasProp {
+			return nil
+		}
+
+		return p.gameState.Participants().FindByHandle64(controllerProp.Handle())
+	}
+
 	pawnEntity.Property("m_hController").OnUpdate(func(controllerHandleVal st.PropertyValue) {
 		controllerHandle := controllerHandleVal.Handle()
 		if controllerHandle == constants.InvalidEntityHandleSource2 || controllerHandle == prevControllerHandle {
@@ -540,65 +549,89 @@ func (p *parser) bindNewPlayerPawnS2(pawnEntity st.Entity) {
 
 		pl := p.getOrCreatePlayerFromControllerEntity(controllerEntity)
 
+		p.bindPlayerWeaponsS2(pawnEntity, pl)
+
 		if !pl.IsConnected {
 			pl.IsConnected = true
-
 			if pl.SteamID64 != 0 {
 				p.eventDispatcher.Dispatch(events.PlayerConnect{Player: pl})
 			} else {
 				p.eventDispatcher.Dispatch(events.BotConnect{Player: pl})
 			}
 		}
+	})
 
-		// Position
-		pawnEntity.OnPositionUpdate(func(pos r3.Vector) {
-			if pl.IsAlive() {
-				pl.LastAlivePosition = pos
-			}
-		})
+	// Position
+	pawnEntity.OnPositionUpdate(func(pos r3.Vector) {
+		pl := getPlayerFromPawnEntity(pawnEntity)
+		if pl == nil {
+			return
+		}
+		if pl.IsAlive() {
+			pl.LastAlivePosition = pos
+		}
+	})
 
-		pawnEntity.Property("m_flFlashDuration").OnUpdate(func(val st.PropertyValue) {
-			if val.Float() == 0 {
-				pl.FlashTick = 0
-			} else {
-				pl.FlashTick = p.gameState.ingameTick
-			}
-
-			pl.FlashDuration = val.Float()
-
-			if pl.FlashDuration > 0 {
-				if len(p.gameState.flyingFlashbangs) == 0 {
-					return
-				}
-
-				flashbang := p.gameState.flyingFlashbangs[0]
-				flashbang.flashedEntityIDs = append(flashbang.flashedEntityIDs, pl.EntityID)
-			}
-		})
-
-		p.bindPlayerWeaponsS2(pawnEntity, pl)
-
-		pawnEntity.Property("m_pWeaponServices.m_hActiveWeapon").OnUpdate(func(val st.PropertyValue) {
-			pl.IsReloading = false
-		})
-
-		pawnEntity.Property("m_bIsDefusing").OnUpdate(func(val st.PropertyValue) {
-			pl.IsDefusing = val.BoolVal()
-		})
-
-		spottedByMaskProp := pawnEntity.Property("m_bSpottedByMask.0000")
-		if spottedByMaskProp != nil {
-			spottersChanged := func(val st.PropertyValue) {
-				p.eventDispatcher.Dispatch(events.PlayerSpottersChanged{Spotted: pl})
-			}
-
-			spottedByMaskProp.OnUpdate(spottersChanged)
-			pawnEntity.Property("m_bSpottedByMask.0001").OnUpdate(spottersChanged)
+	pawnEntity.Property("m_flFlashDuration").OnUpdate(func(val st.PropertyValue) {
+		pl := getPlayerFromPawnEntity(pawnEntity)
+		if pl == nil {
+			return
+		}
+		if val.Float() == 0 {
+			pl.FlashTick = 0
+		} else {
+			pl.FlashTick = p.gameState.ingameTick
 		}
 
-		pawnEntity.OnDestroy(func() {
-			pl.IsConnected = false
-		})
+		pl.FlashDuration = val.Float()
+
+		if pl.FlashDuration > 0 {
+			if len(p.gameState.flyingFlashbangs) == 0 {
+				return
+			}
+
+			flashbang := p.gameState.flyingFlashbangs[0]
+			flashbang.flashedEntityIDs = append(flashbang.flashedEntityIDs, pl.EntityID)
+		}
+	})
+
+	pawnEntity.Property("m_pWeaponServices.m_hActiveWeapon").OnUpdate(func(val st.PropertyValue) {
+		pl := getPlayerFromPawnEntity(pawnEntity)
+		if pl == nil {
+			return
+		}
+		pl.IsReloading = false
+	})
+
+	pawnEntity.Property("m_bIsDefusing").OnUpdate(func(val st.PropertyValue) {
+		pl := getPlayerFromPawnEntity(pawnEntity)
+		if pl == nil {
+			return
+		}
+		pl.IsDefusing = val.BoolVal()
+	})
+
+	spottedByMaskProp := pawnEntity.Property("m_bSpottedByMask.0000")
+	if spottedByMaskProp != nil {
+		spottersChanged := func(val st.PropertyValue) {
+			pl := getPlayerFromPawnEntity(pawnEntity)
+			if pl == nil {
+				return
+			}
+
+			p.eventDispatcher.Dispatch(events.PlayerSpottersChanged{Spotted: pl})
+		}
+
+		spottedByMaskProp.OnUpdate(spottersChanged)
+		pawnEntity.Property("m_bSpottedByMask.0001").OnUpdate(spottersChanged)
+	}
+
+	pawnEntity.OnDestroy(func() {
+		pl := getPlayerFromPawnEntity(pawnEntity)
+		if pl == nil {
+			return
+		}
+		pl.IsConnected = false
 	})
 }
 


### PR DESCRIPTION
Alternative to fix https://github.com/markus-wa/demoinfocs-golang/pull/467.

This PR moves the logic inside the `OnUpdate` callback of `m_hController` outside to avoid calling pawn entity properties lifecycle when we should not.
The pawn entity props that we need to listen now retrieve the player associated with the pawn entity from the current `m_hController` prop value.
