### PR TITLE
fix: possible wrong players team

### DIFF
--- a/pkg/demoinfocs/game_events.go
+++ b/pkg/demoinfocs/game_events.go
@@ -668,6 +668,14 @@ func (geh gameEventHandler) playerTeam(data map[string]*msg.CSVCMsg_GameEventKey
 
 	if player != nil {
 		if player.Team != newTeam {
+			if geh.parser.isSource2() {
+				// The "team" field may be incorrect with CS2 demos.
+				// As the prop m_iTeamNum (bound to player.Team) is updated before the game-event is fired we can force
+				// the correct team here.
+				// https://github.com/markus-wa/demoinfocs-golang/issues/494
+				newTeam = player.Team
+			}
+
 			player.Team = newTeam
 		}
 


### PR DESCRIPTION
For some reason, the `team` field from `player_team` events may be incorrect.  
That's why players were assigned to the wrong team.

ref #494
ref #492