### PR TITLE
fix: possible nil player in game events on rare occasion

### DIFF
--- a/pkg/demoinfocs/datatables.go
+++ b/pkg/demoinfocs/datatables.go
@@ -563,6 +563,7 @@ func (p *parser) bindNewPlayerControllerS2(controllerEntity st.Entity) {
 	pl := p.getOrCreatePlayerFromControllerEntity(controllerEntity)
 
 	controllerEntity.Property("m_iConnected").OnUpdate(func(val st.PropertyValue) {
+		pl := p.getOrCreatePlayerFromControllerEntity(controllerEntity)
 		state := val.S2UInt32()
 		wasConnected := pl.IsConnected
 		pl.IsConnected = state == 0


### PR DESCRIPTION
Make sure to create/update players in gameState (`playersByEntityID`, `playersByUserID`) on connection status changes.
Sometimes players raw info are not available on controller entity creation so it would result in missing players in `gameState.playersByUserID`.
It may be related to player disconnection as the affected player got disconnected at the beginning of the demo.

fix https://github.com/akiver/cs-demo-manager/issues/904
