### PR TITLE
ci: run on Go 1.20.x

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
     - name: Install Go
       uses: actions/setup-go@v2
       with:
-        go-version: 1.21.x
+        go-version: 1.20.x
 
     - name: Install Reviewdog
       uses: reviewdog/action-setup@v1


### PR DESCRIPTION
To make sure we stay compatible with 1.20