### PR TITLE
fix: bound field-state allocations to fail fast on corrupt bitstreams

### DIFF
--- a/pkg/demoinfocs/sendtables/sendtablescs2/entity.go
+++ b/pkg/demoinfocs/sendtables/sendtablescs2/entity.go
@@ -439,6 +439,9 @@ func (e *Entity) readFields(r *reader, paths *[]*fieldPath) {
 
 		if updateCollection { //nolint:nestif
 			newLen := val.(uint64)
+			if newLen > maxFieldIndex {
+				_panicf("variable collection size %d out of range [0, %d] (path %v): corrupt or desynced demo bitstream", newLen, maxFieldIndex, fp.path[:fp.last+1])
+			}
 
 			// Retrieve the *fieldState pointer stored on the first update.
 			// We store a pointer so we can resize in place on subsequent updates

--- a/pkg/demoinfocs/sendtables/sendtablescs2/field_state.go
+++ b/pkg/demoinfocs/sendtables/sendtablescs2/field_state.go
@@ -10,6 +10,16 @@ func newFieldState() *fieldState {
 	}
 }
 
+// maxFieldIndex bounds decoded field-path components and variable-collection sizes.
+// Anything larger means a corrupt or desynced bitstream and would allocate GBs in one call.
+const maxFieldIndex = 1 << 20
+
+func validateFieldIndex(z int, fp *fieldPath) {
+	if z < 0 || z > maxFieldIndex {
+		_panicf("field path component %d out of range [0, %d] (path %v): corrupt or desynced demo bitstream", z, maxFieldIndex, fp.path[:fp.last+1])
+	}
+}
+
 func (s *fieldState) get(fp *fieldPath) any {
 	x := s
 	z := 0
@@ -35,6 +45,7 @@ func (s *fieldState) set(fp *fieldPath, v any) {
 	// Fast path for the common single-level case (fp.last == 0)
 	if fp.last == 0 { //nolint:nestif
 		z := fp.path[0]
+		validateFieldIndex(z, fp)
 		if y := len(s.state); y <= z {
 			if z+2 > cap(s.state) {
 				newSlice := make([]any, z+1, max(z+2, y*2))
@@ -55,6 +66,7 @@ func (s *fieldState) set(fp *fieldPath, v any) {
 
 	for i := 0; i <= fp.last; i++ {
 		z = fp.path[i]
+		validateFieldIndex(z, fp)
 
 		if y := len(x.state); y <= z {
 			newCap := max(z+2, y*2)

--- a/pkg/demoinfocs/sendtables/sendtablescs2/field_state_test.go
+++ b/pkg/demoinfocs/sendtables/sendtablescs2/field_state_test.go
@@ -1,0 +1,40 @@
+package sendtablescs2
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestFieldStateSetGetRoundTrip(t *testing.T) {
+	s := newFieldState()
+
+	leaf := &fieldPath{path: []int{45}, last: 0}
+	s.set(leaf, "leaf")
+
+	assert.Equal(t, "leaf", s.get(leaf))
+
+	nested := &fieldPath{path: []int{3, 129, 7}, last: 2}
+	s.set(nested, 42)
+
+	assert.Equal(t, 42, s.get(nested))
+}
+
+// Real values observed on a desynced CS2 bitstream; unguarded, the first one
+// makes set() allocate ~32 GB in a single call.
+func TestFieldStateSetRejectsCorruptIndex(t *testing.T) {
+	paths := [][]int{
+		{2142459506},
+		{3, 2142459506},
+		{0, 7, 1829614422},
+		{-1},
+	}
+
+	for _, path := range paths {
+		fp := &fieldPath{path: path, last: len(path) - 1}
+
+		assert.Panics(t, func() {
+			newFieldState().set(fp, "x")
+		}, "set(%v) should panic", path)
+	}
+}


### PR DESCRIPTION
`fieldState.set` trusts decoded field-path components completely; get() bounds-checks but set() does not. On a desynced bitstream a garbage component such as 2142459506 (observed in production on a CS2 demo after a handler panic corrupted entity state) makes `set()` allocate (z+1) * 16 bytes in a single call - about 32 GB. Live heap reached ~121 GB before the OOM killer intervened; because the memory is reachable, `GOMEMLIMIT` cannot defend against it. The variable-size collection path in `Entity.readFields` has the same exposure through `make([]any, newLen, newLen*2)`.

Bound both with a shared `maxFieldIndex (1<<20)`. Real components top out in the double digits and the largest networked arrays hold a few thousand entries, so the bound only fires on corrupt or desynced input, converting an OOM kill into a recoverable parse error.

Validated against a production demo that motivated this: parse now fails in ~2.3s at ~159MB peak instead of OOM at ~121GB, and healthy demos parse with byte-identical results.