### PR TITLE
Add Kukri's knife to equipment map

### DIFF
--- a/pkg/demoinfocs/common/equipment.go
+++ b/pkg/demoinfocs/common/equipment.go
@@ -573,4 +573,5 @@ var EquipmentIndexMapping = map[uint64]EquipmentType{
 	522: EqKnife,                    // weapon_knife_stiletto
 	523: EqKnife,                    // weapon_knife_widowmaker
 	525: EqKnife,                    // weapon_knife_skeleton
+	526: EqKnife,                    // weapon_knife_kukri
 }


### PR DESCRIPTION
The Kukri knife was added sometime ago and because of that I'm getting a warning whenever a player is using it in the demo:

`unknown equipment with index 526`

526 is the id for that knife in the items file