### PR TITLE
datatables cs2: update equipment owner

### DIFF
--- a/pkg/demoinfocs/datatables.go
+++ b/pkg/demoinfocs/datatables.go
@@ -951,6 +951,7 @@ func (p *parser) bindWeaponS2(entity st.Entity) {
 	entity.Property("m_hOwnerEntity").OnUpdate(func(val st.PropertyValue) {
 		weaponOwner := p.GameState().Participants().FindByPawnHandle(val.Handle())
 		if weaponOwner == nil {
+			equipment.Owner = nil
 			return
 		}
 
@@ -974,6 +975,7 @@ func (p *parser) bindWeaponS2(entity st.Entity) {
 		}
 
 		lastMoneyIncreased = false
+		equipment.Owner = nil
 		delete(p.gameState.weapons, entityID)
 	})
 


### PR DESCRIPTION
This relates to #472. 
This PR sets an equipment's owner to nil in cases where the equipment is destroyed or dropped, making `GameState().Weapons()` give a _slightly more_ correct view of a player's weapons.

Note: in my experience it still shows duplicate knives and starter pistols.

EDIT: I wonder if the duplicate starter weapons are due to player deaths? 🤔 