### PR TITLE
perf: fix alloc regressions, pool frame buffers, end below v5.2.0 in allocs & memory

### DIFF
--- a/pkg/demoinfocs/parser.go
+++ b/pkg/demoinfocs/parser.go
@@ -134,6 +134,8 @@ type parser struct {
 	stringTables          []*msg.CSVCMsg_CreateStringTable                         // Contains all created sendtables, needed when updating them
 	delayedEventHandlers  []func()                                                 // Contains event handlers that need to be executed at the end of a tick (e.g. flash events because FlashDuration isn't updated before that)
 	pendingMessagesCache  []pendingMessage                                         // Cache for pending messages that need to be dispatched after the current tick
+	pendingMsgBufs        []*[]byte                                                // Pool entries backing pendingMessagesCache's buffers, returned to msgBufPool when the packet is done
+	snappyScratch         []byte                                                   // Reusable snappy decode destination for compressed frames (single-threaded frame parsing)
 	userCmdStates         map[int32]*userCmdPlayerState                            // Per-player command-number ring reconstructed from full + delta updates
 	userCmdButtonStates   map[int32]*userCmdButtonPlayerState                      // Per-player command-number ring containing buttonstate1 only
 	hasUserCmdMessages    bool                                                     // True once a CSVCMsg_UserCommands message has been seen; replace the legacy m_nButtonDownMaskPrev prop

--- a/pkg/demoinfocs/parsing.go
+++ b/pkg/demoinfocs/parsing.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"io"
 	"math"
+	"sync"
 	"time"
 
 	"github.com/golang/snappy"
@@ -16,6 +17,34 @@ import (
 
 	"github.com/markus-wa/demoinfocs-golang/v5/pkg/demoinfocs/events"
 )
+
+// msgBufPool recycles the byte slices that hold frame and embedded-message
+// payloads. proto.Unmarshal always copies bytes fields into the message, so
+// the input buffers are dead once the message is unmarshaled and can be
+// returned to this pool. See parseFrame() and handleDemoPacket().
+var msgBufPool = sync.Pool{
+	New: func() any {
+		b := make([]byte, 0, 1024)
+		return &b
+	},
+}
+
+func getMsgBuf(n int) *[]byte {
+	bp := msgBufPool.Get().(*[]byte)
+	if cap(*bp) < n {
+		*bp = make([]byte, 0, n)
+	}
+
+	*bp = (*bp)[:0]
+
+	return bp
+}
+
+func putMsgBuf(bp *[]byte) {
+	if bp != nil {
+		msgBufPool.Put(bp)
+	}
+}
 
 const (
 	playerWeaponPrefixS2 = "m_pWeaponServices.m_hMyWeapons"
@@ -257,6 +286,75 @@ var demoCommandMsgsCreators = map[msg.EDemoCommands]NetMessageCreator{
 	msg.EDemoCommands_DEM_Recovery:        func() proto.Message { return &msg.CDemoRecovery{} },
 }
 
+// readFramePayload reads (and, if needed, decompresses) the current frame's payload.
+//
+// Regular demos read into a pooled buffer and reuse the per-parser snappy
+// scratch as the decompression destination; the pool entry is returned so the
+// caller can put it back after proto.Unmarshal (which copies everything it
+// needs). bp is nil whenever buf is not pool-backed.
+//
+// CSTV broadcasts retain buf in messages (m.Data = buf), so they get a plain,
+// unpooled read with a fresh snappy destination.
+func (p *parser) readFramePayload(size int, msgCompressed, isCSTVBroadcast bool) (buf []byte, bp *[]byte) {
+	if isCSTVBroadcast {
+		buf = p.bitReader.ReadBytes(size)
+
+		if msgCompressed {
+			var err error
+
+			buf, err = snappy.Decode(nil, buf)
+			if err != nil {
+				p.handleSnappyError(err)
+			}
+		}
+
+		return buf, nil
+	}
+
+	bp = getMsgBuf(size)
+	p.bitReader.ReadBytesInto(bp, size)
+	buf = *bp
+
+	if !msgCompressed {
+		return buf, bp
+	}
+
+	// Reuse the per-parser scratch as the snappy destination: the decoded
+	// payload is dead after the caller's proto.Unmarshal, and frame parsing
+	// is single-threaded.
+	var err error
+
+	buf, err = snappy.Decode(p.snappyScratch, buf)
+
+	// The pooled input is consumed either way; only the decoded scratch
+	// carries data from here on.
+	putMsgBuf(bp)
+
+	if err != nil {
+		buf = nil
+
+		p.handleSnappyError(err)
+
+		return buf, nil
+	}
+
+	p.snappyScratch = buf[:0]
+
+	return buf, nil
+}
+
+func (p *parser) handleSnappyError(err error) {
+	if errors.Is(err, snappy.ErrCorrupt) {
+		p.eventDispatcher.Dispatch(events.ParserWarn{
+			Message: "compressed message is corrupt",
+		})
+
+		return
+	}
+
+	panic(err)
+}
+
 //nolint:funlen
 func (p *parser) parseFrame() bool {
 	cmd := msg.EDemoCommands(p.bitReader.ReadVarInt32())
@@ -317,22 +415,7 @@ func (p *parser) parseFrame() bool {
 		return true
 	}
 
-	buf := p.bitReader.ReadBytes(int(size))
-
-	if msgCompressed {
-		var err error
-
-		buf, err = snappy.Decode(nil, buf)
-		if err != nil {
-			if errors.Is(err, snappy.ErrCorrupt) {
-				p.eventDispatcher.Dispatch(events.ParserWarn{
-					Message: "compressed message is corrupt",
-				})
-			} else {
-				panic(err)
-			}
-		}
-	}
+	buf, bp := p.readFramePayload(int(size), msgCompressed, isCSTVBroadcast)
 
 	m := msgCreator()
 
@@ -359,6 +442,8 @@ func (p *parser) parseFrame() bool {
 		if err != nil {
 			panic(err) // FIXME: avoid panic
 		}
+
+		putMsgBuf(bp)
 	}
 
 	p.msgQueue <- m

--- a/pkg/demoinfocs/s2_commands.go
+++ b/pkg/demoinfocs/s2_commands.go
@@ -325,14 +325,25 @@ func (p *parser) handleDemoPacket(pack *msg.CDemoPacket, isFullPacket bool) {
 	r := bitread.NewSmallBitReader(bytes.NewReader(b))
 
 	p.pendingMessagesCache = p.pendingMessagesCache[:0]
+	p.pendingMsgBufs = p.pendingMsgBufs[:0]
 
 	for len(b)*8-r.ActualPosition() > 7 {
 		t := int32(r.ReadUBitInt())
 		size := r.ReadVarInt32()
-		buf := r.ReadBytes(int(size))
+		bp := getMsgBuf(int(size))
+		r.ReadBytesInto(bp, int(size))
 
-		p.pendingMessagesCache = append(p.pendingMessagesCache, pendingMessage{t, buf})
+		p.pendingMessagesCache = append(p.pendingMessagesCache, pendingMessage{t, *bp})
+		p.pendingMsgBufs = append(p.pendingMsgBufs, bp)
 	}
+
+	// All buffers are consumed by the unmarshal loop below; make sure they go
+	// back to the pool no matter how the loop ends.
+	defer func() {
+		for _, bp := range p.pendingMsgBufs {
+			putMsgBuf(bp)
+		}
+	}()
 
 	p.poolBitReader(r)
 

--- a/pkg/demoinfocs/sendtables/sendtablescs2/field.go
+++ b/pkg/demoinfocs/sendtables/sendtablescs2/field.go
@@ -127,10 +127,12 @@ func (f *field) setModel(model int) {
 			polyID := f.polySerializerID
 			f.baseDecoder = func(r *reader) any {
 				if r.readBoolean() {
-					return &polyUpdate{id: polyID, ser: polyTypes[r.readUBitVar()]}
+					r.polyScratch = polyUpdate{id: polyID, ser: polyTypes[r.readUBitVar()]}
+				} else {
+					r.polyScratch = polyUpdate{id: polyID}
 				}
 
-				return &polyUpdate{id: polyID, ser: nil}
+				return &r.polyScratch
 			}
 		}
 

--- a/pkg/demoinfocs/sendtables/sendtablescs2/field_decoder.go
+++ b/pkg/demoinfocs/sendtables/sendtablescs2/field_decoder.go
@@ -368,8 +368,17 @@ func noscaleFloat32(r *reader) float32 {
 	return r.cachedFloat32(bits).(float32)
 }
 
+// noscaleDecoder returns the pre-boxed value from the reader's float32 cache
+// instead of boxing a freshly returned float32, which would allocate on every
+// decode. noscaleFloat32 exists for callers that need a plain float32 (QAngle
+// noscale components); use it there, never re-box its result here.
 func noscaleDecoder(r *reader) any {
-	return noscaleFloat32(r)
+	bits := r.readLeUint32()
+	if bits == 0 {
+		return float32(0)
+	}
+
+	return r.cachedFloat32(bits)
 }
 
 func runeTimeDecoder(r *reader) any {

--- a/pkg/demoinfocs/sendtables/sendtablescs2/field_decoder.go
+++ b/pkg/demoinfocs/sendtables/sendtablescs2/field_decoder.go
@@ -293,7 +293,17 @@ func quantizedFactory(f *field) fieldDecoder {
 	qfd := newQuantizedFloatDecoder(f.bitCount, f.encodeFlags, f.lowValue, f.highValue)
 
 	return func(r *reader) any {
-		return qfd.decode(r)
+		v := qfd.decode(r)
+
+		// Route through the reader's boxed-value cache: quantized values repeat
+		// heavily across ticks (positions of stationary players etc.), so a
+		// cache hit avoids the float32 boxing allocation.
+		bits := math.Float32bits(v)
+		if bits == 0 {
+			return float32(0)
+		}
+
+		return r.cachedFloat32(bits)
 	}
 }
 
@@ -417,7 +427,7 @@ func qanglePreciseDecoder(r *reader) any {
 		v[2] = readBitCoordPres(r)
 	}
 
-	return v
+	return r.cachedVec3(v)
 }
 
 func qangleFactory(f *field) fieldDecoder {
@@ -431,22 +441,22 @@ func qangleFactory(f *field) fieldDecoder {
 		// m_aimPunchAngle reading a near-constant ~265-273 deg). Mirror floatFactory's noscale guard.
 		if *f.bitCount >= 32 {
 			return func(r *reader) any {
-				return [3]float32{
+				return r.cachedVec3([3]float32{
 					noscaleFloat32(r),
 					noscaleFloat32(r),
 					noscaleFloat32(r),
-				}
+				})
 			}
 		}
 
 		n := uint32(*f.bitCount)
 
 		return func(r *reader) any {
-			return [3]float32{
+			return r.cachedVec3([3]float32{
 				r.readAngle(n),
 				r.readAngle(n),
 				r.readAngle(n),
-			}
+			})
 		}
 	}
 
@@ -469,7 +479,7 @@ func qangleFactory(f *field) fieldDecoder {
 			ret[2] = r.readCoord()
 		}
 
-		return ret
+		return r.cachedVec3(ret)
 	}
 }
 

--- a/pkg/demoinfocs/sendtables/sendtablescs2/reader.go
+++ b/pkg/demoinfocs/sendtables/sendtablescs2/reader.go
@@ -24,6 +24,10 @@ type reader struct {
 	// Indexed by (bits & f32CacheMask); same bits == same float32 value so reuse is safe.
 	// Retained across pool reuse to maximise hit rate; no reset needed on newReader.
 	f32Cache [512]f32CacheEntry
+	// polyScratch is reused by polymorphic pointer base decoders to return
+	// *polyUpdate without allocating. Safe because readFields consumes the
+	// returned value synchronously before the next decode on the same reader.
+	polyScratch polyUpdate
 }
 
 const f32CacheMask = uint32(512 - 1) // must match f32Cache array size

--- a/pkg/demoinfocs/sendtables/sendtablescs2/reader.go
+++ b/pkg/demoinfocs/sendtables/sendtablescs2/reader.go
@@ -23,14 +23,46 @@ type reader struct {
 	// f32Cache is a direct-mapped cache of pre-boxed float32 any values.
 	// Indexed by (bits & f32CacheMask); same bits == same float32 value so reuse is safe.
 	// Retained across pool reuse to maximise hit rate; no reset needed on newReader.
-	f32Cache [512]f32CacheEntry
+	f32Cache [4096]f32CacheEntry
+	// v3Cache is a direct-mapped cache of pre-boxed [3]float32 any values,
+	// keyed by the three IEEE-754 bit patterns. Angles repeat heavily across
+	// ticks (stationary players), so a hit avoids the array boxing allocation.
+	v3Cache [1024]v3CacheEntry
 	// polyScratch is reused by polymorphic pointer base decoders to return
 	// *polyUpdate without allocating. Safe because readFields consumes the
 	// returned value synchronously before the next decode on the same reader.
 	polyScratch polyUpdate
 }
 
-const f32CacheMask = uint32(512 - 1) // must match f32Cache array size
+const f32CacheMask = uint32(4096 - 1) // must match f32Cache array size
+const v3CacheMask = uint32(1024 - 1)  // must match v3Cache array size
+
+// v3CacheEntry caches a pre-boxed [3]float32 for a given bit-pattern triple.
+type v3CacheEntry struct {
+	bits  [3]uint32
+	boxed any
+}
+
+// cachedVec3 returns a pre-boxed any for the given [3]float32, allocating and
+// caching on miss. See f32Cache for the rationale of direct-mapped reuse.
+func (r *reader) cachedVec3(v [3]float32) any {
+	xb := math.Float32bits(v[0])
+	yb := math.Float32bits(v[1])
+	zb := math.Float32bits(v[2])
+
+	idx := (xb ^ (xb >> 16) ^ yb ^ (yb >> 16) ^ zb ^ (zb >> 16)) & v3CacheMask
+
+	e := &r.v3Cache[idx]
+	if e.boxed != nil && e.bits == [3]uint32{xb, yb, zb} {
+		return e.boxed
+	}
+
+	b := any(v)
+	e.bits = [3]uint32{xb, yb, zb}
+	e.boxed = b
+
+	return b
+}
 
 // cachedFloat32 returns a pre-boxed any for the given float32 bit pattern,
 // allocating and caching on miss. Zero is handled by the caller where possible.


### PR DESCRIPTION
## Motivation

Benchmarking master against v5.2.0 (s2.dem, benchstat, n=10) showed the polymorphic-field work regressed the parser hot path:

- **allocs/op: +37%** (5.79M → 7.96M)
- **ns/op: +8.5%** (~19% of CPU samples in `mallocgc`/GC scan machinery)

pprof (alloc_objects) attributed essentially the entire regression to two spots, both fixed and verified here. A second pass then pushed allocations and memory *below* v5.2.0 levels.

## Commit 1 — restore zero-alloc noscale decode, drop polyUpdate churn

- `noscaleDecoder` re-boxed the cached `float32` into a fresh `any` on every decode, defeating `reader.f32Cache` (the pre-boxed direct-mapped cache from the perf2026 work). It returned the pre-boxed cache value directly again; `noscaleFloat32` remains for the QAngle ≥32-bit path, which needs plain `float32` values.
  - pprof: 2.36M allocs / 3 parses → **0**
- Polymorphic pointer base decoders allocated a `polyUpdate` per decode even when the active type didn't change. They now return a pointer to a scratch slot on the `reader` — safe because `readFields` consumes the value synchronously before the next decode on the same reader.

## Commit 2 — widen value caches and pool frame payload buffers

- `f32Cache` 512 → 4096 entries (tested 8192: diminishing returns; working-set misses dominate)
- Quantized float32 decodes route through `f32Cache` (positions of stationary players repeat across ticks)
- New per-reader `v3Cache`: QAngle decoders return pre-boxed `[3]float32` keyed by the three bit patterns
- **Frame and embedded-message payload buffers** (`parseFrame`, `handleDemoPacket`) are recycled via `sync.Pool` — `proto.Unmarshal` always copies bytes fields, so input buffers are dead after unmarshaling. CSTV broadcasts keep the unpooled path since they retain buffers in messages (`m.Data = buf`)
- Compressed frames decode snappy into a per-parser scratch instead of a fresh allocation per frame

## Results (s2.dem, benchstat vs v5.2.0)

| Metric | v5.2.0 | master | this PR | Δ vs v5.2.0 |
|---|---|---|---|---|
| allocs/op | 5.792M | 7.957M | **5.107M** | **−11.8%** |
| B/op | 350.0 Mi | 333.9 Mi | **243.9 Mi** | **−30.2%** |
| CPU | baseline | +8.5% | **~3% faster** | differential pprof |

Wall-clock ns/op comparisons between benchmark sessions on this machine drift ±5–9% with thermals, so the CPU figure is based on differential pprof (`-diff_base`), which cancels that noise: master vs v5.2.0 = −0.03s net (parity), this PR vs master = −0.12s (~2.5% faster).

## Notes

- Corrupt-snappy behavior is preserved (warn + empty message for `ErrCorrupt`, panic otherwise); the pooled path nulls the partial decode first so no stale scratch bytes are ever unmarshaled
- Remaining alloc sources are legitimate work (proto message structs, handler dispatch, one-time collection states)

## Verification

- `go test ./...` green (golden files + s2 regression set)
- Race detector clean, including full-demo parse (`TestDemoInfoCs -race`)
- `golangci-lint` clean on both commits