### PR TITLE
fix: stable sort messages

### DIFF
--- a/pkg/demoinfocs/s2_commands.go
+++ b/pkg/demoinfocs/s2_commands.go
@@ -320,7 +320,7 @@ func (p *parser) handleDemoPacket(pack *msgs2.CDemoPacket) {
 		ms = append(ms, pendingMessage{t, buf})
 	}
 
-	sort.Slice(ms, func(i, j int) bool {
+	sort.SliceStable(ms, func(i, j int) bool {
 		return ms[i].priority() < ms[j].priority() // TODO: taken from dotabuff/manta. do we really need this?
 	})
 


### PR DESCRIPTION
Fixes #555 

All messages (SVC/UserMessages/GameEvents etc.) found in a demo packet are sorted based on their priority (ported from [dotabuff/manta](https://github.com/dotabuff/manta)). The used sorting function `sort.Slice()`  performs an unstable sort which might cause messages of the same priority to be reordered in arbitrary order.  This PR changes sorting function to `sort.SliceStable()`.

This unstable sort behaviour breaks POV demos while not affecting normal demos for some reason - someone can investigate further.

I tested it on broken POV demo that was provided with issue and 9 more that I had available - they all correctly parsed after this change. 


