### PR TITLE
Fix empty-weapon PlayerHurt world vs bomb classification

### DIFF
--- a/pkg/demoinfocs/datatables.go
+++ b/pkg/demoinfocs/datatables.go
@@ -173,8 +173,6 @@ func (p *parser) bindBomb() {
 				return
 			}
 
-			// Mirror game_events.go:bombExploded() so empty-weapon PlayerHurt can correlate same-frame C4 damage
-			// even when BombExplode is detected from S2 props instead of mimic-source1 game events.
 			p.gameEventHandler.frameToBombExploded[p.currentFrame] = true
 			p.eventDispatcher.Dispatch(events.BombExplode{
 				BombEvent: events.BombEvent{

--- a/pkg/demoinfocs/datatables.go
+++ b/pkg/demoinfocs/datatables.go
@@ -173,6 +173,9 @@ func (p *parser) bindBomb() {
 				return
 			}
 
+			// Mirror game_events.go:bombExploded() so empty-weapon PlayerHurt can correlate same-frame C4 damage
+			// even when BombExplode is detected from S2 props instead of mimic-source1 game events.
+			p.gameEventHandler.frameToBombExploded[p.currentFrame] = true
 			p.eventDispatcher.Dispatch(events.BombExplode{
 				BombEvent: events.BombEvent{
 					Player: planter,

--- a/pkg/demoinfocs/game_events.go
+++ b/pkg/demoinfocs/game_events.go
@@ -1065,8 +1065,6 @@ func (geh gameEventHandler) attackerWeaponType(wepType common.EquipmentType, vic
 		}
 	}
 
-	unassert.NotSame(wepType, common.EqUnknown)
-
 	return wepType
 }
 

--- a/pkg/demoinfocs/game_events.go
+++ b/pkg/demoinfocs/game_events.go
@@ -1056,6 +1056,7 @@ func (geh gameEventHandler) attackerWeaponType(wepType common.EquipmentType, vic
 	// unfortunately RoundEndReasonTargetBombed isn't enough and sometimes we need to check for 0 as well
 	if wepType == common.EqUnknown {
 		if reason, ok := geh.frameToRoundEndReason[geh.parser.currentFrame]; ok {
+			//nolint:exhaustive
 			switch reason {
 			case 0:
 				fallthrough

--- a/pkg/demoinfocs/game_events.go
+++ b/pkg/demoinfocs/game_events.go
@@ -486,47 +486,29 @@ func (geh gameEventHandler) playerHurt(data map[string]*msg.CMsgSource1LegacyGam
 		})
 	}
 
-	// CS2 may emit player_hurt with an empty weapon string for both world/fall damage and C4 damage.
-	// Delay only these ambiguous cases until the end of the frame so same-frame fall-damage, BombExplode,
-	// and round-end evidence is available without changing dispatch timing for known weapons.
 	if rawWeapon == "" && wepType == common.EqUnknown {
 		geh.parser.delayedEventHandlers = append(geh.parser.delayedEventHandlers, func() {
-			dispatchPlayerHurt(geh.playerHurtWeaponType(wepType, userID))
+			resolvedType := geh.attackerWeaponType(wepType, userID)
+			if resolvedType == common.EqUnknown {
+				if geh.frameToBombExploded[geh.parser.currentFrame] {
+					resolvedType = common.EqBomb
+				} else {
+					resolvedType = common.EqWorld
+				}
+			}
+
+			dispatchPlayerHurt(resolvedType)
 		})
 
 		return
 	}
 
-	dispatchPlayerHurt(geh.attackerWeaponType(wepType, userID))
+	wepType = geh.attackerWeaponType(wepType, userID)
+	dispatchPlayerHurt(wepType)
 }
 
 func (geh gameEventHandler) playerFallDamage(data map[string]*msg.CMsgSource1LegacyGameEventKeyT) {
 	geh.userIDToFallDamageFrame[data["userid"].GetValShort()] = geh.parser.currentFrame
-}
-
-func (geh gameEventHandler) playerHurtWeaponType(wepType common.EquipmentType, victimUserID int32) common.EquipmentType {
-	if wepType != common.EqUnknown {
-		return geh.attackerWeaponType(wepType, victimUserID)
-	}
-
-	if geh.userIDToFallDamageFrame[victimUserID] == geh.parser.currentFrame {
-		return common.EqWorld
-	}
-
-	if geh.frameToBombExploded[geh.parser.currentFrame] {
-		return common.EqBomb
-	}
-
-	if reason, ok := geh.frameToRoundEndReason[geh.parser.currentFrame]; ok {
-		switch reason {
-		case 0:
-			fallthrough
-		case events.RoundEndReasonTargetBombed:
-			return common.EqBomb
-		}
-	}
-
-	return common.EqWorld
 }
 
 func (geh gameEventHandler) playerBlind(data map[string]*msg.CMsgSource1LegacyGameEventKeyT) {
@@ -804,8 +786,6 @@ func (geh gameEventHandler) bombExploded(data map[string]*msg.CMsgSource1LegacyG
 		return
 	}
 
-	// Mirror the datatable-based bomb-explode path in datatables.go so empty-weapon PlayerHurt can correlate
-	// same-frame C4 damage regardless of whether the event came from mimic-source1 game events or S2 props.
 	geh.frameToBombExploded[geh.parser.currentFrame] = true
 	geh.gameState().currentDefuser = nil
 	geh.dispatch(events.BombExplode{BombEvent: bombEvent})

--- a/pkg/demoinfocs/game_events.go
+++ b/pkg/demoinfocs/game_events.go
@@ -67,6 +67,7 @@ func (p *parser) handleGameEvent(ge *msg.CMsgSource1LegacyGameEvent) {
 type gameEventHandler struct {
 	parser                      *parser
 	gameEventNameToHandler      map[string]gameEventHandlerFunc
+	frameToBombExploded         map[int]bool
 	userIDToFallDamageFrame     map[int32]int
 	frameToRoundEndReason       map[int]events.RoundEndReason
 	ignoreBombsiteIndexNotFound bool // see https://github.com/markus-wa/demoinfocs-golang/issues/314
@@ -108,6 +109,7 @@ type gameEventHandlerFunc func(map[string]*msg.CMsgSource1LegacyGameEventKeyT)
 func newGameEventHandler(parser *parser, ignoreBombsiteIndexNotFound bool) gameEventHandler {
 	geh := gameEventHandler{
 		parser:                      parser,
+		frameToBombExploded:         make(map[int]bool),
 		userIDToFallDamageFrame:     make(map[int32]int),
 		frameToRoundEndReason:       make(map[int]events.RoundEndReason),
 		ignoreBombsiteIndexNotFound: ignoreBombsiteIndexNotFound,
@@ -440,8 +442,8 @@ func (geh gameEventHandler) playerHurt(data map[string]*msg.CMsgSource1LegacyGam
 	player := geh.playerByUserID32(userID)
 	attacker := geh.playerByUserID32(data["attacker"].GetValShort())
 
-	wepType := common.MapEquipment(data["weapon"].GetValString())
-	wepType = geh.attackerWeaponType(wepType, userID)
+	rawWeapon := data["weapon"].GetValString()
+	wepType := common.MapEquipment(rawWeapon)
 
 	health := int(data["health"].GetValByte())
 	armor := int(data["armor"].GetValByte())
@@ -469,22 +471,62 @@ func (geh gameEventHandler) playerHurt(data map[string]*msg.CMsgSource1LegacyGam
 		}
 	}
 
-	geh.dispatch(events.PlayerHurt{
-		Player:            player,
-		Attacker:          attacker,
-		Health:            health,
-		Armor:             armor,
-		HealthDamage:      healthDamage,
-		ArmorDamage:       armorDamage,
-		HealthDamageTaken: healthDamageTaken,
-		ArmorDamageTaken:  armorDamageTaken,
-		HitGroup:          events.HitGroup(data["hitgroup"].GetValByte()),
-		Weapon:            geh.getEquipmentInstance(attacker, wepType),
-	})
+	dispatchPlayerHurt := func(wepType common.EquipmentType) {
+		geh.dispatch(events.PlayerHurt{
+			Player:            player,
+			Attacker:          attacker,
+			Health:            health,
+			Armor:             armor,
+			HealthDamage:      healthDamage,
+			ArmorDamage:       armorDamage,
+			HealthDamageTaken: healthDamageTaken,
+			ArmorDamageTaken:  armorDamageTaken,
+			HitGroup:          events.HitGroup(data["hitgroup"].GetValByte()),
+			Weapon:            geh.getEquipmentInstance(attacker, wepType),
+		})
+	}
+
+	// CS2 may emit player_hurt with an empty weapon string for both world/fall damage and C4 damage.
+	// Delay only these ambiguous cases until the end of the frame so same-frame fall-damage, BombExplode,
+	// and round-end evidence is available without changing dispatch timing for known weapons.
+	if rawWeapon == "" && wepType == common.EqUnknown {
+		geh.parser.delayedEventHandlers = append(geh.parser.delayedEventHandlers, func() {
+			dispatchPlayerHurt(geh.playerHurtWeaponType(wepType, userID))
+		})
+
+		return
+	}
+
+	dispatchPlayerHurt(geh.attackerWeaponType(wepType, userID))
 }
 
 func (geh gameEventHandler) playerFallDamage(data map[string]*msg.CMsgSource1LegacyGameEventKeyT) {
 	geh.userIDToFallDamageFrame[data["userid"].GetValShort()] = geh.parser.currentFrame
+}
+
+func (geh gameEventHandler) playerHurtWeaponType(wepType common.EquipmentType, victimUserID int32) common.EquipmentType {
+	if wepType != common.EqUnknown {
+		return geh.attackerWeaponType(wepType, victimUserID)
+	}
+
+	if geh.userIDToFallDamageFrame[victimUserID] == geh.parser.currentFrame {
+		return common.EqWorld
+	}
+
+	if geh.frameToBombExploded[geh.parser.currentFrame] {
+		return common.EqBomb
+	}
+
+	if reason, ok := geh.frameToRoundEndReason[geh.parser.currentFrame]; ok {
+		switch reason {
+		case 0:
+			fallthrough
+		case events.RoundEndReasonTargetBombed:
+			return common.EqBomb
+		}
+	}
+
+	return common.EqWorld
 }
 
 func (geh gameEventHandler) playerBlind(data map[string]*msg.CMsgSource1LegacyGameEventKeyT) {
@@ -762,6 +804,9 @@ func (geh gameEventHandler) bombExploded(data map[string]*msg.CMsgSource1LegacyG
 		return
 	}
 
+	// Mirror the datatable-based bomb-explode path in datatables.go so empty-weapon PlayerHurt can correlate
+	// same-frame C4 damage regardless of whether the event came from mimic-source1 game events or S2 props.
+	geh.frameToBombExploded[geh.parser.currentFrame] = true
 	geh.gameState().currentDefuser = nil
 	geh.dispatch(events.BombExplode{BombEvent: bombEvent})
 }
@@ -1029,11 +1074,13 @@ func (geh gameEventHandler) attackerWeaponType(wepType common.EquipmentType, vic
 	// if the round ended in the current frame with reason 1 or 0 we assume it was bomb damage
 	// unfortunately RoundEndReasonTargetBombed isn't enough and sometimes we need to check for 0 as well
 	if wepType == common.EqUnknown {
-		switch geh.frameToRoundEndReason[geh.parser.currentFrame] {
-		case 0:
-			fallthrough
-		case events.RoundEndReasonTargetBombed:
-			wepType = common.EqBomb
+		if reason, ok := geh.frameToRoundEndReason[geh.parser.currentFrame]; ok {
+			switch reason {
+			case 0:
+				fallthrough
+			case events.RoundEndReasonTargetBombed:
+				wepType = common.EqBomb
+			}
 		}
 	}
 

--- a/pkg/demoinfocs/game_events.go
+++ b/pkg/demoinfocs/game_events.go
@@ -1052,18 +1052,10 @@ func (geh gameEventHandler) attackerWeaponType(wepType common.EquipmentType, vic
 		wepType = common.EqWorld
 	}
 
-	// For this unknown-weapon fallback, real same-frame bomb samples are not always covered by
-	// RoundEndReasonTargetBombed alone. Some of them still expose RoundEndReasonStillInProgress
-	// on the same frame, so we also treat that value as bomb-side evidence here.
 	if wepType == common.EqUnknown {
-		if reason, ok := geh.frameToRoundEndReason[geh.parser.currentFrame]; ok {
-			//nolint:exhaustive
-			switch reason {
-			case events.RoundEndReasonStillInProgress:
-				fallthrough
-			case events.RoundEndReasonTargetBombed:
-				wepType = common.EqBomb
-			}
+		reason, ok := geh.frameToRoundEndReason[geh.parser.currentFrame]
+		if ok && reason == events.RoundEndReasonTargetBombed {
+			wepType = common.EqBomb
 		}
 	}
 

--- a/pkg/demoinfocs/game_events.go
+++ b/pkg/demoinfocs/game_events.go
@@ -1052,13 +1052,14 @@ func (geh gameEventHandler) attackerWeaponType(wepType common.EquipmentType, vic
 		wepType = common.EqWorld
 	}
 
-	// if the round ended in the current frame with reason 1 or 0 we assume it was bomb damage
-	// unfortunately RoundEndReasonTargetBombed isn't enough and sometimes we need to check for 0 as well
+	// For this unknown-weapon fallback, real same-frame bomb samples are not always covered by
+	// RoundEndReasonTargetBombed alone. Some of them still expose RoundEndReasonStillInProgress
+	// on the same frame, so we also treat that value as bomb-side evidence here.
 	if wepType == common.EqUnknown {
 		if reason, ok := geh.frameToRoundEndReason[geh.parser.currentFrame]; ok {
 			//nolint:exhaustive
 			switch reason {
-			case 0:
+			case events.RoundEndReasonStillInProgress:
 				fallthrough
 			case events.RoundEndReasonTargetBombed:
 				wepType = common.EqBomb

--- a/pkg/demoinfocs/game_events.go
+++ b/pkg/demoinfocs/game_events.go
@@ -483,6 +483,7 @@ func (geh gameEventHandler) playerHurt(data map[string]*msg.CMsgSource1LegacyGam
 			ArmorDamageTaken:  armorDamageTaken,
 			HitGroup:          events.HitGroup(data["hitgroup"].GetValByte()),
 			Weapon:            geh.getEquipmentInstance(attacker, wepType),
+			WeaponString:      rawWeapon,
 		})
 	}
 

--- a/pkg/demoinfocs/game_events_test.go
+++ b/pkg/demoinfocs/game_events_test.go
@@ -217,6 +217,132 @@ func TestGetEquipmentInstance_Grenade_Thrown(t *testing.T) {
 	assert.Equal(t, he, wep)
 }
 
+func TestPlayerHurtWeaponType_UnknownDefaultsToWorld(t *testing.T) {
+	p := NewParser(rand.Reader).(*parser)
+	p.currentFrame = 24
+
+	wepType := p.gameEventHandler.playerHurtWeaponType(common.EqUnknown, 123)
+
+	assert.Equal(t, common.EqWorld, wepType)
+}
+
+func TestPlayerHurtWeaponType_FallDamageWins(t *testing.T) {
+	p := NewParser(rand.Reader).(*parser)
+	p.currentFrame = 36
+	p.gameEventHandler.userIDToFallDamageFrame[123] = p.currentFrame
+
+	wepType := p.gameEventHandler.playerHurtWeaponType(common.EqUnknown, 123)
+
+	assert.Equal(t, common.EqWorld, wepType)
+}
+
+func TestPlayerHurtWeaponType_BombExplodeWins(t *testing.T) {
+	p := NewParser(rand.Reader).(*parser)
+	p.currentFrame = 48
+	p.gameEventHandler.frameToBombExploded[p.currentFrame] = true
+
+	wepType := p.gameEventHandler.playerHurtWeaponType(common.EqUnknown, 123)
+
+	assert.Equal(t, common.EqBomb, wepType)
+}
+
+func TestPlayerHurtWeaponType_RoundEndReasonTargetBombedWins(t *testing.T) {
+	p := NewParser(rand.Reader).(*parser)
+	p.currentFrame = 60
+	p.gameEventHandler.frameToRoundEndReason[p.currentFrame] = events.RoundEndReasonTargetBombed
+
+	wepType := p.gameEventHandler.playerHurtWeaponType(common.EqUnknown, 123)
+
+	assert.Equal(t, common.EqBomb, wepType)
+}
+
+func TestPlayerHurt_UnknownWeaponDefaultsToWorld(t *testing.T) {
+	p := NewParser(rand.Reader).(*parser)
+	p.currentFrame = 72
+
+	var got []events.PlayerHurt
+	p.RegisterEventHandler(func(e events.PlayerHurt) {
+		got = append(got, e)
+	})
+
+	p.gameEventHandler.playerHurt(playerHurtEventData(11, 65535, ""))
+	assert.Len(t, got, 0)
+
+	p.processFrameGameEvents()
+
+	assert.Len(t, got, 1)
+	assert.NotNil(t, got[0].Weapon)
+	assert.Equal(t, common.EqWorld, got[0].Weapon.Type)
+}
+
+func TestPlayerHurt_UnknownWeaponUsesBombWhenBombExplodedThisFrame(t *testing.T) {
+	p := NewParser(rand.Reader).(*parser)
+	p.currentFrame = 84
+	p.gameEventHandler.frameToBombExploded[p.currentFrame] = true
+
+	var got []events.PlayerHurt
+	p.RegisterEventHandler(func(e events.PlayerHurt) {
+		got = append(got, e)
+	})
+
+	p.gameEventHandler.playerHurt(playerHurtEventData(12, 65535, ""))
+	assert.Len(t, got, 0)
+
+	p.processFrameGameEvents()
+
+	assert.Len(t, got, 1)
+	assert.NotNil(t, got[0].Weapon)
+	assert.Equal(t, common.EqBomb, got[0].Weapon.Type)
+}
+
+func TestPlayerHurt_KnownWeaponDispatchesImmediately(t *testing.T) {
+	p := NewParser(rand.Reader).(*parser)
+	p.currentFrame = 96
+
+	var got []events.PlayerHurt
+	p.RegisterEventHandler(func(e events.PlayerHurt) {
+		got = append(got, e)
+	})
+
+	p.gameEventHandler.playerHurt(playerHurtEventData(13, 7, "ak47"))
+
+	assert.Len(t, got, 1)
+	assert.NotNil(t, got[0].Weapon)
+	assert.Equal(t, common.EqAK47, got[0].Weapon.Type)
+
+	p.processFrameGameEvents()
+	assert.Len(t, got, 1)
+}
+
+func playerHurtEventData(userID int32, attacker int32, weapon string) map[string]*msg.CMsgSource1LegacyGameEventKeyT {
+	return map[string]*msg.CMsgSource1LegacyGameEventKeyT{
+		"userid": {
+			ValShort: proto.Int32(userID),
+		},
+		"attacker": {
+			ValShort: proto.Int32(attacker),
+		},
+		"weapon": {
+			ValString: proto.String(weapon),
+		},
+		"health": {
+			ValByte: proto.Int32(92),
+		},
+		"armor": {
+			ValByte: proto.Int32(0),
+		},
+		"dmg_health": {
+			ValShort: proto.Int32(8),
+		},
+		"dmg_armor": {
+			ValByte: proto.Int32(0),
+		},
+		"hitgroup": {
+			ValByte: proto.Int32(int32(events.HitGroupGeneric)),
+		},
+	}
+}
+
 func TestGetCommunityId(t *testing.T) {
 	xuid, err := guidToSteamID64("STEAM_0:1:26343269")
 	assert.Nil(t, err)

--- a/pkg/demoinfocs/game_events_test.go
+++ b/pkg/demoinfocs/game_events_test.go
@@ -217,7 +217,7 @@ func TestGetEquipmentInstance_Grenade_Thrown(t *testing.T) {
 	assert.Equal(t, he, wep)
 }
 
-func TestAttackerWeaponType_UnknownDefaultsToWorld(t *testing.T) {
+func TestAttackerWeaponType_UnknownStaysUnknownWithoutContext(t *testing.T) {
 	p := NewParser(rand.Reader).(*parser)
 	p.currentFrame = 24
 

--- a/pkg/demoinfocs/game_events_test.go
+++ b/pkg/demoinfocs/game_events_test.go
@@ -217,48 +217,38 @@ func TestGetEquipmentInstance_Grenade_Thrown(t *testing.T) {
 	assert.Equal(t, he, wep)
 }
 
-func TestPlayerHurtWeaponType_UnknownDefaultsToWorld(t *testing.T) {
+func TestAttackerWeaponType_UnknownDefaultsToWorld(t *testing.T) {
 	p := NewParser(rand.Reader).(*parser)
 	p.currentFrame = 24
 
-	wepType := p.gameEventHandler.playerHurtWeaponType(common.EqUnknown, 123)
+	wepType := p.gameEventHandler.attackerWeaponType(common.EqUnknown, 123)
 
-	assert.Equal(t, common.EqWorld, wepType)
+	assert.Equal(t, common.EqUnknown, wepType)
 }
 
-func TestPlayerHurtWeaponType_FallDamageWins(t *testing.T) {
+func TestAttackerWeaponType_FallDamageWins(t *testing.T) {
 	p := NewParser(rand.Reader).(*parser)
 	p.currentFrame = 36
 	p.gameEventHandler.userIDToFallDamageFrame[123] = p.currentFrame
 
-	wepType := p.gameEventHandler.playerHurtWeaponType(common.EqUnknown, 123)
+	wepType := p.gameEventHandler.attackerWeaponType(common.EqUnknown, 123)
 
 	assert.Equal(t, common.EqWorld, wepType)
 }
 
-func TestPlayerHurtWeaponType_BombExplodeWins(t *testing.T) {
+func TestAttackerWeaponType_RoundEndReasonTargetBombedWins(t *testing.T) {
 	p := NewParser(rand.Reader).(*parser)
 	p.currentFrame = 48
-	p.gameEventHandler.frameToBombExploded[p.currentFrame] = true
-
-	wepType := p.gameEventHandler.playerHurtWeaponType(common.EqUnknown, 123)
-
-	assert.Equal(t, common.EqBomb, wepType)
-}
-
-func TestPlayerHurtWeaponType_RoundEndReasonTargetBombedWins(t *testing.T) {
-	p := NewParser(rand.Reader).(*parser)
-	p.currentFrame = 60
 	p.gameEventHandler.frameToRoundEndReason[p.currentFrame] = events.RoundEndReasonTargetBombed
 
-	wepType := p.gameEventHandler.playerHurtWeaponType(common.EqUnknown, 123)
+	wepType := p.gameEventHandler.attackerWeaponType(common.EqUnknown, 123)
 
 	assert.Equal(t, common.EqBomb, wepType)
 }
 
 func TestPlayerHurt_UnknownWeaponDefaultsToWorld(t *testing.T) {
 	p := NewParser(rand.Reader).(*parser)
-	p.currentFrame = 72
+	p.currentFrame = 60
 
 	var got []events.PlayerHurt
 	p.RegisterEventHandler(func(e events.PlayerHurt) {
@@ -277,7 +267,7 @@ func TestPlayerHurt_UnknownWeaponDefaultsToWorld(t *testing.T) {
 
 func TestPlayerHurt_UnknownWeaponUsesBombWhenBombExplodedThisFrame(t *testing.T) {
 	p := NewParser(rand.Reader).(*parser)
-	p.currentFrame = 84
+	p.currentFrame = 72
 	p.gameEventHandler.frameToBombExploded[p.currentFrame] = true
 
 	var got []events.PlayerHurt
@@ -297,7 +287,7 @@ func TestPlayerHurt_UnknownWeaponUsesBombWhenBombExplodedThisFrame(t *testing.T)
 
 func TestPlayerHurt_KnownWeaponDispatchesImmediately(t *testing.T) {
 	p := NewParser(rand.Reader).(*parser)
-	p.currentFrame = 96
+	p.currentFrame = 84
 
 	var got []events.PlayerHurt
 	p.RegisterEventHandler(func(e events.PlayerHurt) {
@@ -309,9 +299,6 @@ func TestPlayerHurt_KnownWeaponDispatchesImmediately(t *testing.T) {
 	assert.Len(t, got, 1)
 	assert.NotNil(t, got[0].Weapon)
 	assert.Equal(t, common.EqAK47, got[0].Weapon.Type)
-
-	p.processFrameGameEvents()
-	assert.Len(t, got, 1)
 }
 
 func playerHurtEventData(userID int32, attacker int32, weapon string) map[string]*msg.CMsgSource1LegacyGameEventKeyT {


### PR DESCRIPTION
## Summary
- delay only ambiguous CS2 `player_hurt` events with an empty weapon string until end-of-frame so world/fall damage can be distinguished from same-frame C4 damage
- keep real bomb damage classified as bomb by correlating both game-event and datatable `BombExplode` paths, while avoiding the old zero-value round-end fallback
- keep the final implementation scoped to the ambiguous empty-weapon path rather than changing dispatch timing for all `PlayerHurt` events

## Validation
- `go test ./pkg/demoinfocs -run 'Test(AttackerWeaponType|PlayerHurt)_'`
- real-demo check on `test/cs-demos/cs2/faze-vs-inner-circle-m2-nuke.dem`

## Comparison to issue #642
Issue #642 reports that some CS2 world/fall samples emit raw `player_hurt.weapon = ""`, but typed `PlayerHurt.Weapon` incorrectly falls through to `C4`, while typed `Kill.Weapon` still ends up as `World`.

### Issue-reported samples (before this fix)
From issue #642:

| sample | demo | round / tick | raw `player_hurt.weapon` | usable `player_falldamage` | raw `player_death.weapon` | typed `PlayerHurt.Weapon` | typed `Kill.Weapon` |
|---|---|---|---|---|---|---|---|
| `broky` world death | `faze-vs-inner-circle-m2-nuke.dem` | round 21 / tick 170355 | `""` | no | `"worldent"` | `C4` | `World` |
| `s1mple` world death | `bc-game-vs-ninjas-in-pyjamas-m2-nuke.dem` | round 4 / tick 24826 | `""` | no | `"worldent"` | `C4` | `World` |

These are the mismatches described in the issue: the generic `player_hurt` path falls through to `C4`, while the generic `player_death` path still maps to `World`.

### Real-demo world / fall samples after this fix
From `test/cs-demos/cs2/faze-vs-inner-circle-m2-nuke.dem`:

| sample | frame | tick | raw `player_hurt.weapon` | same-frame `BombExplode` | raw `player_death.weapon` | typed `PlayerHurt.Weapon` | typed `Kill.Weapon` |
|---|---:|---:|---|---|---|---|---|
| non-lethal world sample (`Twistzz`) | 2526 | 2323 | `""` | no | – | `World` | – |
| non-lethal world sample (`Flierax`) | 21416 | 20011 | `""` | no | – | `World` | – |
| issue-style world death (`broky`) | 181991 | 170355 | `""` | no | `"worldent"` | `World` | `World` |

This is the behavior the issue asks for: the world/fall samples no longer collapse into `C4`, and the `broky` sample now matches `PlayerHurt=World` with `Kill=World` instead of the mismatch described in the issue.

### Same-frame bomb samples after this fix
From the same real demo:

| sample | frame | tick | raw `player_hurt.weapon` | same-frame `BombExplode` | typed `PlayerHurt.Weapon` |
|---|---:|---:|---|---|---|
| bomb damage sample 1 | 14132 | 13196 | `""` | yes | `C4` |
| bomb damage sample 2 | 43767 | 40941 | `""` | yes | `C4` |
| bomb damage sample 3 | 78816 | 73759 | `""` | yes | `C4` |
| bomb damage sample 4 | 141156 | 132116 | `""` | yes | `C4` |
| bomb damage sample 5 | 160681 | 150401 | `""` | yes | `C4` |

So the real-demo result now matches the intended split described in the issue comments: empty-weapon world/fall samples stay on the `World` side, while true same-frame bomb damage stays on the `C4` side.
