### PR TITLE
fix: possible panic due to incorrect weapon's owner

### DIFF
--- a/pkg/demoinfocs/datatables.go
+++ b/pkg/demoinfocs/datatables.go
@@ -1015,20 +1015,18 @@ func (p *parser) bindWeaponS2(entity st.Entity) {
 	// - The player is inside the buy zone
 	// - The player's money has increased AND the weapon entity is destroyed at the same tick (unfortunately the money is updated first)
 	var (
-		owner               *common.Player
 		oldOwnerMoney       int
 		lastMoneyUpdateTick int
 		lastMoneyIncreased  bool
 	)
 
 	entity.Property("m_hOwnerEntity").OnUpdate(func(val st.PropertyValue) {
-		weaponOwner := p.GameState().Participants().FindByPawnHandle(val.Handle())
-		if weaponOwner == nil {
+		owner := p.GameState().Participants().FindByPawnHandle(val.Handle())
+		if owner == nil {
 			equipment.Owner = nil
 			return
 		}
 
-		owner = weaponOwner
 		oldOwnerMoney = owner.Money()
 
 		owner.Entity.Property("m_pInGameMoneyServices.m_iAccount").OnUpdate(func(val st.PropertyValue) {
@@ -1040,6 +1038,7 @@ func (p *parser) bindWeaponS2(entity st.Entity) {
 	})
 
 	entity.OnDestroy(func() {
+		owner := p.GameState().Participants().FindByPawnHandle(entity.PropertyValueMust("m_hOwnerEntity").Handle())
 		if owner != nil && owner.IsInBuyZone() && p.GameState().IngameTick() == lastMoneyUpdateTick && lastMoneyIncreased {
 			p.eventDispatcher.Dispatch(events.ItemRefund{
 				Player: owner,


### PR DESCRIPTION
Hi!

The crash has been reported [here](https://github.com/akiver/cs-demo-manager/issues/724).
The owner may point to a disconnected player, this PR retrieves the good owner when the weapon entity is destroyed.

Thanks