### PR TITLE
Make sure only actual flashbangs are added to flyingFlashbangs.

### DIFF
--- a/pkg/demoinfocs/datatables.go
+++ b/pkg/demoinfocs/datatables.go
@@ -679,10 +679,12 @@ func (p *parser) bindGrenadeProjectiles(entity st.Entity) {
 
 		p.gameEventHandler.addThrownGrenade(proj.Thrower, proj.WeaponInstance)
 
-		p.gameState.flyingFlashbangs = append(p.gameState.flyingFlashbangs, &FlyingFlashbang{
-			projectile:       proj,
-			flashedEntityIDs: []int{},
-		})
+		if proj.WeaponInstance.Type == common.EqFlash {
+			p.gameState.flyingFlashbangs = append(p.gameState.flyingFlashbangs, &FlyingFlashbang{
+				projectile:       proj,
+				flashedEntityIDs: []int{},
+			})
+		}
 
 		proj.Trajectory = append(proj.Trajectory, common.TrajectoryEntry{
 			Tick:     p.gameState.ingameTick,


### PR DESCRIPTION
Currently all projectiles are added to flyingFlashbangs, and the event "playerFlashed" has the wrong projectile with it.

Here's a snippet from an eventhandler for PlayerFlashed
```
Weapon type: 503, Weapon entity type: Incendiary Grenade
Player LeiNad (76561198128382445) was flashed by player PurpleJim (76561198090370174)

Weapon type: 506, Weapon entity type: HE Grenade
Player Blahbleh (76561198840578776) was flashed by player PurpleJim (76561198090370174)

Weapon type: 506, Weapon entity type: HE Grenade
Player PurpleJim (76561198090370174) was flashed by player PurpleJim (76561198090370174)

Weapon type: 506, Weapon entity type: HE Grenade
Player Nein (76561199172964515) was flashed by player PurpleJim (76561198090370174)

Weapon type: 506, Weapon entity type: HE Grenade
Player LeiNad (76561198128382445) was flashed by player PurpleJim (76561198090370174)
```