### PR TITLE
fix: incomplete stringtables parsing

### DIFF
--- a/pkg/demoinfocs/demoinfocs_test.go
+++ b/pkg/demoinfocs/demoinfocs_test.go
@@ -549,6 +549,10 @@ func testDemoSet(t *testing.T, path string) {
 						t.Log("expected known issue with missing item definition index occurred:", warn.Message)
 						return
 
+					case events.WarnTypeStringTableParsingFailure:
+						t.Log("expected known issue with stringtables parsing occurred:", warn.Message)
+						return
+
 					case events.WarnTypeGameEventBeforeDescriptors:
 						if strings.Contains(name, "POV-orbit-skytten-vs-cloud9-gfinity15sm1-nuke.dem") {
 							t.Log("expected known issue for POV demos occurred:", warn.Message)

--- a/pkg/demoinfocs/events/events.go
+++ b/pkg/demoinfocs/events/events.go
@@ -196,7 +196,7 @@ type GrenadeEvent struct {
 	GrenadeType     common.EquipmentType
 	Grenade         *common.Equipment // Maybe nil for InfernoStart & InfernoExpired since we don't know the thrower (at least in old demos)
 	Position        r3.Vector
-	Thrower         *common.Player // May be nil if the demo is partially corrupt (player is 'unconnected', see #156 and #172).
+	Thrower         *common.Player // May be nil with POV demos or if the demo is partially corrupt (player is 'unconnected', see #156 and #172).
 	GrenadeEntityID int
 }
 
@@ -301,7 +301,7 @@ const (
 // BombEvent contains the common attributes of bomb events. Dont register
 // handlers on this tho, you want BombEventIf for that.
 type BombEvent struct {
-	Player *common.Player
+	Player *common.Player // Can be nil with POV demos
 	Site   Bombsite
 }
 
@@ -414,7 +414,7 @@ const (
 
 // PlayerHurt signals that a player has been damaged.
 type PlayerHurt struct {
-	Player            *common.Player // May be nil if the demo is partially corrupt (player is 'unconnected', see #156 and #172).
+	Player            *common.Player // May be nil with POV demos or if the demo is partially corrupt (player is 'unconnected', see #156 and #172).
 	Attacker          *common.Player // May be nil if the player is taking world damage (e.g. fall damage) or if the demo is partially corrupt (player is 'unconnected', see #156 and #172).
 	Health            int
 	Armor             int
@@ -583,6 +583,7 @@ const (
 
 	WarnTypeUnknownEquipmentIndex
 	WarnTypeMissingItemDefinitionIndex
+	WarnTypeStringTableParsingFailure // Should happen only with CS2 POV demos
 )
 
 // ParserWarn signals that a non-fatal problem occurred during parsing.

--- a/pkg/demoinfocs/game_events.go
+++ b/pkg/demoinfocs/game_events.go
@@ -493,13 +493,12 @@ func (geh gameEventHandler) playerHurt(data map[string]*msg.CSVCMsg_GameEventKey
 		armorDamageTaken = 100
 	}
 
-	if player != nil && (!geh.parser.isSource2() || (player.PlayerPawnEntity() != nil)) {
-		// m_iHealth & m_ArmorValue check for CS2 POV demos
-		if health == 0 && (!geh.parser.isSource2() || player.PlayerPawnEntity().Property("m_iHealth") != nil) {
+	if player != nil {
+		if health == 0 {
 			healthDamageTaken = player.Health()
 		}
 
-		if armor == 0 && (!geh.parser.isSource2() || player.PlayerPawnEntity().Property("m_ArmorValue") != nil) {
+		if armor == 0 {
 			armorDamageTaken = player.Armor()
 		}
 	}

--- a/pkg/demoinfocs/stringtables.go
+++ b/pkg/demoinfocs/stringtables.go
@@ -294,7 +294,9 @@ const (
 )
 
 // Parse a string table data blob, returning a list of item updates.
-func parseStringTable(
+//
+//nolint:funlen,gocognit
+func (p *parser) parseStringTable(
 	buf []byte,
 	numUpdates int32,
 	name string,
@@ -307,6 +309,16 @@ func parseStringTable(
 	if len(buf) == 0 {
 		return items
 	}
+
+	defer func() {
+		err := recover()
+		if err != nil {
+			p.eventDispatcher.Dispatch(events.ParserWarn{
+				Type:    events.WarnTypeStringTableParsingFailure,
+				Message: "failed to parse stringtable properly",
+			})
+		}
+	}()
 
 	// Create a reader for the buffer
 	r := bit.NewSmallBitReader(bytes.NewReader(buf))
@@ -372,41 +384,42 @@ func parseStringTable(
 			if len(keys) > stringtableKeyHistorySize {
 				keys = keys[1:]
 			}
+		}
 
-			// Some entries have a value.
-			hasValue := r.ReadBit()
-			if hasValue {
-				bitSize := uint(0)
-				isCompressed := false
+		// Some entries have a value.
+		hasValue := r.ReadBit()
+		//nolint:nestif
+		if hasValue {
+			bitSize := uint(0)
+			isCompressed := false
 
-				if userDataFixed {
-					bitSize = uint(userDataSize)
-				} else {
-					if (flags & 0x1) != 0 {
-						isCompressed = r.ReadBit()
-					}
-
-					if variantBitCount {
-						bitSize = r.ReadUBitInt() * 8
-					} else {
-						bitSize = r.ReadInt(17) * 8
-					}
+			if userDataFixed {
+				bitSize = uint(userDataSize)
+			} else {
+				if (flags & 0x1) != 0 {
+					isCompressed = r.ReadBit()
 				}
 
-				value = r.ReadBits(int(bitSize))
-
-				if isCompressed {
-					tmp, err := snappy.Decode(nil, value)
-					if err != nil {
-						panic(fmt.Sprintf("unable to decode snappy compressed stringtable item (%s, %d, %s): %s", name, index, key, err))
-					}
-
-					value = tmp
+				if variantBitCount {
+					bitSize = r.ReadUBitInt() * 8
+				} else {
+					bitSize = r.ReadInt(17) * 8
 				}
 			}
 
-			items = append(items, &stringTableItem{index, key, value})
+			value = r.ReadBits(int(bitSize))
+
+			if isCompressed {
+				tmp, err := snappy.Decode(nil, value)
+				if err != nil {
+					panic(fmt.Sprintf("unable to decode snappy compressed stringtable item (%s, %d, %s): %s", name, index, key, err))
+				}
+
+				value = tmp
+			}
 		}
+
+		items = append(items, &stringTableItem{index, key, value})
 	}
 
 	return items
@@ -415,7 +428,7 @@ func parseStringTable(
 var instanceBaselineKeyRegex = regexp.MustCompile(`^\d+:\d+$`)
 
 func (p *parser) processStringTableS2(tab createStringTable) {
-	items := parseStringTable(tab.StringData, tab.GetNumEntries(), tab.GetName(), tab.GetUserDataFixedSize(), tab.GetUserDataSize(), tab.GetFlags(), tab.GetUsingVarintBitcounts())
+	items := p.parseStringTable(tab.StringData, tab.GetNumEntries(), tab.GetName(), tab.GetUserDataFixedSize(), tab.GetUserDataSize(), tab.GetFlags(), tab.GetUsingVarintBitcounts())
 
 	for _, item := range items {
 		switch tab.GetName() {


### PR DESCRIPTION
fix https://github.com/markus-wa/demoinfocs-golang/issues/539 https://github.com/markus-wa/demoinfocs-golang/issues/532 https://github.com/markus-wa/demoinfocs-golang/issues/522 and maybe https://github.com/markus-wa/demoinfocs-golang/issues/525 (i can't reproduce the issue).
Tests of the project https://github.com/akiver/cs-demo-analyzer/pull/10/checks are also green.

This PR reverts the logic in `parseStringTable` introduced in v4.1.0 and instead if a panic occurs while parsing a stringtable, we recover and dispatch a warning.
I'm not 100% sure but sometimes data seems corrupted and skipping it seems fine.
I didn't find a logic that doesn't panic when parsing stringtables for both CSTV and POV demos, that's why I decided to go for the recover solution.
