### PR TITLE
fix: possible invalid weapon in kill events

### DIFF
--- a/pkg/demoinfocs/common/equipment.go
+++ b/pkg/demoinfocs/common/equipment.go
@@ -287,7 +287,7 @@ func MapEquipment(eqName string) EquipmentType {
 			wep = EqHelmet
 		} else {
 			for name := range eqNameToWeapon {
-				if strings.HasPrefix(eqName, name) {
+				if strings.HasPrefix(eqName, name) || strings.HasSuffix(eqName, name) {
 					wep = eqNameToWeapon[name]
 					break
 				}

--- a/pkg/demoinfocs/common/equipment_test.go
+++ b/pkg/demoinfocs/common/equipment_test.go
@@ -29,6 +29,14 @@ func TestMapEquipment(t *testing.T) {
 	assert.Equal(t, EqUnknown, MapEquipment("asdf"), "'asdf' should be mapped to EqUnknown")
 }
 
+func TestWeirdCS2Values(t *testing.T) {
+	assert.Equal(t, EqDeagle, MapEquipment("deagle_vip"), "'deagle_vip' should be mapped to EqDeagle")
+	assert.Equal(t, EqUSP, MapEquipment("usp_silencer_vip"), "'usp_silencer_vip' should be mapped to EqUSP")
+	assert.Equal(t, EqUSP, MapEquipment("5e_vip_usp_silencer"), "'5e_vip_usp_silencer' should be mapped to EqUSP")
+	assert.Equal(t, EqAK47, MapEquipment("5e_vip_ak47"), "'5e_vip_ak47' should be mapped to EqAK47")
+	assert.Equal(t, EqDeagle, MapEquipment("5e_default_deagle"), "'5e_default_deagle' should be mapped to EqDeagle")
+}
+
 func TestEquipment_Class(t *testing.T) {
 	assert.Equal(t, EqClassUnknown, NewEquipment(EqUnknown).Class(), "EqUnknown should have the class EqClassUnknown")
 	assert.Equal(t, EqClassPistols, NewEquipment(EqP2000).Class(), "EqP2000 should have the class EqClassPistols")


### PR DESCRIPTION
Following https://github.com/markus-wa/demoinfocs-golang/pull/490.

- It's not always a suffix - it can be a prefix.
- The suffix/prefix is not the killer's name but the words `vip` or `default` (there may be others).
- The team's name may also be part of the suffix/prefix

Noticed with demos coming from https://github.com/akiver/cs-demo-manager/issues/727.  
Example with this one https://mega.nz/file/LZFlhATB#aCO-g1hoGohndAKXJVUHzLCcbyzH-n7cGi9ZWO5UdSM.

Weapon's name from game events:
```
5e_vip_usp_silencer
5e_default_deagle
5e_vip_xm1014
5e_default_mp9
5e_default_galilar
5e_vip_m4a1_silencer
5e_vip_ak47
```