### PR TITLE
Fixed a typo

### DIFF
--- a/pkg/demoinfocs/parser.go
+++ b/pkg/demoinfocs/parser.go
@@ -136,7 +136,7 @@ func (p *parser) ServerClasses() st.ServerClasses {
 }
 
 // Header returns the DemoHeader which contains the demo's metadata.
-// Only possible after ParserHeader() has been called.
+// Only possible after ParseHeader() has been called.
 func (p *parser) Header() common.DemoHeader {
 	return *p.header
 }


### PR DESCRIPTION
Found a typo in function documentation. For me at least, as this library's first time user, it was a bit misleading. :)