### PR TITLE
fix: hostage leader possibly nil

### DIFF
--- a/pkg/demoinfocs/common/hostage.go
+++ b/pkg/demoinfocs/common/hostage.go
@@ -3,6 +3,7 @@ package common
 import (
 	"github.com/golang/geo/r3"
 
+	"github.com/markus-wa/demoinfocs-golang/v4/pkg/demoinfocs/constants"
 	st "github.com/markus-wa/demoinfocs-golang/v4/pkg/demoinfocs/sendtables"
 )
 
@@ -54,7 +55,12 @@ func (hostage *Hostage) Health() int {
 // Returns nil if the hostage is not following a player.
 func (hostage *Hostage) Leader() *Player {
 	if hostage.demoInfoProvider.IsSource2() {
-		return hostage.demoInfoProvider.FindPlayerByPawnHandle(getUInt64(hostage.Entity, "m_leader"))
+		leaderHandle := getUInt64(hostage.Entity, "m_leader")
+		if leaderHandle != constants.InvalidEntityHandleSource2 {
+			return hostage.demoInfoProvider.FindPlayerByPawnHandle(leaderHandle)
+		}
+
+		return hostage.demoInfoProvider.FindPlayerByPawnHandle(getUInt64(hostage.Entity, "m_hHostageGrabber"))
 	}
 
 	return hostage.demoInfoProvider.FindPlayerByHandle(uint64(getInt(hostage.Entity, "m_leader")))

--- a/pkg/demoinfocs/common/hostage_test.go
+++ b/pkg/demoinfocs/common/hostage_test.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
+	"github.com/markus-wa/demoinfocs-golang/v4/pkg/demoinfocs/constants"
 	st "github.com/markus-wa/demoinfocs-golang/v4/pkg/demoinfocs/sendtables"
 )
 
@@ -15,6 +16,29 @@ func TestHostage_Leader(t *testing.T) {
 		playersByHandle: map[uint64]*Player{10: player},
 	}
 	hostage := hostageWithProperty("m_leader", st.PropertyValue{IntVal: 10}, provider)
+
+	assert.Equal(t, player, hostage.Leader())
+}
+
+func TestHostage_LeaderWithInvalidHandleS2(t *testing.T) {
+	player := new(Player)
+	player.EntityID = 10
+	provider := demoInfoProviderMock{
+		playersByHandle: map[uint64]*Player{10: player},
+		isSource2:       true,
+	}
+	hostage := hostageWithProperties([]fakeProp{
+		{
+			propName: "m_leader",
+			value:    st.PropertyValue{Any: uint64(constants.InvalidEntityHandleSource2)},
+			isNil:    false,
+		},
+		{
+			propName: "m_hHostageGrabber",
+			value:    st.PropertyValue{Any: uint64(10)},
+			isNil:    false,
+		},
+	}, provider)
 
 	assert.Equal(t, player, hostage.Leader())
 }
@@ -33,4 +57,8 @@ func TestHostage_Health(t *testing.T) {
 
 func hostageWithProperty(propName string, value st.PropertyValue, provider demoInfoProviderMock) *Hostage {
 	return &Hostage{Entity: entityWithProperty(propName, value), demoInfoProvider: provider}
+}
+
+func hostageWithProperties(properties []fakeProp, provider demoInfoProviderMock) *Hostage {
+	return &Hostage{Entity: entityWithProperties(properties), demoInfoProvider: provider}
 }


### PR DESCRIPTION
ref https://github.com/akiver/cs-demo-manager/issues/839

`hostage.Leader()` may return `nil` when a player is grabbing a hostage.
To match the CSGO behavior (it's not nil) I fallback to the new CS2 prop `m_hHostageGrabber`.
