### PR TITLE
fix: Reset CSTV delta failure count on success

### DIFF
--- a/pkg/demoinfocs/cstv/cstv.go
+++ b/pkg/demoinfocs/cstv/cstv.go
@@ -74,7 +74,8 @@ func (c *Reader) Read(p []byte) (n int, err error) {
 		backoff = time.Second
 		nFails = 0
 
-		n2, err := c.buf.Read(p[n:])
+		var n2 int
+		n2, err = c.buf.Read(p[n:])
 		n += n2
 	}
 

--- a/pkg/demoinfocs/cstv/cstv.go
+++ b/pkg/demoinfocs/cstv/cstv.go
@@ -70,7 +70,9 @@ func (c *Reader) Read(p []byte) (n int, err error) {
 		}
 
 		c.frag++
-		backoff = time.Second // reset backoff on success
+		// reset backoff and nFails on success
+		backoff = time.Second
+		nFails = 0
 
 		n2, err := c.buf.Read(p[n:])
 		n += n2


### PR DESCRIPTION
Ran into this issue where 404s to /delta accumulates and triggers EOF even though the polling eventually succeeds.

I don't have much experience with CSTV broadcast servers or other polling internals in this lib, but at least the one I'm testing with is consistently behind the library polling, so `nFails` always reaches its limit in less than a minute.