### PR TITLE
fix: weapon may be incorrect in kill events

### DIFF
--- a/pkg/demoinfocs/common/equipment.go
+++ b/pkg/demoinfocs/common/equipment.go
@@ -281,7 +281,18 @@ func MapEquipment(eqName string) EquipmentType {
 		wep = EqKnife
 	} else {
 		// If the eqName isn't known it will be EqUnknown as that is the default value for EquipmentType
-		wep = eqNameToWeapon[eqName]
+		if strings.HasPrefix(eqName, "m4a1_silencer") {
+			wep = EqM4A1
+		} else if strings.HasPrefix(eqName, "vesthelm") {
+			wep = EqHelmet
+		} else {
+			for name := range eqNameToWeapon {
+				if strings.HasPrefix(eqName, name) {
+					wep = eqNameToWeapon[name]
+					break
+				}
+			}
+		}
 	}
 
 	return wep

--- a/pkg/demoinfocs/common/equipment_test.go
+++ b/pkg/demoinfocs/common/equipment_test.go
@@ -24,6 +24,8 @@ func TestMapEquipment(t *testing.T) {
 	assert.Equal(t, EqKnife, MapEquipment("weapon_knife_butterfly"), "'weapon_knife_butterfly' should be mapped to EqKnife")
 	assert.Equal(t, EqM4A4, MapEquipment("weapon_m4a1"), "'weapon_m4a1' should be mapped to EqM4A4") // This is correct, weapon_m4a1 == M4A4
 	assert.Equal(t, EqM4A1, MapEquipment("weapon_m4a1_silencer"), "'weapon_m4a1_silencer' should be mapped to EqM4A1")
+	assert.Equal(t, EqKevlar, MapEquipment("weapon_vest"), "'weapon_vest' should be mapped to EqKevlar")
+	assert.Equal(t, EqHelmet, MapEquipment("weapon_vesthelm"), "'weapon_vesthelm' should be mapped to EqHelmet")
 	assert.Equal(t, EqUnknown, MapEquipment("asdf"), "'asdf' should be mapped to EqUnknown")
 }
 


### PR DESCRIPTION
Bug reported [here](https://github.com/akiver/cs-demo-manager/issues/721).

It's a weird CS2 bug - the weapon's name in `player_death` events can have a suffix that is part of the killer's name.

Example:
```go
fmt.Println(geh.gameState().IngameTick(), killer.Name, data["weapon"].GetValString())
```

Output:
```
1631 𝑽𝑰𝑷 落日下恋人相拥，无人在意这是黄昏 deagle_vip
1920 goparojotu3 deagle
2043 𝑽𝑰𝑷 罗锅 deagle_vip
2348 老恋歌 glock
2378 罗锅被查内务出列 usp_silencer
2491 年𝑽𝑰𝑷 修记者 glock_vip
2916 喝杯奶茶再说吧 usp_silencer
3326 罗锅被查内务出列 usp_silencer
3419 老恋歌 glock
4402 年𝑽𝑰𝑷 修记者 glock_vip
4898 𝑽𝑰𝑷 呢嘛，叔输输。 deagle_vip
5160 𝑽𝑰𝑷 落日下恋人相拥，无人在意这是黄昏 deagle_vip
5291 goparojotu3 deagle
5554 goparojotu3 deagle
5647 𝑽𝑰𝑷 罗锅 deagle_vip
5674 goparojotu3 deagle
6216 𝑽𝑰𝑷 怎么有人打GO都能破防啊 glock_vip
6326 𝑽𝑰𝑷 罗锅 deagle_vip
6601 喝杯奶茶再说吧 usp_silencer
6906 老恋歌 knife_karambit
6923 𝑽𝑰𝑷 落日下恋人相拥，无人在意这是黄昏 deagle_vip
6970 𝑽𝑰𝑷 怎么有人打GO都能破防啊 glock_vip
9611 𝑽𝑰𝑷 罗锅 usp_silencer_vip
```

It seems that only `player_death` events are affected.

I understand if you want to avoid merging it as it's a CS2 bug.