### PR TITLE
docs(common): clarify IsWalking() reflects walk key, not movement

### DIFF
--- a/pkg/demoinfocs/common/player.go
+++ b/pkg/demoinfocs/common/player.go
@@ -240,7 +240,16 @@ func (p *Player) IsInBuyZone() bool {
 	return getBool(p.PlayerPawnEntity(), "m_bInBuyZone")
 }
 
-// IsWalking returns whether the player is currently walking (sneaking) in or not.
+// IsWalking returns whether the player is holding the walk (sneak) key,
+// i.e. is in sneak mode.
+//
+// Note: this does not indicate that the player is actually moving - it is true
+// even while standing still, as long as the walk key is held.
+// For actual movement detection use Velocity() instead, or derive it from the
+// position delta between ticks (see Position()), since Velocity() returns a
+// zero vector on GOTV demos.
+//
+// See https://github.com/markus-wa/demoinfocs-golang/issues/318
 func (p *Player) IsWalking() bool {
 	return getBool(p.PlayerPawnEntity(), "m_bIsWalking")
 }


### PR DESCRIPTION
## Context

`IsWalking()` is backed by the `m_bIsWalking` prop, which indicates that the walk (sneak) key is being held — it does **not** mean the player is actually moving. As demonstrated in #318, it is `true` even while standing perfectly still, as long as the walk key is held.

## Changes

Clarify the doc comment on `Player.IsWalking()` to:

- state that it reflects the walk/sneak key being held (sneak mode), true even when stationary
- point to `Velocity()` — or position deltas between ticks, since `Velocity()` returns a zero vector on GOTV demos — for actual movement detection

Docs-only change, no behavior change.

Refs #318 (issue carries the `needs: documentation` label; a potential rename of the function could be considered for a future major version)