### PR TITLE
workaround for `userid` in `player_connect`

### DIFF
--- a/pkg/demoinfocs/game_events.go
+++ b/pkg/demoinfocs/game_events.go
@@ -641,10 +641,6 @@ func (geh gameEventHandler) HostageRescuedAll(map[string]*msg.CSVCMsg_GameEventK
 }
 
 func (geh gameEventHandler) playerConnect(data map[string]*msg.CSVCMsg_GameEventKeyT) {
-	if geh.parser.isSource2() {
-		return
-	}
-
 	pl := common.PlayerInfo{
 		UserID:       int(data["userid"].GetValShort()),
 		Name:         data["name"].GetValString(),
@@ -662,7 +658,14 @@ func (geh gameEventHandler) playerConnect(data map[string]*msg.CSVCMsg_GameEvent
 		}
 	}
 
-	geh.parser.setRawPlayer(int(data["index"].GetValByte()), pl)
+	var playerIndex int
+	if geh.parser.isSource2() {
+		playerIndex = pl.UserID
+	} else {
+		playerIndex = int(data["index"].GetValByte())
+	}
+
+	geh.parser.setRawPlayer(playerIndex, pl)
 }
 
 func (geh gameEventHandler) playerDisconnect(data map[string]*msg.CSVCMsg_GameEventKeyT) {

--- a/pkg/demoinfocs/game_events.go
+++ b/pkg/demoinfocs/game_events.go
@@ -2,6 +2,7 @@ package demoinfocs
 
 import (
 	"fmt"
+	"math"
 
 	"github.com/golang/geo/r3"
 	"github.com/markus-wa/go-unassert"
@@ -661,6 +662,9 @@ func (geh gameEventHandler) playerConnect(data map[string]*msg.CSVCMsg_GameEvent
 	var playerIndex int
 	if geh.parser.isSource2() {
 		playerIndex = pl.UserID
+		if !pl.IsFakePlayer && !pl.IsHltv && pl.XUID > 0 && pl.UserID <= math.MaxUint8 {
+			pl.UserID |= math.MaxUint8 << 8
+		}
 	} else {
 		playerIndex = int(data["index"].GetValByte())
 	}


### PR DESCRIPTION
Since the last update, I've been encountering many demos in which after a player has disconnected, and then reconnected, they wouldn't be registered in the `rawPlayers` field. Thus, in many cases, there were `nil` players in some events (e. g. all grenade events).

I investigated this a little and found out that seemingly the only place we could get information to add the player back to the `rawPlayers` (at least in particular demos I've been using) is inside the `player_connect` handler, which was disabled for s2 demos in #499. I'm assuming this was done because the user ids for players have been changed in the February, 6 update from being in the lower digits to 652xx.

I'm not sure what exactly has been changed in the last update (my guess is the `userinfo` string table is not parsed as often or not at all in some situations anymore?), but I've implemented a workaround that allows us to use the `player_connect` again by noticing that the old used ids are still present in the new ones -- they are the least significant byte of the two, and the other one is just set to 255.

Here's an [example demo](http://replay189.valve.net/730/003682163088783573210_2005656758.dem.bz2). On tick number 48430 `kefu_.` disconnects, then at tick 50731 we get a `player_connect` event, and then at tick 51237, when the `m_iConnected` is updated, `PlayerConnect` is dispatched (but, notably, we don't know the new user id at this point so the `rawPlayers` field doesn't get updated). This leads to `Thrower` being `nil` in the dispatched `HeExplode` event on tick 53754, which breaks at least my application 😄

This PR is more of an attempt to get some attention to the problem. There probably is a proper way to handle the situation without resorting to this hacky method, which might or might not work in the future. But I've already tested this implementation (and by "tested" I mean I've been using it in the production since yesterday) and was able to lower the error count in the parsed matches tenfold, so maybe that would help someone else in a similar situation.