### PR TITLE
feat: skip unknown demo commands messages

### DIFF
--- a/pkg/demoinfocs/events/events.go
+++ b/pkg/demoinfocs/events/events.go
@@ -570,6 +570,7 @@ const (
 	WarnTypeBombsiteUnknown            // may occur on de_grind for bombsite B as the bounding box of the bombsite is wrong
 	WarnTypeTeamSwapPlayerNil          // TODO: figure out why this happens
 	WarnTypeGameEventBeforeDescriptors // may occur in POV demos
+	WarnUnknownDemoCommandMessageType  // occur when we have an unknown EDemoCommands message type, the protobuf messages probably need to be updated
 
 	// WarnTypeMissingNetMessageDecryptionKey occurs when encrypted net-messages are encountered and the decryption key is missing.
 	// See ParserConfig.NetMessageDecryptionKey

--- a/pkg/demoinfocs/parsing.go
+++ b/pkg/demoinfocs/parsing.go
@@ -340,6 +340,17 @@ func (p *parser) parseFrameS2() bool {
 
 	size := p.bitReader.ReadVarInt32()
 
+	msgCreator := demoCommandMsgsCreators[msgType]
+	if msgCreator == nil {
+		p.eventDispatcher.Dispatch(events.ParserWarn{
+			Message: fmt.Sprintf("skipping unknown demo commands message type with value %d", msgType),
+			Type:    events.WarnUnknownDemoCommandMessageType,
+		})
+		p.bitReader.Skip(int(size) << 3)
+
+		return true
+	}
+
 	buf := p.bitReader.ReadBytes(int(size))
 
 	if msgCompressed {
@@ -357,7 +368,7 @@ func (p *parser) parseFrameS2() bool {
 		}
 	}
 
-	msg := demoCommandMsgsCreators[msgType]()
+	msg := msgCreator()
 
 	if msg == nil {
 		panic(fmt.Sprintf("Unknown demo command: %d", msgType))


### PR DESCRIPTION
To avoid panicking when the protobuf messages need to be updated