### PR TITLE
feat: expose knife detail via original weapon string + KnifeType helper

### DIFF
--- a/pkg/demoinfocs/common/equipment.go
+++ b/pkg/demoinfocs/common/equipment.go
@@ -314,9 +314,12 @@ type Equipment struct {
 	Type   EquipmentType // The type of weapon which the equipment instantiates.
 	Entity st.Entity     // The game entity instance
 	Owner  *Player       // The player carrying the equipment, not necessarily the buyer.
-	// E.g. 'models/weapons/w_rif_m4a1_s.mdl'.
-	// Used internally to differentiate alternative weapons (M4A4 / M4A1-S etc.) for Source 1 demos.
-	// It's always an empty string with Source 2 demos, you should use Type to know which weapon it is.
+	// Holds the original string of the weapon / equipment.
+	// E.g. the raw weapon name as provided by game events like 'knife_karambit' or 'ak47'.
+	// For entity-bound equipment that hasn't been seen in a game event it's empty.
+	// Use MapKnifeType() to resolve knife details from the raw name, or, if the
+	// equipment is entity-bound, map the item definition index
+	// (m_iItemDefinitionIndex) via KnifeTypeIndexMapping.
 	OriginalString string
 
 	uniqueID2 ulid.ULID

--- a/pkg/demoinfocs/common/knife.go
+++ b/pkg/demoinfocs/common/knife.go
@@ -1,0 +1,148 @@
+package common
+
+import (
+	"fmt"
+	"strings"
+)
+
+// KnifeType identifies the concrete knife model of a piece of equipment whose
+// Type is EqKnife. It is KnifeTypeUnknown for all other equipment.
+//
+// As Valve can add new knives over time, the known names and item definition
+// indexes are exposed through the mutable maps KnifeTypes and
+// KnifeTypeIndexMapping so new knives can be registered without upgrading the
+// library.
+type KnifeType int
+
+// All currently known knife types.
+const (
+	KnifeTypeUnknown       KnifeType = 0
+	KnifeTypeDefault       KnifeType = 1  // weapon_knife / weapon_knife_t
+	KnifeTypeBayonet       KnifeType = 2  // weapon_bayonet
+	KnifeTypeClassic       KnifeType = 3  // weapon_knife_css
+	KnifeTypeFlip          KnifeType = 4  // weapon_knife_flip
+	KnifeTypeGut           KnifeType = 5  // weapon_knife_gut
+	KnifeTypeKarambit      KnifeType = 6  // weapon_knife_karambit
+	KnifeTypeM9Bayonet     KnifeType = 7  // weapon_knife_m9_bayonet
+	KnifeTypeHuntsman      KnifeType = 8  // weapon_knife_tactical
+	KnifeTypeFalchion      KnifeType = 9  // weapon_knife_falchion
+	KnifeTypeBowie         KnifeType = 10 // weapon_knife_survival_bowie
+	KnifeTypeButterfly     KnifeType = 11 // weapon_knife_butterfly
+	KnifeTypeShadowDaggers KnifeType = 12 // weapon_knife_push
+	KnifeTypeParacord      KnifeType = 13 // weapon_knife_cord
+	KnifeTypeSurvival      KnifeType = 14 // weapon_knife_canis
+	KnifeTypeUrsus         KnifeType = 15 // weapon_knife_ursus
+	KnifeTypeNavaja        KnifeType = 16 // weapon_knife_gypsy_jackknife
+	KnifeTypeNomad         KnifeType = 17 // weapon_knife_outdoor
+	KnifeTypeStiletto      KnifeType = 18 // weapon_knife_stiletto
+	KnifeTypeTalon         KnifeType = 19 // weapon_knife_widowmaker
+	KnifeTypeSkeleton      KnifeType = 20 // weapon_knife_skeleton
+	KnifeTypeKukri         KnifeType = 21 // weapon_knife_kukri
+)
+
+// KnifeTypes maps the names of knives as they appear in game events and
+// MapEquipment (e.g. "knife_karambit") to their KnifeType.
+//
+// This map is mutable so new knives can be registered without upgrading the
+// library. The "weapon_" prefix, if present, is stripped before lookup.
+var KnifeTypes = map[string]KnifeType{
+	"knife":                 KnifeTypeDefault,
+	"knife_t":               KnifeTypeDefault,
+	"bayonet":               KnifeTypeBayonet,
+	"knife_css":             KnifeTypeClassic,
+	"knife_flip":            KnifeTypeFlip,
+	"knife_gut":             KnifeTypeGut,
+	"knife_karambit":        KnifeTypeKarambit,
+	"knife_m9_bayonet":      KnifeTypeM9Bayonet,
+	"knife_tactical":        KnifeTypeHuntsman,
+	"knife_falchion":        KnifeTypeFalchion,
+	"knife_survival_bowie":  KnifeTypeBowie,
+	"knife_butterfly":       KnifeTypeButterfly,
+	"knife_push":            KnifeTypeShadowDaggers,
+	"knife_cord":            KnifeTypeParacord,
+	"knife_canis":           KnifeTypeSurvival,
+	"knife_ursus":           KnifeTypeUrsus,
+	"knife_gypsy_jackknife": KnifeTypeNavaja,
+	"knife_outdoor":         KnifeTypeNomad,
+	"knife_stiletto":        KnifeTypeStiletto,
+	"knife_widowmaker":      KnifeTypeTalon,
+	"knife_skeleton":        KnifeTypeSkeleton,
+	"knife_kukri":           KnifeTypeKukri,
+}
+
+// KnifeTypeIndexMapping maps m_iItemDefinitionIndex values of knives to their
+// KnifeType.
+//
+// This map is mutable so new knives can be registered without upgrading the
+// library. The novelty knifegg (41) and ghost (80) knives are intentionally
+// not mapped and resolve to KnifeTypeUnknown.
+var KnifeTypeIndexMapping = map[uint64]KnifeType{
+	42:  KnifeTypeDefault,
+	59:  KnifeTypeDefault,
+	500: KnifeTypeBayonet,
+	503: KnifeTypeClassic,
+	505: KnifeTypeFlip,
+	506: KnifeTypeGut,
+	507: KnifeTypeKarambit,
+	508: KnifeTypeM9Bayonet,
+	509: KnifeTypeHuntsman,
+	512: KnifeTypeFalchion,
+	514: KnifeTypeBowie,
+	515: KnifeTypeButterfly,
+	516: KnifeTypeShadowDaggers,
+	517: KnifeTypeParacord,
+	518: KnifeTypeSurvival,
+	519: KnifeTypeUrsus,
+	520: KnifeTypeNavaja,
+	521: KnifeTypeNomad,
+	522: KnifeTypeStiletto,
+	523: KnifeTypeTalon,
+	525: KnifeTypeSkeleton,
+	526: KnifeTypeKukri,
+}
+
+// KnifeTypeNames contains the display names of all known knife types.
+//
+// This map is mutable so display names can be registered for custom knife
+// types added to KnifeTypes / KnifeTypeIndexMapping.
+var KnifeTypeNames = map[KnifeType]string{
+	KnifeTypeDefault:       "Default Knife",
+	KnifeTypeBayonet:       "Bayonet",
+	KnifeTypeClassic:       "Classic Knife",
+	KnifeTypeFlip:          "Flip Knife",
+	KnifeTypeGut:           "Gut Knife",
+	KnifeTypeKarambit:      "Karambit",
+	KnifeTypeM9Bayonet:     "M9 Bayonet",
+	KnifeTypeHuntsman:      "Huntsman Knife",
+	KnifeTypeFalchion:      "Falchion Knife",
+	KnifeTypeBowie:         "Bowie Knife",
+	KnifeTypeButterfly:     "Butterfly Knife",
+	KnifeTypeShadowDaggers: "Shadow Daggers",
+	KnifeTypeParacord:      "Paracord Knife",
+	KnifeTypeSurvival:      "Survival Knife",
+	KnifeTypeUrsus:         "Ursus Knife",
+	KnifeTypeNavaja:        "Navaja Knife",
+	KnifeTypeNomad:         "Nomad Knife",
+	KnifeTypeStiletto:      "Stiletto Knife",
+	KnifeTypeTalon:         "Talon Knife",
+	KnifeTypeSkeleton:      "Skeleton Knife",
+	KnifeTypeKukri:         "Kukri Knife",
+}
+
+// String returns the human readable name of the knife type.
+// E.g. 'Karambit', 'Shadow Daggers', 'Kukri Knife' etc.
+func (k KnifeType) String() string {
+	if name, ok := KnifeTypeNames[k]; ok {
+		return name
+	}
+
+	return fmt.Sprintf("KnifeType(%d)", k)
+}
+
+// MapKnifeType creates a KnifeType from the name of the knife.
+// The "weapon_" prefix, if present, is ignored, so both "knife_karambit" and
+// "weapon_knife_karambit" map to KnifeTypeKarambit.
+// Returns KnifeTypeUnknown for names that don't map to a known knife type.
+func MapKnifeType(eqName string) KnifeType {
+	return KnifeTypes[strings.TrimPrefix(eqName, weaponPrefix)]
+}

--- a/pkg/demoinfocs/common/knife_test.go
+++ b/pkg/demoinfocs/common/knife_test.go
@@ -1,0 +1,57 @@
+package common
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestMapKnifeType(t *testing.T) {
+	assert.Equal(t, KnifeTypeKarambit, MapKnifeType("knife_karambit"), "'knife_karambit' should map to KnifeTypeKarambit")
+	assert.Equal(t, KnifeTypeBayonet, MapKnifeType("bayonet"), "'bayonet' should map to KnifeTypeBayonet")
+	assert.Equal(t, KnifeTypeBayonet, MapKnifeType("weapon_bayonet"), "'weapon_bayonet' should map to KnifeTypeBayonet")
+	assert.Equal(t, KnifeTypeTalon, MapKnifeType("knife_widowmaker"), "'knife_widowmaker' should map to KnifeTypeTalon")
+	assert.Equal(t, KnifeTypeDefault, MapKnifeType("knife"), "'knife' should map to KnifeTypeDefault")
+	assert.Equal(t, KnifeTypeUnknown, MapKnifeType("knife_unknown_future_knife"), "unknown knife names should map to KnifeTypeUnknown")
+	assert.Equal(t, KnifeTypeUnknown, MapKnifeType("ak47"), "non-knife names should map to KnifeTypeUnknown")
+}
+
+func TestKnifeTypeString(t *testing.T) {
+	assert.Equal(t, "Shadow Daggers", KnifeTypeShadowDaggers.String(), "KnifeTypeShadowDaggers should be named correctly")
+	assert.Equal(t, "Classic Knife", KnifeTypeClassic.String(), "KnifeTypeClassic should be named correctly")
+	assert.Equal(t, "Kukri Knife", KnifeTypeKukri.String(), "KnifeTypeKukri should be named correctly")
+	assert.Equal(t, "KnifeType(0)", KnifeTypeUnknown.String(), "KnifeTypeUnknown should have a fallback name")
+	assert.Equal(t, "KnifeType(999)", KnifeType(999).String(), "unknown knife types should have a fallback name")
+}
+
+func TestKnifeTypeNamesExtension(t *testing.T) {
+	custom := KnifeType(500)
+	KnifeTypeNames[custom] = "Custom Knife"
+
+	assert.Equal(t, "Custom Knife", custom.String(), "custom knife types should be nameable via KnifeTypeNames")
+}
+
+func TestKnifeTypeIndexMappingCompleteness(t *testing.T) {
+	// Every knife in EquipmentIndexMapping (index >= 500, excluding the novelty
+	// knifegg and knife_ghost items) should have a KnifeTypeIndexMapping entry
+	// so knife details can always be resolved from the item definition index.
+	for itemIndex, eqType := range EquipmentIndexMapping {
+		if eqType != EqKnife {
+			continue
+		}
+
+		if itemIndex < 500 {
+			continue
+		}
+
+		knifeType, ok := KnifeTypeIndexMapping[itemIndex]
+		assert.True(t, ok, "index %d should have a KnifeTypeIndexMapping entry", itemIndex)
+		assert.NotEqual(t, KnifeTypeUnknown, knifeType, "index %d should map a known knife type", itemIndex)
+	}
+}
+
+func TestKnifeTypesValues(t *testing.T) {
+	for name, knifeType := range KnifeTypes {
+		assert.NotEqual(t, KnifeTypeUnknown, knifeType, "name %q should map to a known knife type", name)
+	}
+}

--- a/pkg/demoinfocs/datatables.go
+++ b/pkg/demoinfocs/datatables.go
@@ -739,7 +739,7 @@ func (p *parser) bindGrenadeProjectiles(entity st.Entity) {
 		}
 
 		// copy the weapon so it doesn't get overwritten by a new entity in parser.weapons
-		wepCopy := *(getPlayerWeapon(proj.Thrower, wep))
+		wepCopy := *(getPlayerWeapon(proj.Thrower, wep, ""))
 		proj.WeaponInstance = &wepCopy
 
 		unassert.NotNilf(proj.WeaponInstance, "couldn't find grenade instance for player")

--- a/pkg/demoinfocs/game_events.go
+++ b/pkg/demoinfocs/game_events.go
@@ -397,11 +397,12 @@ func (geh gameEventHandler) weaponFire(data map[string]*msg.CMsgSource1LegacyGam
 	}
 
 	shooter := geh.playerByUserID32(data["userid"].GetValShort())
-	wepType := common.MapEquipment(data["weapon"].GetValString())
+	rawWeapon := data["weapon"].GetValString()
+	wepType := common.MapEquipment(rawWeapon)
 
 	geh.dispatch(events.WeaponFire{
 		Shooter: shooter,
-		Weapon:  getPlayerWeapon(shooter, wepType),
+		Weapon:  getPlayerWeapon(shooter, wepType, rawWeapon),
 	})
 }
 
@@ -421,7 +422,8 @@ func (geh gameEventHandler) weaponReload(data map[string]*msg.CMsgSource1LegacyG
 
 func (geh gameEventHandler) playerDeath(data map[string]*msg.CMsgSource1LegacyGameEventKeyT) {
 	killer := geh.playerByUserID32(data["attacker"].GetValShort())
-	wepType := common.MapEquipment(data["weapon"].GetValString())
+	rawWeapon := data["weapon"].GetValString()
+	wepType := common.MapEquipment(rawWeapon)
 	victimUserID := data["userid"].GetValShort()
 
 	wepType = geh.attackerWeaponType(wepType, victimUserID)
@@ -436,7 +438,7 @@ func (geh gameEventHandler) playerDeath(data map[string]*msg.CMsgSource1LegacyGa
 		Assister:          geh.playerByUserID32(data["assister"].GetValShort()),
 		IsHeadshot:        data["headshot"].GetValBool(),
 		PenetratedObjects: int(data["penetrated"].GetValShort()),
-		Weapon:            geh.getEquipmentInstance(killer, wepType),
+		Weapon:            geh.getEquipmentInstance(killer, wepType, rawWeapon),
 		AssistedFlash:     data["assistedflash"].GetValBool(),
 		AttackerBlind:     data["attackerblind"].GetValBool(),
 		NoScope:           data["noscope"].GetValBool(),
@@ -506,7 +508,7 @@ func (geh gameEventHandler) playerHurt(data map[string]*msg.CMsgSource1LegacyGam
 		HealthDamageTaken: healthDamageTaken,
 		ArmorDamageTaken:  armorDamageTaken,
 		HitGroup:          events.HitGroup(data["hitgroup"].GetValByte()),
-		Weapon:            geh.getEquipmentInstance(attacker, wepType),
+		Weapon:            geh.getEquipmentInstance(attacker, wepType, rawWeapon),
 		WeaponString:      rawWeapon,
 	})
 }
@@ -900,8 +902,9 @@ func (geh gameEventHandler) otherDeath(data map[string]*msg.CMsgSource1LegacyGam
 		otherPosition = other.Position()
 	}
 
-	wepType := common.MapEquipment(data["weapon"].GetValString())
-	weapon := getPlayerWeapon(killer, wepType)
+	rawWeapon := data["weapon"].GetValString()
+	wepType := common.MapEquipment(rawWeapon)
+	weapon := getPlayerWeapon(killer, wepType, rawWeapon)
 
 	geh.dispatch(events.OtherDeath{
 		Killer:            killer,
@@ -921,7 +924,7 @@ func (geh gameEventHandler) itemEvent(data map[string]*msg.CMsgSource1LegacyGame
 	player := geh.playerByUserID32(data["userid"].GetValShort())
 
 	wepType := common.MapEquipment(data["item"].GetValString())
-	weapon := getPlayerWeapon(player, wepType)
+	weapon := getPlayerWeapon(player, wepType, data["item"].GetValString())
 
 	return player, weapon
 }
@@ -1077,27 +1080,33 @@ func (geh gameEventHandler) attackerWeaponType(wepType common.EquipmentType, vic
 	return wepType
 }
 
-func (geh gameEventHandler) getEquipmentInstance(player *common.Player, wepType common.EquipmentType) *common.Equipment {
+func (geh gameEventHandler) getEquipmentInstance(player *common.Player, wepType common.EquipmentType, rawName string) *common.Equipment {
 	isGrenade := wepType.Class() == common.EqClassGrenade
 	if isGrenade {
 		return geh.getThrownGrenade(player, wepType)
 	}
 
-	return getPlayerWeapon(player, wepType)
+	return getPlayerWeapon(player, wepType, rawName)
 }
 
 // Returns the players instance of the weapon if applicable or a new instance otherwise.
-func getPlayerWeapon(player *common.Player, wepType common.EquipmentType) *common.Equipment {
+//
+// The weapon's OriginalString is set to the raw event weapon name (rawName),
+// which may be empty (e.g. for grenade projectiles).
+func getPlayerWeapon(player *common.Player, wepType common.EquipmentType, rawName string) *common.Equipment {
 	if player != nil {
 		alternateWepType := common.EquipmentAlternative(wepType)
 		for _, wep := range player.Weapons() {
 			if wep.Type == wepType || (alternateWepType != common.EqUnknown && wep.Type == alternateWepType) {
+				wep.OriginalString = rawName
+
 				return wep
 			}
 		}
 	}
 
 	wep := common.NewEquipment(wepType)
+	wep.OriginalString = rawName
 
 	return wep
 }

--- a/pkg/demoinfocs/game_events_test.go
+++ b/pkg/demoinfocs/game_events_test.go
@@ -59,7 +59,7 @@ func TestRoundEnd_LoserState_Score(t *testing.T) {
 }
 
 func TestGetPlayerWeapon_NilPlayer(t *testing.T) {
-	wep := getPlayerWeapon(nil, common.EqAK47)
+	wep := getPlayerWeapon(nil, common.EqAK47, "")
 
 	assert.NotNil(t, wep)
 	assert.Equal(t, common.EqAK47, wep.Type)
@@ -73,9 +73,10 @@ func TestGetPlayerWeapon_Found(t *testing.T) {
 		},
 	}
 
-	wep := getPlayerWeapon(pl, common.EqAK47)
+	wep := getPlayerWeapon(pl, common.EqAK47, "ak47")
 
 	assert.True(t, wep == ak)
+	assert.Equal(t, "ak47", wep.OriginalString)
 }
 
 func TestGetPlayerWeapon_NotFound(t *testing.T) {
@@ -86,9 +87,22 @@ func TestGetPlayerWeapon_NotFound(t *testing.T) {
 		},
 	}
 
-	wep := getPlayerWeapon(pl, common.EqM4A1)
+	wep := getPlayerWeapon(pl, common.EqM4A1, "")
 
 	assert.Equal(t, common.EqM4A1, wep.Type)
+}
+
+func TestGetPlayerWeapon_OriginalString(t *testing.T) {
+	wep := getPlayerWeapon(nil, common.EqKnife, "knife_karambit")
+
+	assert.Equal(t, common.EqKnife, wep.Type)
+	assert.Equal(t, "knife_karambit", wep.OriginalString)
+}
+
+func TestGetPlayerWeapon_OriginalString_NonKnife(t *testing.T) {
+	wep := getPlayerWeapon(nil, common.EqAK47, "ak47")
+
+	assert.Equal(t, "ak47", wep.OriginalString)
 }
 
 func TestAddThrownGrenade_NilPlayer(t *testing.T) {
@@ -231,7 +245,7 @@ func TestGetEquipmentInstance_NotGrenade(t *testing.T) {
 	p := NewParser(rand.Reader).(*parser)
 	pl := &common.Player{}
 
-	wep := p.gameEventHandler.getEquipmentInstance(pl, common.EqAK47)
+	wep := p.gameEventHandler.getEquipmentInstance(pl, common.EqAK47, "")
 
 	assert.Equal(t, common.EqAK47, wep.Type)
 }
@@ -240,7 +254,7 @@ func TestGetEquipmentInstance_Grenade_NotThrown(t *testing.T) {
 	p := NewParser(rand.Reader).(*parser)
 	pl := &common.Player{}
 
-	wep := p.gameEventHandler.getEquipmentInstance(pl, common.EqSmoke)
+	wep := p.gameEventHandler.getEquipmentInstance(pl, common.EqSmoke, "")
 
 	assert.Nil(t, wep)
 }
@@ -251,7 +265,7 @@ func TestGetEquipmentInstance_Grenade_Thrown(t *testing.T) {
 	he := common.NewEquipment(common.EqHE)
 
 	p.gameEventHandler.addThrownGrenade(pl, he)
-	wep := p.gameEventHandler.getEquipmentInstance(pl, he.Type)
+	wep := p.gameEventHandler.getEquipmentInstance(pl, he.Type, "")
 
 	assert.Equal(t, he, wep)
 }


### PR DESCRIPTION
Enable consumers to resolve which specific knife a player is carrying. Implements the feature requested in #431.

## Design

A specific knife is *not* precomputed on `Equipment` — the Source 2 server class for knives is a single `CKnife`, so the only per-knife identifiers are:
- the raw weapon string in game events (e.g. `"knife_karambit"`), and
- `m_iItemDefinitionIndex` on the weapon entity.

So instead:

- New `common.KnifeType` + `common.MapKnifeType(name)` + `String()` (retail names — e.g. `knife_css` → Classic Knife, `knife_tactical` → Huntsman Knife, `knife_widowmaker` → Talon Knife, `knife_push` → Shadow Daggers).
- Mutable, user-extensible maps so Valve can add knives without a library upgrade:
  - `common.KnifeTypes` (name → `KnifeType`)
  - `common.KnifeTypeIndexMapping` (item definition index → `KnifeType`)
  - `common.KnifeTypeNames` (type → display name)
- `Equipment.OriginalString` is now populated with the raw weapon string from game events — on both the bound weapon entity and the `NewEquipment` fallback (kills, hurt, fire, pickups, item events). Users can map it with `MapKnifeType()`, or resolve knife details from the entity's `m_iItemDefinitionIndex` via `KnifeTypeIndexMapping`.

`Type == EqKnife` stays the canonical "is a knife" check (backwards compatible).

## Tests
- `common/knife_test.go`: name mapping, display names (+ custom-name extension), index-map completeness against `EquipmentIndexMapping`.
- `game_events_test.go`: `OriginalString` set from the event weapon string on both paths.