### PR TITLE
remove player#InspectWeaponCount

### DIFF
--- a/pkg/demoinfocs/common/player.go
+++ b/pkg/demoinfocs/common/player.go
@@ -31,7 +31,6 @@ type Player struct {
 	IsReloading         bool
 	IsUnknown           bool   // Used to identify unknown/broken players. see https://github.com/markus-wa/demoinfocs-golang/issues/162
 	ButtonsPressedState uint64 // Pressed buttons state represented as an uint64. You can use IsPressingButton(buttonMask) to check for specific buttons.
-	InspectWeaponCount  uint   // Number of times the player has inspected his weapon so far in the demo.
 }
 
 func (p *Player) PlayerPawnEntity() st.Entity {

--- a/pkg/demoinfocs/datatables.go
+++ b/pkg/demoinfocs/datatables.go
@@ -529,9 +529,6 @@ func (p *parser) bindNewPlayerPawn(pawnEntity st.Entity) {
 
 			state := val.UInt64()
 			pl.ButtonsPressedState = state
-			if state&uint64(common.ButtonLookAtWeapon) != 0 {
-				pl.InspectWeaponCount++
-			}
 
 			p.eventDispatcher.Dispatch(events.PlayerButtonsStateUpdate{
 				Player:       pl,


### PR DESCRIPTION
I think it should be done by the lib consumer using the event `PlayerButtonsStateUpdate`.