### PR TITLE
require go 1.27

### DIFF
--- a/.github/workflows/protobuf.yml
+++ b/.github/workflows/protobuf.yml
@@ -27,7 +27,7 @@ jobs:
         if: env.PROTOBUFS_CHANGED == 'true'
         uses: actions/setup-go@v7
         with:
-          go-version: 1.24.x
+          go-version: 1.27.x
 
       - name: Install Protobuf tools
         if: env.PROTOBUFS_CHANGED == 'true'

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ See [broadcast example for live CSTV+ parsing](https://github.com/markus-wa/demo
 
 ## Requirements
 
-This library requires at least `go 1.24` to run.
+This library requires at least `go 1.27` to run.
 You can download the latest version of Go [here](https://golang.org/).
 
 ## Quickstart Guide

--- a/go.mod
+++ b/go.mod
@@ -26,4 +26,4 @@ require (
 	golang.org/x/text v0.34.0 // indirect
 )
 
-go 1.24.0
+go 1.27.0


### PR DESCRIPTION
Bump the minimum Go version to 1.27:
- `go.mod`: `go 1.24.0` → `go 1.27.0`
- `protobuf.yml`: Go 1.24.x → 1.27.x (CI main already uses `go-version-file: go.mod`)
- `README.md`: document the new minimum

This unblocks dependabot PR #658 (golang.org/x/image 0.35 → 0.41 requires go ≥ 1.25; all newer x/image versions require 1.25+, and 1.25 is already EOL).

Verified locally under Go 1.27: build + unit tests + race tests (incl. demo parse), generated interfaces, golangci-lint v2.13.2 (no new issues vs master).