### PR TITLE
fix: bound readBytes allocation before decoding corrupt lengths

### DIFF
--- a/pkg/demoinfocs/sendtables/sendtablescs2/reader.go
+++ b/pkg/demoinfocs/sendtables/sendtablescs2/reader.go
@@ -111,15 +111,17 @@ func (r *reader) readByte() byte {
 	return byte(r.readBits(8))
 }
 
-// readBytes reads the given number of bytes
+// readBytes reads the given number of bytes.
+// The bounds are checked before any allocation: n is often decoded from the
+// bitstream and an unbounded make() could allocate GBs on a corrupt demo.
 func (r *reader) readBytes(n uint32) []byte {
+	if n > r.remBytes() {
+		_panicf("readBytes: insufficient buffer (%d of %d)", uint64(r.pos)+uint64(n), r.size)
+	}
+
 	// Fast path if we're byte aligned
 	if r.bitCount == 0 {
 		r.pos += n
-
-		if r.pos > r.size {
-			_panicf("readBytes: insufficient buffer (%d of %d)", r.pos, r.size)
-		}
 
 		return r.buf[r.pos-n : r.pos]
 	}

--- a/pkg/demoinfocs/sendtables/sendtablescs2/reader_test.go
+++ b/pkg/demoinfocs/sendtables/sendtablescs2/reader_test.go
@@ -1,0 +1,81 @@
+package sendtablescs2
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestReader_ReadBytes_Aligned covers the byte-aligned fast path, including
+// reading exactly the remaining bytes and the bounds panic past them.
+func TestReader_ReadBytes_Aligned(t *testing.T) {
+	t.Parallel()
+
+	data := []byte{0x12, 0x34, 0x56, 0x78, 0x9A}
+	r := newReader(data)
+
+	assert.Equal(t, []byte{0x12, 0x34}, r.readBytes(2))
+	assert.Equal(t, []byte{0x56, 0x78, 0x9A}, r.readBytes(3))
+
+	// Exact boundary: reading the remaining bytes must not panic.
+	assert.Equal(t, []byte{}, r.readBytes(0))
+
+	assert.Panics(t, func() {
+		r.readBytes(1)
+	})
+}
+
+// TestReader_ReadBytes_Unaligned covers the bit-packed path, including the
+// exact boundary and bit-correct output after an initial misalignment.
+func TestReader_ReadBytes_Unaligned(t *testing.T) {
+	t.Parallel()
+
+	// Consume the low 4 bits of the first byte, shifting the stream by 4 bits.
+	assert.Equal(t, uint32(0x2), newReader([]byte{0x12}).readBits(4))
+
+	data := []byte{0x12, 0x34, 0x56, 0x78, 0x9A}
+	r := newReader(data)
+
+	assert.Equal(t, uint32(0x2), r.readBits(4))
+	assert.Equal(t, []byte{0x41, 0x63, 0x85}, r.readBytes(3))
+	// The remaining stream still lines up correctly.
+	assert.Equal(t, uint32(0xA7), r.readBits(8))
+
+	assert.Panics(t, func() {
+		r.readBytes(1)
+	})
+}
+
+// TestReader_ReadBytes_CorruptLength ensures a wire-decoded length that
+// exceeds the remaining buffer is rejected before any allocation.
+// Before the bounds check was hoisted, the unaligned path allocated up to
+// uint32-max bytes (OOM) before panicking.
+func TestReader_ReadBytes_CorruptLength(t *testing.T) {
+	t.Parallel()
+
+	aligned := newReader(make([]byte, 8))
+	requirePanicContaining(t, "readBytes: insufficient buffer", func() {
+		aligned.readBytes(0xFFFFFFFF)
+	})
+
+	unaligned := newReader(make([]byte, 8))
+	unaligned.readBits(3)
+	requirePanicContaining(t, "readBytes: insufficient buffer", func() {
+		unaligned.readBytes(0xFFFFFFFF)
+	})
+}
+
+func requirePanicContaining(t *testing.T, contains string, f func()) {
+	t.Helper()
+
+	defer func() {
+		r := recover()
+		require.NotNil(t, r)
+		msg, ok := r.(string)
+		require.True(t, ok)
+		assert.Contains(t, msg, contains)
+	}()
+
+	f()
+}


### PR DESCRIPTION
Follow-up to #665 (same OOM class, separate allocation site).

## Problem

`reader.readBytes`' bit-packed path allocated `make([]byte, n)` **before** touching the buffer, and `n` is often decoded straight off the bitstream:
- `binaryBlockDecoder` (field_decoder.go) — decoded length inside `PacketEntities` field decoding, i.e. precisely the desynced-stream scenario from #665;
- `parser.ParsePacket` (parser.go:162) — `r.readBytes(r.readVarUint32())` for flattened-serializer blobs.

A length-prefixed corrupt demo header field could yield `n` up to `uint32-max`, attempting a ~4 GB allocation before the read loop would ever hit the existing `nextByte` bounds panic. The byte-aligned fast path was already safe (advances `pos` then checks), but the unaligned path was not. Same "reachable memory defeats GOMEMLIMIT" profile as #665.

## Fix

Hoist the bounds check to the top of `readBytes`, before either path:

```go
if n > r.remBytes() {
    _panicf("readBytes: insufficient buffer (%d of %d)", uint64(r.pos)+uint64(n), r.size)
}
```

**Why it is exactly correct (no off-by-one / no false panics):** at entry `bitCount` is always `[0, 8)`, so reading `n` bytes consumes exactly `n` buffer bytes in both the byte-aligned and bit-packed cases — `n == remBytes()` still succeeds at the exact boundary. Bonus: the aligned path no longer advances `pos` past `size` before panicking.

The panic converts a potential OOM into the standard recoverable "corrupt demo" error (recovered by the dispatcher's PanicHandler / recorded parse error, consistent with #664/#678).

## Tests

New `reader_test.go`:
- byte-aligned reads incl. the exact-boundary case;
- bit-packed reads with correct bit-shifted output after misalignment;
- a corrupt length (`0xFFFFFFFF`) in both aligned and unaligned modes panics with the insufficient-buffer message — previously this path attempted a multi-GB allocation first.

## Validation

- `go build ./...`, `go vet` clean
- full `go test ./pkg/...` passes (healthy demo corpus parses unchanged — the bound only fires on corrupt input)
- race detector clean on the new tests