### PR TITLE
fix: set player connected flag to false when controller is destroyed

### DIFF
--- a/pkg/demoinfocs/datatables.go
+++ b/pkg/demoinfocs/datatables.go
@@ -526,6 +526,7 @@ func (p *parser) bindNewPlayerControllerS2(controllerEntity st.Entity) {
 	})
 
 	controllerEntity.OnDestroy(func() {
+		pl.IsConnected = false
 		delete(p.gameState.playersByEntityID, controllerEntity.ID())
 	})
 }


### PR DESCRIPTION
Bot controller entities can be destroyed:


![d](https://github.com/markus-wa/demoinfocs-golang/assets/1842524/50667eff-1ab3-422d-b632-e0309754b1ae)

```
96322 player_controller_destroy 12 Baroud 0
107866 player_controller_destroy 14 Bank 0
```

If we don't update the prop `Connected`, the bot will still be in the slice returned by `Playing()`.   
As a result, calling a player's function that relies on its pawn entity such as `EquipmentValueCurrent()` may result in a panic as the pawn entity doesn't exists anymore.

Noticed with this demo https://mega.nz/file/uBdF3TBT#aoGpmJ6PKaNIMqPdZsVxHyhiv7DbxO3M9jJNWAOIhb0 and the following code:

```go
p.RegisterEventHandler(func(e events.RoundStart) {
  fmt.Println(p.GameState().TeamCounterTerrorists().CurrentEquipmentValue())
  fmt.Println(p.GameState().TeamTerrorists().CurrentEquipmentValue())
})
```

ref https://github.com/akiver/cs-demo-manager/issues/727