### PR TITLE
fix: delete disconnected players references

### DIFF
--- a/pkg/demoinfocs/datatables.go
+++ b/pkg/demoinfocs/datatables.go
@@ -432,6 +432,8 @@ func (p *parser) bindNewPlayerController(controllerEntity st.Entity) {
 	controllerEntity.OnDestroy(func() {
 		pl.IsConnected = false
 		delete(p.gameState.playersByEntityID, controllerEntity.ID())
+		delete(p.gameState.playerControllerEntities, controllerEntity.ID())
+		delete(p.gameState.playersByUserID, pl.UserID)
 	})
 }
 


### PR DESCRIPTION
fix https://github.com/akiver/cs-demo-manager/issues/1137
fix https://github.com/akiver/cs-demo-manager/issues/1192

Player controller entities may in rare occasion being re-used for new players after disconnect, leaving stale references that cause incorrect players.