### PR TITLE
fix: decode CGlobalSymbol as null-terminated string

### DIFF
--- a/pkg/demoinfocs/sendtables/sendtablescs2/field_decoder.go
+++ b/pkg/demoinfocs/sendtables/sendtablescs2/field_decoder.go
@@ -79,6 +79,7 @@ var fieldTypeDecoders = map[string]fieldDecoder{
 	"char":            stringDecoder,
 	"CUtlString":      stringDecoder,
 	"CUtlSymbolLarge": stringDecoder,
+	"CGlobalSymbol":   stringDecoder,
 
 	// some dotabuff/manta stuff
 	"GameTime_t": noscaleDecoder,


### PR DESCRIPTION
## Summary
- CS2's April 2026 patch introduced `CGlobalSymbol` fields in the `CCSPlayerPawn` send-tables (notably `CBodyComponent.m_vecSecondarySkeletonSlotIDs`). On the wire this type is a **null-terminated string** (e.g. `"active_weapon\0"`), but the parser had no explicit decoder for it and fell through to `defaultDecoder = readVarUint32`, consuming only the first byte (`'a'` = 97). This desyncs the bit-reader for the remainder of the packet, and the cascade eventually produces `unable to find existing entity N` once the misalignment reaches the next entity's opcode bits.
- One-line fix: add `"CGlobalSymbol": stringDecoder` alongside the existing `CUtlSymbolLarge`/`CUtlString` entries.
- Fixes #652.

## Repro / verification
- Broken demo: a CS2 GOTV from 2026-04-21. Before the fix, parse panics after ~36 frames with `unable to find existing entity 136`.
- After the fix, the same demo parses all 138,750 frames end-to-end without errors or warnings.

## How this was diagnosed
Instrumented `readFields` to dump raw buffer bytes at the suspect field. The bytes at the decode position were literally `"active_weapon\x00..."` — a human-readable asset name, confirming the wire format is a string, not a hashed symbol handle. Verified against `saul/demofile-net`, which is the only sibling parser with an explicit `CGlobalSymbol` mapping — it also treats the inner value as string-like.

## Test plan
- [x] Parse a broken CS2 demo from after the April 2026 patch — previously panicked at ~frame 36, now completes (138,750 frames).
- [ ] Run existing test suite (`go test ./...`).