### PR TITLE
fix: round to nearest when quantizing floats

### DIFF
--- a/pkg/demoinfocs/sendtables/sendtablescs2/quantizedfloat.go
+++ b/pkg/demoinfocs/sendtables/sendtablescs2/quantizedfloat.go
@@ -125,7 +125,12 @@ func (qfd *quantizedFloatDecoder) quantize(val float32) float32 {
 		return qfd.High
 	}
 
-	i := uint32((val - qfd.Low) * qfd.HighLowMul)
+	// Round to nearest like the engine's encoder does. Truncating here can
+	// wrongly keep a round-up/round-down/encode-zero special flag that the
+	// encoder discarded (e.g. bits=10 low=0 high=102.3 gives raw 1022.99994,
+	// which must quantize to 1023 so the round-up flag is removed), making the
+	// decoder read a phantom flag bit and desync the entity stream.
+	i := uint32((val-qfd.Low)*qfd.HighLowMul + 0.5)
 	return qfd.Low + float32((qfd.High-qfd.Low)*float32(float32(i)*qfd.DecMul))
 }
 


### PR DESCRIPTION
Reported here https://github.com/akiver/cs-demo-analyzer/issues/32

Fixes an entity-stream desync (panic: "unable to find existing entity") on demos containing plugin-spawned entities such as CBeam.

The quantized-float decoder truncated in quantize(), but the engine's encoder rounds to nearest. For fields like CBeam m_fWidth (bits=10, low=0, high=102.3, round-up flag), quantize(high) yields 1022.99994: truncation reconstructs a value != high, so the round-up flag was wrongly kept and the decoder consumed a phantom 1-bit special flag where the stream held a plain 10-bit value, desyncing the rest of the message.