### PR TITLE
fix: Participants().Playing() may returned disconnected players

### DIFF
--- a/pkg/demoinfocs/common/player.go
+++ b/pkg/demoinfocs/common/player.go
@@ -37,6 +37,15 @@ type Player struct {
 }
 
 func (p *Player) PlayerPawnEntity() st.Entity {
+	pawn, exists := p.Entity.PropertyValue("m_hPawn")
+	if !exists {
+		return nil
+	}
+
+	if pawn.Handle() == constants.InvalidEntityHandleSource2 {
+		return nil
+	}
+
 	playerPawn, exists := p.Entity.PropertyValue("m_hPlayerPawn")
 	if !exists {
 		return nil

--- a/pkg/demoinfocs/common/player_test.go
+++ b/pkg/demoinfocs/common/player_test.go
@@ -431,6 +431,7 @@ func TestPlayer_Velocity(t *testing.T) {
 func createPlayerForVelocityTest() *Player {
 	controllerEntity := entityWithProperties([]fakeProp{
 		{propName: "m_hPlayerPawn", value: st.PropertyValue{Any: uint64(1), S2: true}},
+		{propName: "m_hPawn", value: st.PropertyValue{Any: uint64(1), S2: true}},
 	})
 	pawnEntity := new(stfake.Entity)
 	position := r3.Vector{X: 20, Y: 300, Z: 100}

--- a/pkg/demoinfocs/datatables.go
+++ b/pkg/demoinfocs/datatables.go
@@ -514,6 +514,12 @@ func (p *parser) getOrCreatePlayerFromControllerEntity(controllerEntity st.Entit
 func (p *parser) bindNewPlayerControllerS2(controllerEntity st.Entity) {
 	pl := p.getOrCreatePlayerFromControllerEntity(controllerEntity)
 
+	controllerEntity.Property("m_hPawn").OnUpdate(func(val st.PropertyValue) {
+		if val.Handle() == constants.InvalidEntityHandleSource2 {
+			pl.IsConnected = false
+		}
+	})
+
 	controllerEntity.Property("m_iTeamNum").OnUpdate(func(val st.PropertyValue) {
 		pl.Team = common.Team(val.S2UInt64())
 		pl.TeamState = p.gameState.Team(pl.Team)


### PR DESCRIPTION
It should fix #481, #458 and this [issue](https://github.com/akiver/cs-demo-manager/issues/723) (same problem as #458).

I noticed this thing with the demo from https://github.com/akiver/cs-demo-manager/issues/723:

![disco](https://github.com/markus-wa/demoinfocs-golang/assets/1842524/bd0ec51a-7f04-41d3-a1b7-29a69f82de35)

As you can see the last player is disconnected but still visible on the scoreboard.
When this kind of disconnection happens, the player pawn entity is "invalidated" - it points to a `CBaseViewModel` instance rather than a `CCSPlayerPawn` one.
This is why in #458 and https://github.com/akiver/cs-demo-manager/issues/723 the properties don't exist and it panics.

This PR:
- Update `player.IsConnected` when the pawn entity is invalid
- Verify that `m_hPawn` is valid, otherwise it means `m_hPlayerPawn` will point to a `CBaseViewModel`

Thanks


