### PR TITLE
fix: possible panic in player.EquipmentValueCurrent()

### DIFF
--- a/pkg/demoinfocs/common/player.go
+++ b/pkg/demoinfocs/common/player.go
@@ -359,7 +359,17 @@ func (p *Player) Money() int {
 
 // EquipmentValueCurrent returns the current value of equipment in the player's inventory.
 func (p *Player) EquipmentValueCurrent() int {
-	return int(getUInt64(p.PlayerPawnEntity(), "m_unCurrentEquipmentValue"))
+	pawnEntity := p.PlayerPawnEntity()
+	if pawnEntity == nil {
+		return 0
+	}
+
+	equipmentValue, exists := pawnEntity.PropertyValue("m_unCurrentEquipmentValue")
+	if !exists {
+		return 0
+	}
+
+	return int(equipmentValue.UInt64()) //#nosec G115
 }
 
 // EquipmentValueRoundStart returns the value of equipment in the player's inventory at the time of the round start.


### PR DESCRIPTION
the prop `m_unCurrentEquipmentValue` may not exists on player connection.
it can be reproduced with this [renown demo ](https://demos.renown.gg/renown-match-15236.dem.gz) and the following code:

```go
p.RegisterEventHandler(func(event events.PlayerConnect) {
	for _, pl := range p.GameState().Participants().Playing() {
		fmt.Printf("Player: %-20s | EquipmentValueCurrent: %4d\n",
			pl.Name,
			pl.EquipmentValueCurrent(),
		)
	}
})
```