### PR TITLE
fix: stop processing queued messages once a fatal error is recorded

### DIFF
--- a/pkg/demoinfocs/game_events.go
+++ b/pkg/demoinfocs/game_events.go
@@ -16,6 +16,10 @@ import (
 )
 
 func (p *parser) handleGameEventList(gel *msg.CMsgSource1LegacyGameEventList) {
+	if p.aborted() {
+		return
+	}
+
 	p.gameEventDescs = make(map[int32]*msg.CMsgSource1LegacyGameEventListDescriptorT)
 	for _, d := range gel.GetDescriptors() {
 		p.gameEventDescs[d.GetEventid()] = d
@@ -23,6 +27,10 @@ func (p *parser) handleGameEventList(gel *msg.CMsgSource1LegacyGameEventList) {
 }
 
 func (p *parser) handleGameEvent(ge *msg.CMsgSource1LegacyGameEvent) {
+	if p.aborted() {
+		return
+	}
+
 	if p.gameEventDescs == nil {
 		p.eventDispatcher.Dispatch(events.ParserWarn{
 			Message: "received GameEvent but event descriptors are missing",

--- a/pkg/demoinfocs/net_messages.go
+++ b/pkg/demoinfocs/net_messages.go
@@ -21,6 +21,10 @@ func (p *parser) onEntity(e sendtables.Entity, op sendtables.EntityOp) error {
 }
 
 func (p *parser) handleSetConVar(setConVar *msg.CNETMsg_SetConVar) {
+	if p.aborted() {
+		return
+	}
+
 	updated := make(map[string]string)
 	for _, cvar := range setConVar.Convars.Cvars {
 		updated[cvar.GetName()] = cvar.GetValue()
@@ -33,6 +37,10 @@ func (p *parser) handleSetConVar(setConVar *msg.CNETMsg_SetConVar) {
 }
 
 func (p *parser) handleServerInfo(srvInfo *msg.CSVCMsg_ServerInfo) {
+	if p.aborted() {
+		return
+	}
+
 	// srvInfo.MapCrc might be interesting as well
 	p.tickInterval = srvInfo.GetTickInterval()
 
@@ -43,6 +51,10 @@ func (p *parser) handleServerInfo(srvInfo *msg.CSVCMsg_ServerInfo) {
 }
 
 func (p *parser) handleMessageSayText(msg *msg.CUserMessageSayText) {
+	if p.aborted() {
+		return
+	}
+
 	p.eventDispatcher.Dispatch(events.SayText{
 		EntIdx:    int(msg.GetPlayerindex()),
 		IsChat:    msg.GetChat(),
@@ -52,6 +64,10 @@ func (p *parser) handleMessageSayText(msg *msg.CUserMessageSayText) {
 }
 
 func (p *parser) handleMessageSayText2(msg *msg.CUserMessageSayText2) {
+	if p.aborted() {
+		return
+	}
+
 	p.eventDispatcher.Dispatch(events.SayText2{
 		EntIdx:    int(msg.GetEntityindex()),
 		IsChat:    msg.GetChat(),
@@ -90,6 +106,10 @@ func (p *parser) handleMessageSayText2(msg *msg.CUserMessageSayText2) {
 }
 
 func (p *parser) handleServerRankUpdate(msg *msg.CCSUsrMsg_ServerRankUpdate) {
+	if p.aborted() {
+		return
+	}
+
 	for _, v := range msg.RankUpdate {
 		steamID32 := uint32(v.GetAccountId())
 		player, ok := p.gameState.playersBySteamID32[steamID32]

--- a/pkg/demoinfocs/parser.go
+++ b/pkg/demoinfocs/parser.go
@@ -314,6 +314,12 @@ func (p *parser) error() error {
 	return err
 }
 
+// aborted reports whether a fatal error has been recorded. Message handlers
+// no-op once it is set, so the queued backlog drains without further decoding.
+func (p *parser) aborted() bool {
+	return p.error() != nil
+}
+
 func (p *parser) setError(err error) {
 	if err == nil {
 		return

--- a/pkg/demoinfocs/parsing.go
+++ b/pkg/demoinfocs/parsing.go
@@ -74,8 +74,22 @@ func (p *parser) parseHeader() (header, error) {
 
 		p.stParser.OnEntity(p.onEntity)
 
-		p.RegisterNetMessageHandler(p.stParser.OnServerInfo)
-		p.RegisterNetMessageHandler(p.stParser.OnPacketEntities)
+		// Error returns were already discarded by the dispatcher before these
+		// wrappers existed; the wrappers only add the aborted() short-circuit.
+		p.RegisterNetMessageHandler(func(m *msg.CSVCMsg_ServerInfo) {
+			if p.aborted() {
+				return
+			}
+
+			_ = p.stParser.OnServerInfo(m)
+		})
+		p.RegisterNetMessageHandler(func(m *msg.CSVCMsg_PacketEntities) {
+			if p.aborted() {
+				return
+			}
+
+			_ = p.stParser.OnPacketEntities(m)
+		})
 
 	default:
 		return h, ErrInvalidFileType
@@ -361,6 +375,10 @@ type frameParsedTokenType struct{}
 var frameParsedToken = new(frameParsedTokenType)
 
 func (p *parser) handleFrameParsed(*frameParsedTokenType) {
+	if p.aborted() {
+		return
+	}
+
 	p.processFrameGameEvents()
 
 	p.currentFrame++

--- a/pkg/demoinfocs/s2_commands.go
+++ b/pkg/demoinfocs/s2_commands.go
@@ -16,6 +16,10 @@ import (
 )
 
 func (p *parser) handleSendTables(msg *msg.CDemoSendTables) {
+	if p.aborted() {
+		return
+	}
+
 	err := p.stParser.ParsePacket(msg.Data)
 	if err != nil {
 		panic(errors.Wrap(err, "failed to unmarshal flattened serializer"))
@@ -23,6 +27,10 @@ func (p *parser) handleSendTables(msg *msg.CDemoSendTables) {
 }
 
 func (p *parser) handleClassInfo(msg *msg.CDemoClassInfo) {
+	if p.aborted() {
+		return
+	}
+
 	err := p.stParser.OnDemoClassInfo(msg)
 	if err != nil {
 		panic(err)
@@ -387,6 +395,10 @@ func (p *parser) handleFullPacket(msg *msg.CDemoFullPacket) {
 }
 
 func (p *parser) handleFileInfo(msg *msg.CDemoFileInfo) {
+	if p.aborted() {
+		return
+	}
+
 	p.header.PlaybackTicks = int(*msg.PlaybackTicks)
 	p.header.PlaybackFrames = int(*msg.PlaybackFrames)
 	p.header.PlaybackTime = time.Duration(*msg.PlaybackTime) * time.Second
@@ -418,6 +430,10 @@ func getGameEventListBinForProtocol(networkProtocol int) ([]byte, error) {
 }
 
 func (p *parser) handleDemoFileHeader(msg *msg.CDemoFileHeader) {
+	if p.aborted() {
+		return
+	}
+
 	p.header.ClientName = msg.GetClientName()
 	p.header.ServerName = msg.GetServerName()
 	p.header.GameDirectory = msg.GetGameDirectory()

--- a/pkg/demoinfocs/stringtables.go
+++ b/pkg/demoinfocs/stringtables.go
@@ -138,6 +138,10 @@ func (p *parser) setRawPlayer(index int, player common.PlayerInfo) {
 }
 
 func (p *parser) handleUpdateStringTable(tab *msg.CSVCMsg_UpdateStringTable) {
+	if p.aborted() {
+		return
+	}
+
 	defer func() {
 		p.setError(recoverFromUnexpectedEOF(recover()))
 	}()
@@ -170,6 +174,10 @@ func (p *parser) handleUpdateStringTable(tab *msg.CSVCMsg_UpdateStringTable) {
 }
 
 func (p *parser) handleCreateStringTable(tab *msg.CSVCMsg_CreateStringTable) {
+	if p.aborted() {
+		return
+	}
+
 	defer func() {
 		p.setError(recoverFromUnexpectedEOF(recover()))
 	}()
@@ -436,6 +444,10 @@ func (p *parser) processModelPreCacheUpdate() {
 // XXX TODO: decide if we want to at all integrate these updates,
 // or trust create/update entirely. Let's ignore them for now.
 func (p *parser) handleStringTables(msg *msg.CDemoStringTables) {
+	if p.aborted() {
+		return
+	}
+
 	for _, tab := range msg.GetTables() {
 		if tab.GetTableName() == stNameInstanceBaseline {
 			for _, item := range tab.GetItems() {


### PR DESCRIPTION
Net-messages are handled on a queued goroutine that can lag thousands of messages behind the frame loop. When a message handler panics, the dispatcher's `PanicHandler` records the error immediately and the frame loop stops on its next iteration - but the already-queued backlog is still fully processed, both by the consumer and by shutdown's `SyncAllQueues()`.

For a panic inside `CSVCMsg_PacketEntities` handling this is destructive: the message is half-applied, the entity table no longer matches the stream, and every backlog message decodes against wrong classes. In production we watched ~3,100 queued messages get processed after the first recorded panic, generating ~3,000 follow-on panics and multi-GB allocations from desynced field paths (~121 GB live heap, OOM kill).

Skip handler work once a fatal error has been recorded: `aborted()` checks the recorded error, and every handler that decodes data or invokes user callbacks returns early. The backlog then drains as no-ops and `ParseToEnd` returns the recorded first error promptly. `Cancel()` gets the same fast-stop behaviour since it uses the same error mechanism.

Validated on a production demo that motivated this: with a panicking user handler, the parse now returns the recorded error in ~2.1s at ~139MB peak instead of being OOM-killed at ~121GB; healthy demos parse with byte-identical results.