### PR TITLE
feat: add BulletDamage event + chat messages events

### DIFF
--- a/pkg/demoinfocs/events/events.go
+++ b/pkg/demoinfocs/events/events.go
@@ -399,6 +399,20 @@ type HostageStateChanged struct {
 	Hostage  *common.Hostage
 }
 
+// BulletDamage signals that a bullet did some damage.
+// Available only with CS2 demos after the 22/07/2024 update.
+type BulletDamage struct {
+	Attacker        *common.Player
+	Victim          *common.Player
+	Distance        float32
+	DamageDirX      float32
+	DamageDirY      float32
+	DamageDirZ      float32
+	NumPenetrations int
+	IsNoScope       bool
+	IsAttackerInAir bool
+}
+
 // HitGroup is the type for the various HitGroupXYZ constants.
 //
 // See PlayerHurt.

--- a/pkg/demoinfocs/game_events.go
+++ b/pkg/demoinfocs/game_events.go
@@ -208,6 +208,7 @@ func newGameEventHandler(parser *parser, ignoreBombsiteIndexNotFound bool) gameE
 		"bomb_pickup":                     delayIfNoPlayers(geh.bombPickup),      // Bomb picked up
 		"bomb_planted":                    delayIfNoPlayers(geh.bombPlanted),     // Plant finished
 		"bot_takeover":                    delay(geh.botTakeover),                // Bot got taken over
+		"bullet_damage":                   delayIfNoPlayers(geh.bulletDamage),    // CS2 only
 		"buytime_ended":                   nil,                                   // Not actually end of buy time, seems to only be sent once per game at the start
 		"choppers_incoming_warning":       nil,                                   // Helicopters are coming (Danger zone mode)
 		"cs_intermission":                 nil,                                   // Dunno, only in locally recorded (POV) demo
@@ -651,6 +652,22 @@ func (geh gameEventHandler) hostageRescued(data map[string]*msg.CSVCMsg_GameEven
 
 func (geh gameEventHandler) HostageRescuedAll(map[string]*msg.CSVCMsg_GameEventKeyT) {
 	geh.dispatch(events.HostageRescuedAll{})
+}
+
+func (geh gameEventHandler) bulletDamage(data map[string]*msg.CSVCMsg_GameEventKeyT) {
+	event := events.BulletDamage{
+		Attacker:        geh.playerByUserID32(data["attacker"].GetValShort()),
+		Victim:          geh.playerByUserID32(data["victim"].GetValShort()),
+		Distance:        data["distance"].GetValFloat(),
+		DamageDirX:      data["damage_dir_x"].GetValFloat(),
+		DamageDirY:      data["damage_dir_y"].GetValFloat(),
+		DamageDirZ:      data["damage_dir_z"].GetValFloat(),
+		NumPenetrations: int(data["num_penetrations"].GetValShort()),
+		IsNoScope:       data["no_scope"].GetValBool(),
+		IsAttackerInAir: data["in_air"].GetValBool(),
+	}
+
+	geh.dispatch(event)
 }
 
 func (geh gameEventHandler) playerConnect(data map[string]*msg.CSVCMsg_GameEventKeyT) {

--- a/pkg/demoinfocs/parser.go
+++ b/pkg/demoinfocs/parser.go
@@ -427,6 +427,8 @@ func NewParserWithConfig(demostream io.Reader, config ParserConfig) Parser {
 	p.msgDispatcher.RegisterHandler(p.handleUpdateStringTableS2)
 	p.msgDispatcher.RegisterHandler(p.handleSetConVarS2)
 	p.msgDispatcher.RegisterHandler(p.handleServerRankUpdate)
+	p.msgDispatcher.RegisterHandler(p.handleMessageSayText)
+	p.msgDispatcher.RegisterHandler(p.handleMessageSayText2)
 
 	if config.MsgQueueBufferSize >= 0 {
 		p.initMsgQueue(config.MsgQueueBufferSize)


### PR DESCRIPTION
- feat: dispatch `BulletDamage` events added in the last update
- feat: add `SayText`/`SayText2` and `ChatMessage` events for CS2 demos. Chat messages are now available in recent Valve demos (and it's not encrypted like csgo).