### PR TITLE
ci: update actions/checkout to v7, setup-go to v7, cache to v6, codeql-action to v4, create-pull-request to v8

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
 
     steps:
       - name: Install Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v7
         with:
           go-version: 1.24.x
 
@@ -22,7 +22,7 @@ jobs:
           reviewdog_version: v0.11.0
 
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Download Go Deps
         run: go mod download
@@ -67,19 +67,19 @@ jobs:
 
     steps:
       - name: Checkout demoinfocs-golang repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           path: demoinfocs-golang
 
       - name: Checkout CSDA repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           repository: akiver/cs-demo-analyzer
           path: cs-demo-analyzer
           ref: main
 
       - name: Install Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v7
         with:
           go-version-file: cs-demo-analyzer/go.mod
           cache-dependency-path: cs-demo-analyzer/go.sum
@@ -96,7 +96,7 @@ jobs:
           curl -L -o demos.txt https://gitlab.com/akiver/cs-demos/-/raw/main/demos.txt
 
       - name: Restore demos cache
-        uses: actions/cache@v4
+        uses: actions/cache@v6
         id: demos-cache
         with:
           path: cs-demo-analyzer/cs-demos

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -16,17 +16,17 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v2
+      uses: actions/checkout@v7
       with:
         # We must fetch at least the immediate parents so that if this is
         # a pull request then we can checkout the head.
         fetch-depth: 2
 
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v1
+      uses: github/codeql-action/init@v4
 
     - name: Autobuild
-      uses: github/codeql-action/autobuild@v1
+      uses: github/codeql-action/autobuild@v4
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v1
+      uses: github/codeql-action/analyze@v4

--- a/.github/workflows/protobuf.yml
+++ b/.github/workflows/protobuf.yml
@@ -10,7 +10,7 @@ jobs:
     env:
       GameTracking_dir: /tmp/GameTracking-CSGO
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v7
       - name: Download latest Protobufs
         run: |
           git clone --depth=1 https://github.com/SteamDatabase/GameTracking-CSGO.git $GameTracking_dir
@@ -25,7 +25,7 @@ jobs:
 
       - name: Install Go
         if: env.PROTOBUFS_CHANGED == 'true'
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v7
         with:
           go-version: 1.24.x
 
@@ -57,7 +57,7 @@ jobs:
       - name: Create Pull Request
         id: pr
         if: env.PROTOBUFS_CHANGED == 'true'
-        uses: peter-evans/create-pull-request@v3
+        uses: peter-evans/create-pull-request@v8
         with:
           token: ${{ secrets.CUSTOM_GITHUB_TOKEN }}
           title: "protobuf: updated to ${{ env.COMMIT_SHA }}"


### PR DESCRIPTION
Updates CI workflows to current action versions.

Changes:
- actions/checkout v2/v4 -> v7
- actions/setup-go v5 -> v7
- actions/cache v4 -> v6
- github/codeql-action v1 -> v4
- peter-evans/create-pull-request v3 -> v8

Notes:
- checkout v7 and setup-go v7 inputs used here (fetch-depth, path, repository, ref, go-version, go-version-file, cache-dependency-path) are unchanged.
- create-pull-request v8 keeps the inputs used here (token, title, base, branch, author, commit-message, body). The v4 default author/committer change does not apply because this workflow sets author explicitly.
- mirror.yml is left as is because it pushes to a mirror remote.

Validation:
- all three workflow files parse as valid YAML with expected jobs
- action refs resolved against the latest stable releases at PR time

Scope: .github/workflows/ci.yml, .github/workflows/codeql-analysis.yml, .github/workflows/protobuf.yml only.
