### PR TITLE
Gracefully handle invalid Content-Type header from CSTV broadcasts

### DIFF
--- a/pkg/demoinfocs/cstv/cstv.go
+++ b/pkg/demoinfocs/cstv/cstv.go
@@ -51,7 +51,7 @@ func (c *Reader) Read(p []byte) (n int, err error) {
 
 		defer deltaResp.Body.Close()
 
-		if deltaResp.StatusCode != http.StatusOK {
+		if deltaResp.StatusCode != http.StatusOK || deltaResp.Header.Get("Content-Type") != "application/octet-stream" {
 			time.Sleep(backoff)
 
 			backoff = time.Duration(float64(backoff) * 1.5)


### PR DESCRIPTION
The Starladder Budapest Majors' CSTV feeds redirect all invalid requests to the major's home webpage. Since those redirects end up returning 200, demoinfocs will append the page HTML to the buffer, causing a panic. My solution is to treat responses that don't use Content-Type: application/octet-stream as errors.