### PR TITLE
v5 -> v6

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,7 +89,7 @@ jobs:
       - name: Update CSDA mod
         run: |
           cd cs-demo-analyzer
-          go mod edit -replace github.com/markus-wa/demoinfocs-golang/v5=../demoinfocs-golang
+          go mod edit -replace github.com/markus-wa/demoinfocs-golang/v6=../demoinfocs-golang
           go mod tidy
 
       - name: Download demos cache file

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -76,7 +76,7 @@ formatters:
       sections:
         - standard
         - default
-        - prefix(github.com/markus-wa/demoinfocs-golang/v5)
+        - prefix(github.com/markus-wa/demoinfocs-golang/v6)
   exclusions:
     paths:
       - msg

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 A blazing fast, feature complete and production ready Go library for parsing and analysing of Counter-Strike 2 and Counter-Strike: Global Offensive (CS:GO) demos (aka replays).
 
-[![go.dev reference](https://img.shields.io/badge/go.dev-reference-007d9c?logo=go&logoColor=white&style=flat-square)](https://pkg.go.dev/github.com/markus-wa/demoinfocs-golang/v5/pkg/demoinfocs?tab=doc)
+[![go.dev reference](https://img.shields.io/badge/go.dev-reference-007d9c?logo=go&logoColor=white&style=flat-square)](https://pkg.go.dev/github.com/markus-wa/demoinfocs-golang/v6/pkg/demoinfocs?tab=doc)
 [![Build Status](https://img.shields.io/github/actions/workflow/status/markus-wa/demoinfocs-golang/ci.yml?branch=master&style=flat-square)](https://github.com/markus-wa/demoinfocs-golang/actions)
 [![codecov](https://img.shields.io/codecov/c/github/markus-wa/demoinfocs-golang?style=flat-square)](https://codecov.io/gh/markus-wa/demoinfocs-golang)
 [![Go Report](https://goreportcard.com/badge/github.com/markus-wa/demoinfocs-golang?style=flat-square)](https://goreportcard.com/report/github.com/markus-wa/demoinfocs-golang)
@@ -21,7 +21,7 @@ For business inquiries please use the contact information found on the [GitHub p
 
 ### Counter-Strike 2 + Live Broadcast Parsing - aka. CSTV+
 
-	go get -u github.com/markus-wa/demoinfocs-golang/v5/pkg/demoinfocs
+	go get -u github.com/markus-wa/demoinfocs-golang/v6/pkg/demoinfocs
 
 See [broadcast example for live CSTV+ parsing](https://github.com/markus-wa/demoinfocs-golang/tree/master/examples/broadcasts)
 
@@ -64,7 +64,7 @@ You can download the latest version of Go [here](https://golang.org/).
 mkdir my-project
 cd my-project
 go mod init my-project
-go get -u github.com/markus-wa/demoinfocs-golang/v5/pkg/demoinfocs
+go get -u github.com/markus-wa/demoinfocs-golang/v6/pkg/demoinfocs
 ```
 
 3. Create a `main.go` file with the example below
@@ -84,8 +84,8 @@ package main
 import (
 	"log"
 
-	demoinfocs "github.com/markus-wa/demoinfocs-golang/v5/pkg/demoinfocs"
-	events "github.com/markus-wa/demoinfocs-golang/v5/pkg/demoinfocs/events"
+	demoinfocs "github.com/markus-wa/demoinfocs-golang/v6/pkg/demoinfocs"
+	events "github.com/markus-wa/demoinfocs-golang/v6/pkg/demoinfocs/events"
 )
 
 func onKill(kill events.Kill) {
@@ -137,17 +137,17 @@ Check out the [examples](examples) folder for more examples, like [how to genera
 
 ### Documentation
 
-The full API documentation is available here on [pkg.go.dev](https://pkg.go.dev/github.com/markus-wa/demoinfocs-golang/v5/pkg/demoinfocs).
+The full API documentation is available here on [pkg.go.dev](https://pkg.go.dev/github.com/markus-wa/demoinfocs-golang/v6/pkg/demoinfocs).
 
 ## Features
 
-* Game events (kills, shots, round starts/ends, footsteps etc.) - [docs](https://pkg.go.dev/github.com/markus-wa/demoinfocs-golang/v5/pkg/demoinfocs/events?tab=doc) / [example](https://github.com/markus-wa/demoinfocs-golang/tree/master/examples/print-events)
-* Tracking of game-state (players, teams, grenades, ConVars etc.) - [docs](https://pkg.go.dev/github.com/markus-wa/demoinfocs-golang/v5/pkg/demoinfocs?tab=doc#GameState)
-* Grenade projectiles / trajectories - [docs](https://pkg.go.dev/github.com/markus-wa/demoinfocs-golang/v5/pkg/demoinfocs?tab=doc#GameState.GrenadeProjectiles) / [example](https://github.com/markus-wa/demoinfocs-golang/tree/master/examples/nade-trajectories)
-* Access to entities, server-classes & data-tables - [docs](https://pkg.go.dev/github.com/markus-wa/demoinfocs-golang/v5/pkg/demoinfocs/sendtables?tab=doc#ServerClasses) / [example](https://github.com/markus-wa/demoinfocs-golang/tree/master/examples/entities)
-* Access to all net-messages - [docs](https://pkg.go.dev/github.com/markus-wa/demoinfocs-golang/v5/pkg/demoinfocs?tab=doc#NetMessageCreator) / [example](https://github.com/markus-wa/demoinfocs-golang/tree/master/examples/net-messages)
-* Chat & console messages <sup id="achat1">1</sup> - [docs](https://pkg.go.dev/github.com/markus-wa/demoinfocs-golang/v5/pkg/demoinfocs/events?tab=doc#ChatMessage) / [example](https://github.com/markus-wa/demoinfocs-golang/tree/master/examples/print-events)
-* Matchmaking ranks (official MM demos only) - [docs](https://pkg.go.dev/github.com/markus-wa/demoinfocs-golang/v5/pkg/demoinfocs/events?tab=doc#RankUpdate)
+* Game events (kills, shots, round starts/ends, footsteps etc.) - [docs](https://pkg.go.dev/github.com/markus-wa/demoinfocs-golang/v6/pkg/demoinfocs/events?tab=doc) / [example](https://github.com/markus-wa/demoinfocs-golang/tree/master/examples/print-events)
+* Tracking of game-state (players, teams, grenades, ConVars etc.) - [docs](https://pkg.go.dev/github.com/markus-wa/demoinfocs-golang/v6/pkg/demoinfocs?tab=doc#GameState)
+* Grenade projectiles / trajectories - [docs](https://pkg.go.dev/github.com/markus-wa/demoinfocs-golang/v6/pkg/demoinfocs?tab=doc#GameState.GrenadeProjectiles) / [example](https://github.com/markus-wa/demoinfocs-golang/tree/master/examples/nade-trajectories)
+* Access to entities, server-classes & data-tables - [docs](https://pkg.go.dev/github.com/markus-wa/demoinfocs-golang/v6/pkg/demoinfocs/sendtables?tab=doc#ServerClasses) / [example](https://github.com/markus-wa/demoinfocs-golang/tree/master/examples/entities)
+* Access to all net-messages - [docs](https://pkg.go.dev/github.com/markus-wa/demoinfocs-golang/v6/pkg/demoinfocs?tab=doc#NetMessageCreator) / [example](https://github.com/markus-wa/demoinfocs-golang/tree/master/examples/net-messages)
+* Chat & console messages <sup id="achat1">1</sup> - [docs](https://pkg.go.dev/github.com/markus-wa/demoinfocs-golang/v6/pkg/demoinfocs/events?tab=doc#ChatMessage) / [example](https://github.com/markus-wa/demoinfocs-golang/tree/master/examples/print-events)
+* Matchmaking ranks (official MM demos only) - [docs](https://pkg.go.dev/github.com/markus-wa/demoinfocs-golang/v6/pkg/demoinfocs/events?tab=doc#RankUpdate)
 * Full POV demo support
 * JavaScript (browser / Node.js) support via WebAssembly - [example](https://github.com/markus-wa/demoinfocs-wasm)
 * [Easy debugging via build-flags](#debugging)
@@ -235,7 +235,7 @@ e.g.
 
 Side-note: The tag isn't called `debug` to avoid naming conflicts with other libs (and underscores in tags don't work, apparently).
 
-To change the default debugging behavior, Go's `ldflags` parameter can be used. Example for additionally printing out all server-classes with their properties: `-ldflags="-X 'github.com/markus-wa/demoinfocs-golang/v5/pkg/demoinfocs.debugServerClasses=YES'"`.
+To change the default debugging behavior, Go's `ldflags` parameter can be used. Example for additionally printing out all server-classes with their properties: `-ldflags="-X 'github.com/markus-wa/demoinfocs-golang/v6/pkg/demoinfocs.debugServerClasses=YES'"`.
 
 e.g.
 

--- a/examples/broadcasts/broadcasts.go
+++ b/examples/broadcasts/broadcasts.go
@@ -5,10 +5,10 @@ import (
 	"fmt"
 	"os"
 
-	demoinfocs "github.com/markus-wa/demoinfocs-golang/v5/pkg/demoinfocs"
-	common "github.com/markus-wa/demoinfocs-golang/v5/pkg/demoinfocs/common"
-	events "github.com/markus-wa/demoinfocs-golang/v5/pkg/demoinfocs/events"
-	"github.com/markus-wa/demoinfocs-golang/v5/pkg/demoinfocs/msg"
+	demoinfocs "github.com/markus-wa/demoinfocs-golang/v6/pkg/demoinfocs"
+	common "github.com/markus-wa/demoinfocs-golang/v6/pkg/demoinfocs/common"
+	events "github.com/markus-wa/demoinfocs-golang/v6/pkg/demoinfocs/events"
+	"github.com/markus-wa/demoinfocs-golang/v6/pkg/demoinfocs/msg"
 )
 
 // Run like this: go run broadcasts.go -url "http://localhost:8080/<token>"

--- a/examples/entities/README.md
+++ b/examples/entities/README.md
@@ -6,7 +6,7 @@ This example shows how to use unhandled data of entities by registering entity-c
 
 You can use the build tag `debugdemoinfocs` and the set `debugServerClasses=YES` with ldflags to find interesting server-classes and their properties.
 
-Example: `go run myprogram.go -tags debugdemoinfocs -ldflags '-X github.com/markus-wa/demoinfocs-golang/v5/pkg/demoinfocs.debugServerClasses=YES' | grep ServerClass`
+Example: `go run myprogram.go -tags debugdemoinfocs -ldflags '-X github.com/markus-wa/demoinfocs-golang/v6/pkg/demoinfocs.debugServerClasses=YES' | grep ServerClass`
 
 This gives you a list of all server-classes from any demo that was parsed in `myprogram.go`.
 

--- a/examples/entities/entities.go
+++ b/examples/entities/entities.go
@@ -5,10 +5,10 @@ import (
 	_ "image/jpeg"
 	"os"
 
-	ex "github.com/markus-wa/demoinfocs-golang/v5/examples"
-	demoinfocs "github.com/markus-wa/demoinfocs-golang/v5/pkg/demoinfocs"
-	events "github.com/markus-wa/demoinfocs-golang/v5/pkg/demoinfocs/events"
-	st "github.com/markus-wa/demoinfocs-golang/v5/pkg/demoinfocs/sendtables"
+	ex "github.com/markus-wa/demoinfocs-golang/v6/examples"
+	demoinfocs "github.com/markus-wa/demoinfocs-golang/v6/pkg/demoinfocs"
+	events "github.com/markus-wa/demoinfocs-golang/v6/pkg/demoinfocs/events"
+	st "github.com/markus-wa/demoinfocs-golang/v6/pkg/demoinfocs/sendtables"
 )
 
 // Run like this: go run entities.go -demo /path/to/demo.dem

--- a/examples/heatmap/heatmap.go
+++ b/examples/heatmap/heatmap.go
@@ -10,10 +10,10 @@ import (
 	heatmap "github.com/markus-wa/go-heatmap/v2"
 	schemes "github.com/markus-wa/go-heatmap/v2/schemes"
 
-	ex "github.com/markus-wa/demoinfocs-golang/v5/examples"
-	demoinfocs "github.com/markus-wa/demoinfocs-golang/v5/pkg/demoinfocs"
-	events "github.com/markus-wa/demoinfocs-golang/v5/pkg/demoinfocs/events"
-	msg "github.com/markus-wa/demoinfocs-golang/v5/pkg/demoinfocs/msg"
+	ex "github.com/markus-wa/demoinfocs-golang/v6/examples"
+	demoinfocs "github.com/markus-wa/demoinfocs-golang/v6/pkg/demoinfocs"
+	events "github.com/markus-wa/demoinfocs-golang/v6/pkg/demoinfocs/events"
+	msg "github.com/markus-wa/demoinfocs-golang/v6/pkg/demoinfocs/msg"
 )
 
 const (

--- a/examples/heatmap/heatmap_test.go
+++ b/examples/heatmap/heatmap_test.go
@@ -4,7 +4,7 @@ import (
 	"os"
 	"testing"
 
-	"github.com/markus-wa/demoinfocs-golang/v5/examples"
+	"github.com/markus-wa/demoinfocs-golang/v6/examples"
 )
 
 // Just make sure the example runs

--- a/examples/map_metadata_test.go
+++ b/examples/map_metadata_test.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
-	"github.com/markus-wa/demoinfocs-golang/v5/examples"
+	"github.com/markus-wa/demoinfocs-golang/v6/examples"
 )
 
 func TestGetMapMetadata(t *testing.T) {

--- a/examples/mocking/README.md
+++ b/examples/mocking/README.md
@@ -9,8 +9,8 @@ First, let's have a look at the API of our code, the 'system under test':
 
 ```go
 import (
-	dem "github.com/markus-wa/demoinfocs-golang/v5/pkg/demoinfocs"
-	events "github.com/markus-wa/demoinfocs-golang/v5/pkg/demoinfocs/events"
+	dem "github.com/markus-wa/demoinfocs-golang/v6/pkg/demoinfocs"
+	events "github.com/markus-wa/demoinfocs-golang/v6/pkg/demoinfocs/events"
 )
 
 func collectKills(parser dem.Parser) (kills []events.Kill, err error) {
@@ -33,9 +33,9 @@ import (
 
 	assert "github.com/stretchr/testify/assert"
 
-	common "github.com/markus-wa/demoinfocs-golang/v5/pkg/demoinfocs/common"
-	events "github.com/markus-wa/demoinfocs-golang/v5/pkg/demoinfocs/events"
-	fake "github.com/markus-wa/demoinfocs-golang/v5/pkg/demoinfocs/fake"
+	common "github.com/markus-wa/demoinfocs-golang/v6/pkg/demoinfocs/common"
+	events "github.com/markus-wa/demoinfocs-golang/v6/pkg/demoinfocs/events"
+	fake "github.com/markus-wa/demoinfocs-golang/v6/pkg/demoinfocs/fake"
 )
 
 func TestCollectKills(t *testing.T) {
@@ -83,9 +83,9 @@ import (
 
 	assert "github.com/stretchr/testify/assert"
 
-	common "github.com/markus-wa/demoinfocs-golang/v5/pkg/demoinfocs/common"
-	events "github.com/markus-wa/demoinfocs-golang/v5/pkg/demoinfocs/events"
-	fake "github.com/markus-wa/demoinfocs-golang/v5/pkg/demoinfocs/fake"
+	common "github.com/markus-wa/demoinfocs-golang/v6/pkg/demoinfocs/common"
+	events "github.com/markus-wa/demoinfocs-golang/v6/pkg/demoinfocs/events"
+	fake "github.com/markus-wa/demoinfocs-golang/v6/pkg/demoinfocs/fake"
 )
 
 func TestCollectKillsError(t *testing.T) {

--- a/examples/mocking/collect_kills.go
+++ b/examples/mocking/collect_kills.go
@@ -1,8 +1,8 @@
 package mocking
 
 import (
-	demoinfocs "github.com/markus-wa/demoinfocs-golang/v5/pkg/demoinfocs"
-	events "github.com/markus-wa/demoinfocs-golang/v5/pkg/demoinfocs/events"
+	demoinfocs "github.com/markus-wa/demoinfocs-golang/v6/pkg/demoinfocs"
+	events "github.com/markus-wa/demoinfocs-golang/v6/pkg/demoinfocs/events"
 )
 
 func collectKills(parser demoinfocs.Parser) (kills []events.Kill, err error) {

--- a/examples/mocking/mocking_test.go
+++ b/examples/mocking/mocking_test.go
@@ -6,9 +6,9 @@ import (
 
 	assert "github.com/stretchr/testify/assert"
 
-	common "github.com/markus-wa/demoinfocs-golang/v5/pkg/demoinfocs/common"
-	events "github.com/markus-wa/demoinfocs-golang/v5/pkg/demoinfocs/events"
-	fake "github.com/markus-wa/demoinfocs-golang/v5/pkg/demoinfocs/fake"
+	common "github.com/markus-wa/demoinfocs-golang/v6/pkg/demoinfocs/common"
+	events "github.com/markus-wa/demoinfocs-golang/v6/pkg/demoinfocs/events"
+	fake "github.com/markus-wa/demoinfocs-golang/v6/pkg/demoinfocs/fake"
 )
 
 func TestCollectKills(t *testing.T) {

--- a/examples/nade-trajectories/nade_trajectories.go
+++ b/examples/nade-trajectories/nade_trajectories.go
@@ -11,11 +11,11 @@ import (
 	"github.com/golang/geo/r2"
 	"github.com/llgcode/draw2d/draw2dimg"
 
-	ex "github.com/markus-wa/demoinfocs-golang/v5/examples"
-	demoinfocs "github.com/markus-wa/demoinfocs-golang/v5/pkg/demoinfocs"
-	common "github.com/markus-wa/demoinfocs-golang/v5/pkg/demoinfocs/common"
-	events "github.com/markus-wa/demoinfocs-golang/v5/pkg/demoinfocs/events"
-	msg "github.com/markus-wa/demoinfocs-golang/v5/pkg/demoinfocs/msg"
+	ex "github.com/markus-wa/demoinfocs-golang/v6/examples"
+	demoinfocs "github.com/markus-wa/demoinfocs-golang/v6/pkg/demoinfocs"
+	common "github.com/markus-wa/demoinfocs-golang/v6/pkg/demoinfocs/common"
+	events "github.com/markus-wa/demoinfocs-golang/v6/pkg/demoinfocs/events"
+	msg "github.com/markus-wa/demoinfocs-golang/v6/pkg/demoinfocs/msg"
 )
 
 type nadePath struct {

--- a/examples/nade-trajectories/nade_trajectories_test.go
+++ b/examples/nade-trajectories/nade_trajectories_test.go
@@ -4,7 +4,7 @@ import (
 	"os"
 	"testing"
 
-	ex "github.com/markus-wa/demoinfocs-golang/v5/examples"
+	ex "github.com/markus-wa/demoinfocs-golang/v6/examples"
 )
 
 // Just make sure the example runs

--- a/examples/net-messages/README.md
+++ b/examples/net-messages/README.md
@@ -37,7 +37,7 @@ import (
 	"google.golang.org/protobuf/proto"
 
 	dem "github.com/markus-wa/demoinfocs-golang"
-	"github.com/markus-wa/demoinfocs-golang/v5/pkg/demoinfocs/msg"
+	"github.com/markus-wa/demoinfocs-golang/v6/pkg/demoinfocs/msg"
 )
 
 cfg := dem.DefaultParserConfig

--- a/examples/net-messages/netmessages.go
+++ b/examples/net-messages/netmessages.go
@@ -6,9 +6,9 @@ import (
 
 	"google.golang.org/protobuf/proto"
 
-	ex "github.com/markus-wa/demoinfocs-golang/v5/examples"
-	demoinfocs "github.com/markus-wa/demoinfocs-golang/v5/pkg/demoinfocs"
-	msg "github.com/markus-wa/demoinfocs-golang/v5/pkg/demoinfocs/msg"
+	ex "github.com/markus-wa/demoinfocs-golang/v6/examples"
+	demoinfocs "github.com/markus-wa/demoinfocs-golang/v6/pkg/demoinfocs"
+	msg "github.com/markus-wa/demoinfocs-golang/v6/pkg/demoinfocs/msg"
 )
 
 // Run like this: go run netmessages.go -demo /path/to/demo.dem > out.png

--- a/examples/player-actions/player_actions.go
+++ b/examples/player-actions/player_actions.go
@@ -5,10 +5,10 @@ import (
 	"fmt"
 	"os"
 
-	ex "github.com/markus-wa/demoinfocs-golang/v5/examples"
-	demoinfocs "github.com/markus-wa/demoinfocs-golang/v5/pkg/demoinfocs"
-	"github.com/markus-wa/demoinfocs-golang/v5/pkg/demoinfocs/common"
-	"github.com/markus-wa/demoinfocs-golang/v5/pkg/demoinfocs/events"
+	ex "github.com/markus-wa/demoinfocs-golang/v6/examples"
+	demoinfocs "github.com/markus-wa/demoinfocs-golang/v6/pkg/demoinfocs"
+	"github.com/markus-wa/demoinfocs-golang/v6/pkg/demoinfocs/common"
+	"github.com/markus-wa/demoinfocs-golang/v6/pkg/demoinfocs/events"
 )
 
 // Run like this: go run player_actions.go -demo /path/to/demo.dem

--- a/examples/print-defuse-time-left/print_defuse_time_left.go
+++ b/examples/print-defuse-time-left/print_defuse_time_left.go
@@ -7,10 +7,10 @@ import (
 	"text/tabwriter"
 	"time"
 
-	ex "github.com/markus-wa/demoinfocs-golang/v5/examples"
-	demoinfocs "github.com/markus-wa/demoinfocs-golang/v5/pkg/demoinfocs"
-	common "github.com/markus-wa/demoinfocs-golang/v5/pkg/demoinfocs/common"
-	events "github.com/markus-wa/demoinfocs-golang/v5/pkg/demoinfocs/events"
+	ex "github.com/markus-wa/demoinfocs-golang/v6/examples"
+	demoinfocs "github.com/markus-wa/demoinfocs-golang/v6/pkg/demoinfocs"
+	common "github.com/markus-wa/demoinfocs-golang/v6/pkg/demoinfocs/common"
+	events "github.com/markus-wa/demoinfocs-golang/v6/pkg/demoinfocs/events"
 )
 
 // Run like this: go run print_defuse_time_left.go -demo /path/to/demo.dem

--- a/examples/print-events/print_events.go
+++ b/examples/print-events/print_events.go
@@ -4,11 +4,11 @@ import (
 	"fmt"
 	"os"
 
-	ex "github.com/markus-wa/demoinfocs-golang/v5/examples"
-	demoinfocs "github.com/markus-wa/demoinfocs-golang/v5/pkg/demoinfocs"
-	common "github.com/markus-wa/demoinfocs-golang/v5/pkg/demoinfocs/common"
-	events "github.com/markus-wa/demoinfocs-golang/v5/pkg/demoinfocs/events"
-	"github.com/markus-wa/demoinfocs-golang/v5/pkg/demoinfocs/msg"
+	ex "github.com/markus-wa/demoinfocs-golang/v6/examples"
+	demoinfocs "github.com/markus-wa/demoinfocs-golang/v6/pkg/demoinfocs"
+	common "github.com/markus-wa/demoinfocs-golang/v6/pkg/demoinfocs/common"
+	events "github.com/markus-wa/demoinfocs-golang/v6/pkg/demoinfocs/events"
+	"github.com/markus-wa/demoinfocs-golang/v6/pkg/demoinfocs/msg"
 )
 
 // Run like this: go run print_events.go -demo /path/to/demo.dem

--- a/examples/viewmodel-settings/viewmodel_settings.go
+++ b/examples/viewmodel-settings/viewmodel_settings.go
@@ -4,9 +4,9 @@ import (
 	"fmt"
 	"os"
 
-	ex "github.com/markus-wa/demoinfocs-golang/v5/examples"
-	demoinfocs "github.com/markus-wa/demoinfocs-golang/v5/pkg/demoinfocs"
-	events "github.com/markus-wa/demoinfocs-golang/v5/pkg/demoinfocs/events"
+	ex "github.com/markus-wa/demoinfocs-golang/v6/examples"
+	demoinfocs "github.com/markus-wa/demoinfocs-golang/v6/pkg/demoinfocs"
+	events "github.com/markus-wa/demoinfocs-golang/v6/pkg/demoinfocs/events"
 )
 
 // Run like this: go run viewmodel_settings.go -demo /path/to/cs2-demo.dem

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/markus-wa/demoinfocs-golang/v5
+module github.com/markus-wa/demoinfocs-golang/v6
 
 require (
 	github.com/andygrunwald/vdf v1.1.0

--- a/pkg/demoinfocs/common/common.go
+++ b/pkg/demoinfocs/common/common.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/golang/geo/r3"
 
-	st "github.com/markus-wa/demoinfocs-golang/v5/pkg/demoinfocs/sendtables"
+	st "github.com/markus-wa/demoinfocs-golang/v6/pkg/demoinfocs/sendtables"
 )
 
 // Team is the type for the various TeamXYZ constants.

--- a/pkg/demoinfocs/common/common_test.go
+++ b/pkg/demoinfocs/common/common_test.go
@@ -7,8 +7,8 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 
-	st "github.com/markus-wa/demoinfocs-golang/v5/pkg/demoinfocs/sendtables"
-	stfake "github.com/markus-wa/demoinfocs-golang/v5/pkg/demoinfocs/sendtables/fake"
+	st "github.com/markus-wa/demoinfocs-golang/v6/pkg/demoinfocs/sendtables"
+	stfake "github.com/markus-wa/demoinfocs-golang/v6/pkg/demoinfocs/sendtables/fake"
 )
 
 func TestGrenadeProjectileUniqueID(t *testing.T) {

--- a/pkg/demoinfocs/common/entity_util.go
+++ b/pkg/demoinfocs/common/entity_util.go
@@ -1,6 +1,6 @@
 package common
 
-import st "github.com/markus-wa/demoinfocs-golang/v5/pkg/demoinfocs/sendtables"
+import st "github.com/markus-wa/demoinfocs-golang/v6/pkg/demoinfocs/sendtables"
 
 func getInt(entity st.Entity, propName string) int {
 	if entity == nil {

--- a/pkg/demoinfocs/common/entity_util_test.go
+++ b/pkg/demoinfocs/common/entity_util_test.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
-	st "github.com/markus-wa/demoinfocs-golang/v5/pkg/demoinfocs/sendtables"
+	st "github.com/markus-wa/demoinfocs-golang/v6/pkg/demoinfocs/sendtables"
 )
 
 func TestGetFloat_Nil(t *testing.T) {

--- a/pkg/demoinfocs/common/equipment.go
+++ b/pkg/demoinfocs/common/equipment.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/oklog/ulid/v2"
 
-	st "github.com/markus-wa/demoinfocs-golang/v5/pkg/demoinfocs/sendtables"
+	st "github.com/markus-wa/demoinfocs-golang/v6/pkg/demoinfocs/sendtables"
 )
 
 // EquipmentClass is the type for the various EqClassXYZ constants.

--- a/pkg/demoinfocs/common/equipment_test.go
+++ b/pkg/demoinfocs/common/equipment_test.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
-	st "github.com/markus-wa/demoinfocs-golang/v5/pkg/demoinfocs/sendtables"
+	st "github.com/markus-wa/demoinfocs-golang/v6/pkg/demoinfocs/sendtables"
 )
 
 func TestEquipmentElement_Class(t *testing.T) {

--- a/pkg/demoinfocs/common/hostage.go
+++ b/pkg/demoinfocs/common/hostage.go
@@ -3,8 +3,8 @@ package common
 import (
 	"github.com/golang/geo/r3"
 
-	"github.com/markus-wa/demoinfocs-golang/v5/pkg/demoinfocs/constants"
-	st "github.com/markus-wa/demoinfocs-golang/v5/pkg/demoinfocs/sendtables"
+	"github.com/markus-wa/demoinfocs-golang/v6/pkg/demoinfocs/constants"
+	st "github.com/markus-wa/demoinfocs-golang/v6/pkg/demoinfocs/sendtables"
 )
 
 // HostageState is the type for the various HostageStateXYZ constants.

--- a/pkg/demoinfocs/common/hostage_test.go
+++ b/pkg/demoinfocs/common/hostage_test.go
@@ -5,8 +5,8 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
-	"github.com/markus-wa/demoinfocs-golang/v5/pkg/demoinfocs/constants"
-	st "github.com/markus-wa/demoinfocs-golang/v5/pkg/demoinfocs/sendtables"
+	"github.com/markus-wa/demoinfocs-golang/v6/pkg/demoinfocs/constants"
+	st "github.com/markus-wa/demoinfocs-golang/v6/pkg/demoinfocs/sendtables"
 )
 
 func TestHostage_Leader(t *testing.T) {

--- a/pkg/demoinfocs/common/inferno.go
+++ b/pkg/demoinfocs/common/inferno.go
@@ -8,7 +8,7 @@ import (
 	"github.com/golang/geo/r3"
 	"github.com/markus-wa/quickhull-go/v2"
 
-	st "github.com/markus-wa/demoinfocs-golang/v5/pkg/demoinfocs/sendtables"
+	st "github.com/markus-wa/demoinfocs-golang/v6/pkg/demoinfocs/sendtables"
 )
 
 // Inferno is a list of Fires with helper functions.

--- a/pkg/demoinfocs/common/inferno_test.go
+++ b/pkg/demoinfocs/common/inferno_test.go
@@ -7,8 +7,8 @@ import (
 	"github.com/golang/geo/r3"
 	"github.com/stretchr/testify/assert"
 
-	st "github.com/markus-wa/demoinfocs-golang/v5/pkg/demoinfocs/sendtables"
-	stfake "github.com/markus-wa/demoinfocs-golang/v5/pkg/demoinfocs/sendtables/fake"
+	st "github.com/markus-wa/demoinfocs-golang/v6/pkg/demoinfocs/sendtables"
+	stfake "github.com/markus-wa/demoinfocs-golang/v6/pkg/demoinfocs/sendtables/fake"
 )
 
 func TestInferno_UniqueID(t *testing.T) {

--- a/pkg/demoinfocs/common/player.go
+++ b/pkg/demoinfocs/common/player.go
@@ -6,8 +6,8 @@ import (
 	"github.com/golang/geo/r3"
 	"github.com/pkg/errors"
 
-	"github.com/markus-wa/demoinfocs-golang/v5/pkg/demoinfocs/constants"
-	st "github.com/markus-wa/demoinfocs-golang/v5/pkg/demoinfocs/sendtables"
+	"github.com/markus-wa/demoinfocs-golang/v6/pkg/demoinfocs/constants"
+	st "github.com/markus-wa/demoinfocs-golang/v6/pkg/demoinfocs/sendtables"
 )
 
 // Player contains mostly game-relevant player information.

--- a/pkg/demoinfocs/common/player_test.go
+++ b/pkg/demoinfocs/common/player_test.go
@@ -7,8 +7,8 @@ import (
 	"github.com/golang/geo/r3"
 	"github.com/stretchr/testify/assert"
 
-	"github.com/markus-wa/demoinfocs-golang/v5/pkg/demoinfocs/constants"
-	st "github.com/markus-wa/demoinfocs-golang/v5/pkg/demoinfocs/sendtables"
+	"github.com/markus-wa/demoinfocs-golang/v6/pkg/demoinfocs/constants"
+	st "github.com/markus-wa/demoinfocs-golang/v6/pkg/demoinfocs/sendtables"
 )
 
 func TestPlayerActiveWeapon(t *testing.T) {

--- a/pkg/demoinfocs/datatables.go
+++ b/pkg/demoinfocs/datatables.go
@@ -7,10 +7,10 @@ import (
 	"github.com/golang/geo/r3"
 	"github.com/markus-wa/go-unassert"
 
-	common "github.com/markus-wa/demoinfocs-golang/v5/pkg/demoinfocs/common"
-	"github.com/markus-wa/demoinfocs-golang/v5/pkg/demoinfocs/constants"
-	events "github.com/markus-wa/demoinfocs-golang/v5/pkg/demoinfocs/events"
-	st "github.com/markus-wa/demoinfocs-golang/v5/pkg/demoinfocs/sendtables"
+	common "github.com/markus-wa/demoinfocs-golang/v6/pkg/demoinfocs/common"
+	"github.com/markus-wa/demoinfocs-golang/v6/pkg/demoinfocs/constants"
+	events "github.com/markus-wa/demoinfocs-golang/v6/pkg/demoinfocs/events"
+	st "github.com/markus-wa/demoinfocs-golang/v6/pkg/demoinfocs/sendtables"
 )
 
 // Bind the attributes of the various entities to our structs on the parser

--- a/pkg/demoinfocs/datatables_test.go
+++ b/pkg/demoinfocs/datatables_test.go
@@ -7,10 +7,10 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 
-	common "github.com/markus-wa/demoinfocs-golang/v5/pkg/demoinfocs/common"
-	events "github.com/markus-wa/demoinfocs-golang/v5/pkg/demoinfocs/events"
-	st "github.com/markus-wa/demoinfocs-golang/v5/pkg/demoinfocs/sendtables"
-	stfake "github.com/markus-wa/demoinfocs-golang/v5/pkg/demoinfocs/sendtables/fake"
+	common "github.com/markus-wa/demoinfocs-golang/v6/pkg/demoinfocs/common"
+	events "github.com/markus-wa/demoinfocs-golang/v6/pkg/demoinfocs/events"
+	st "github.com/markus-wa/demoinfocs-golang/v6/pkg/demoinfocs/sendtables"
+	stfake "github.com/markus-wa/demoinfocs-golang/v6/pkg/demoinfocs/sendtables/fake"
 )
 
 type DevNullReader struct {

--- a/pkg/demoinfocs/debug_off.go
+++ b/pkg/demoinfocs/debug_off.go
@@ -6,8 +6,8 @@
 package demoinfocs
 
 import (
-	msg "github.com/markus-wa/demoinfocs-golang/v5/pkg/demoinfocs/msg"
-	st "github.com/markus-wa/demoinfocs-golang/v5/pkg/demoinfocs/sendtables"
+	msg "github.com/markus-wa/demoinfocs-golang/v6/pkg/demoinfocs/msg"
+	st "github.com/markus-wa/demoinfocs-golang/v6/pkg/demoinfocs/sendtables"
 )
 
 func debugGameEvent(descriptor *msg.CMsgSource1LegacyGameEventListDescriptorT, ge *msg.CMsgSource1LegacyGameEvent) {

--- a/pkg/demoinfocs/debug_on.go
+++ b/pkg/demoinfocs/debug_on.go
@@ -8,9 +8,9 @@ package demoinfocs
 import (
 	"fmt"
 
-	msg "github.com/markus-wa/demoinfocs-golang/v5/pkg/demoinfocs/msg"
+	msg "github.com/markus-wa/demoinfocs-golang/v6/pkg/demoinfocs/msg"
 
-	st "github.com/markus-wa/demoinfocs-golang/v5/pkg/demoinfocs/sendtables"
+	st "github.com/markus-wa/demoinfocs-golang/v6/pkg/demoinfocs/sendtables"
 )
 
 const (
@@ -18,7 +18,7 @@ const (
 	no  = "NO"
 )
 
-// Can be overridden via -ldflags="-X 'github.com/markus-wa/demoinfocs-golang/v5/pkg/demoinfocs.debugServerClasses=YES'"
+// Can be overridden via -ldflags="-X 'github.com/markus-wa/demoinfocs-golang/v6/pkg/demoinfocs.debugServerClasses=YES'"
 // e.g. `go run -tags debugdemoinfocs -ldflags="-X 'github.com/markus-wa/demoinfocs-golang/v2/pkg/demoinfocs.debugDemoCommands=YES'" examples/print-events/print_events.go -demo example.dem`
 // Oh and btw we cant use bools for this, Go says 'cannot use -X with non-string symbol'
 var (

--- a/pkg/demoinfocs/demoinfocs_test.go
+++ b/pkg/demoinfocs/demoinfocs_test.go
@@ -22,10 +22,10 @@ import (
 	"github.com/stretchr/testify/assert"
 	"google.golang.org/protobuf/proto"
 
-	demoinfocs "github.com/markus-wa/demoinfocs-golang/v5/pkg/demoinfocs"
-	common "github.com/markus-wa/demoinfocs-golang/v5/pkg/demoinfocs/common"
-	events "github.com/markus-wa/demoinfocs-golang/v5/pkg/demoinfocs/events"
-	"github.com/markus-wa/demoinfocs-golang/v5/pkg/demoinfocs/msg"
+	demoinfocs "github.com/markus-wa/demoinfocs-golang/v6/pkg/demoinfocs"
+	common "github.com/markus-wa/demoinfocs-golang/v6/pkg/demoinfocs/common"
+	events "github.com/markus-wa/demoinfocs-golang/v6/pkg/demoinfocs/events"
+	"github.com/markus-wa/demoinfocs-golang/v6/pkg/demoinfocs/msg"
 )
 
 const (

--- a/pkg/demoinfocs/events/events.go
+++ b/pkg/demoinfocs/events/events.go
@@ -10,8 +10,8 @@ import (
 
 	"github.com/golang/geo/r3"
 
-	common "github.com/markus-wa/demoinfocs-golang/v5/pkg/demoinfocs/common"
-	msg "github.com/markus-wa/demoinfocs-golang/v5/pkg/demoinfocs/msg"
+	common "github.com/markus-wa/demoinfocs-golang/v6/pkg/demoinfocs/common"
+	msg "github.com/markus-wa/demoinfocs-golang/v6/pkg/demoinfocs/msg"
 )
 
 // FrameDone signals that a demo-frame has been processed.

--- a/pkg/demoinfocs/events/events_test.go
+++ b/pkg/demoinfocs/events/events_test.go
@@ -6,8 +6,8 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
-	common "github.com/markus-wa/demoinfocs-golang/v5/pkg/demoinfocs/common"
-	st "github.com/markus-wa/demoinfocs-golang/v5/pkg/demoinfocs/sendtables"
+	common "github.com/markus-wa/demoinfocs-golang/v6/pkg/demoinfocs/common"
+	st "github.com/markus-wa/demoinfocs-golang/v6/pkg/demoinfocs/sendtables"
 )
 
 func TestPlayerFlashed_FlashDuration(t *testing.T) {

--- a/pkg/demoinfocs/examples_test.go
+++ b/pkg/demoinfocs/examples_test.go
@@ -4,8 +4,8 @@ import (
 	"log"
 	"testing"
 
-	demoinfocs "github.com/markus-wa/demoinfocs-golang/v5/pkg/demoinfocs"
-	events "github.com/markus-wa/demoinfocs-golang/v5/pkg/demoinfocs/events"
+	demoinfocs "github.com/markus-wa/demoinfocs-golang/v6/pkg/demoinfocs"
+	events "github.com/markus-wa/demoinfocs-golang/v6/pkg/demoinfocs/events"
 )
 
 /*

--- a/pkg/demoinfocs/fake/game_rules.go
+++ b/pkg/demoinfocs/fake/game_rules.go
@@ -5,8 +5,8 @@ import (
 
 	"github.com/stretchr/testify/mock"
 
-	demoinfocs "github.com/markus-wa/demoinfocs-golang/v5/pkg/demoinfocs"
-	st "github.com/markus-wa/demoinfocs-golang/v5/pkg/demoinfocs/sendtables"
+	demoinfocs "github.com/markus-wa/demoinfocs-golang/v6/pkg/demoinfocs"
+	st "github.com/markus-wa/demoinfocs-golang/v6/pkg/demoinfocs/sendtables"
 )
 
 var _ demoinfocs.GameRules = new(GameRules)

--- a/pkg/demoinfocs/fake/game_state.go
+++ b/pkg/demoinfocs/fake/game_state.go
@@ -3,9 +3,9 @@ package fake
 import (
 	"github.com/stretchr/testify/mock"
 
-	demoinfocs "github.com/markus-wa/demoinfocs-golang/v5/pkg/demoinfocs"
-	common "github.com/markus-wa/demoinfocs-golang/v5/pkg/demoinfocs/common"
-	st "github.com/markus-wa/demoinfocs-golang/v5/pkg/demoinfocs/sendtables"
+	demoinfocs "github.com/markus-wa/demoinfocs-golang/v6/pkg/demoinfocs"
+	common "github.com/markus-wa/demoinfocs-golang/v6/pkg/demoinfocs/common"
+	st "github.com/markus-wa/demoinfocs-golang/v6/pkg/demoinfocs/sendtables"
 )
 
 var _ demoinfocs.GameState = new(GameState)

--- a/pkg/demoinfocs/fake/parser.go
+++ b/pkg/demoinfocs/fake/parser.go
@@ -9,8 +9,8 @@ import (
 	mock "github.com/stretchr/testify/mock"
 	"golang.org/x/exp/constraints"
 
-	demoinfocs "github.com/markus-wa/demoinfocs-golang/v5/pkg/demoinfocs"
-	st "github.com/markus-wa/demoinfocs-golang/v5/pkg/demoinfocs/sendtables"
+	demoinfocs "github.com/markus-wa/demoinfocs-golang/v6/pkg/demoinfocs"
+	st "github.com/markus-wa/demoinfocs-golang/v6/pkg/demoinfocs/sendtables"
 )
 
 var _ demoinfocs.Parser = new(Parser)

--- a/pkg/demoinfocs/fake/parser_test.go
+++ b/pkg/demoinfocs/fake/parser_test.go
@@ -6,10 +6,10 @@ import (
 	assert "github.com/stretchr/testify/assert"
 	"google.golang.org/protobuf/proto"
 
-	common "github.com/markus-wa/demoinfocs-golang/v5/pkg/demoinfocs/common"
-	events "github.com/markus-wa/demoinfocs-golang/v5/pkg/demoinfocs/events"
-	fake "github.com/markus-wa/demoinfocs-golang/v5/pkg/demoinfocs/fake"
-	msg "github.com/markus-wa/demoinfocs-golang/v5/pkg/demoinfocs/msg"
+	common "github.com/markus-wa/demoinfocs-golang/v6/pkg/demoinfocs/common"
+	events "github.com/markus-wa/demoinfocs-golang/v6/pkg/demoinfocs/events"
+	fake "github.com/markus-wa/demoinfocs-golang/v6/pkg/demoinfocs/fake"
+	msg "github.com/markus-wa/demoinfocs-golang/v6/pkg/demoinfocs/msg"
 )
 
 func TestParseNextFrameEvents(t *testing.T) {

--- a/pkg/demoinfocs/fake/participants.go
+++ b/pkg/demoinfocs/fake/participants.go
@@ -3,8 +3,8 @@ package fake
 import (
 	"github.com/stretchr/testify/mock"
 
-	demoinfocs "github.com/markus-wa/demoinfocs-golang/v5/pkg/demoinfocs"
-	common "github.com/markus-wa/demoinfocs-golang/v5/pkg/demoinfocs/common"
+	demoinfocs "github.com/markus-wa/demoinfocs-golang/v6/pkg/demoinfocs"
+	common "github.com/markus-wa/demoinfocs-golang/v6/pkg/demoinfocs/common"
 )
 
 var _ demoinfocs.Participants = new(Participants)

--- a/pkg/demoinfocs/game_events.go
+++ b/pkg/demoinfocs/game_events.go
@@ -11,10 +11,10 @@ import (
 	"github.com/pkg/errors"
 	"google.golang.org/protobuf/proto"
 
-	common "github.com/markus-wa/demoinfocs-golang/v5/pkg/demoinfocs/common"
-	events "github.com/markus-wa/demoinfocs-golang/v5/pkg/demoinfocs/events"
-	msg "github.com/markus-wa/demoinfocs-golang/v5/pkg/demoinfocs/msg"
-	st "github.com/markus-wa/demoinfocs-golang/v5/pkg/demoinfocs/sendtables"
+	common "github.com/markus-wa/demoinfocs-golang/v6/pkg/demoinfocs/common"
+	events "github.com/markus-wa/demoinfocs-golang/v6/pkg/demoinfocs/events"
+	msg "github.com/markus-wa/demoinfocs-golang/v6/pkg/demoinfocs/msg"
+	st "github.com/markus-wa/demoinfocs-golang/v6/pkg/demoinfocs/sendtables"
 )
 
 func (p *parser) handleGameEventList(gel *msg.CMsgSource1LegacyGameEventList) {

--- a/pkg/demoinfocs/game_events_test.go
+++ b/pkg/demoinfocs/game_events_test.go
@@ -8,11 +8,11 @@ import (
 	"github.com/stretchr/testify/assert"
 	"google.golang.org/protobuf/proto"
 
-	common "github.com/markus-wa/demoinfocs-golang/v5/pkg/demoinfocs/common"
-	events "github.com/markus-wa/demoinfocs-golang/v5/pkg/demoinfocs/events"
-	msg "github.com/markus-wa/demoinfocs-golang/v5/pkg/demoinfocs/msg"
-	st "github.com/markus-wa/demoinfocs-golang/v5/pkg/demoinfocs/sendtables"
-	stfake "github.com/markus-wa/demoinfocs-golang/v5/pkg/demoinfocs/sendtables/fake"
+	common "github.com/markus-wa/demoinfocs-golang/v6/pkg/demoinfocs/common"
+	events "github.com/markus-wa/demoinfocs-golang/v6/pkg/demoinfocs/events"
+	msg "github.com/markus-wa/demoinfocs-golang/v6/pkg/demoinfocs/msg"
+	st "github.com/markus-wa/demoinfocs-golang/v6/pkg/demoinfocs/sendtables"
+	stfake "github.com/markus-wa/demoinfocs-golang/v6/pkg/demoinfocs/sendtables/fake"
 )
 
 // See #90

--- a/pkg/demoinfocs/game_rules_interface.go
+++ b/pkg/demoinfocs/game_rules_interface.go
@@ -5,7 +5,7 @@ package demoinfocs
 import (
 	"time"
 
-	st "github.com/markus-wa/demoinfocs-golang/v5/pkg/demoinfocs/sendtables"
+	st "github.com/markus-wa/demoinfocs-golang/v6/pkg/demoinfocs/sendtables"
 )
 
 // GameRules is an auto-generated interface for gameRules.

--- a/pkg/demoinfocs/game_state.go
+++ b/pkg/demoinfocs/game_state.go
@@ -7,10 +7,10 @@ import (
 	"time"
 
 	"github.com/golang/geo/r3"
-	common "github.com/markus-wa/demoinfocs-golang/v5/pkg/demoinfocs/common"
-	"github.com/markus-wa/demoinfocs-golang/v5/pkg/demoinfocs/constants"
-	"github.com/markus-wa/demoinfocs-golang/v5/pkg/demoinfocs/events"
-	st "github.com/markus-wa/demoinfocs-golang/v5/pkg/demoinfocs/sendtables"
+	common "github.com/markus-wa/demoinfocs-golang/v6/pkg/demoinfocs/common"
+	"github.com/markus-wa/demoinfocs-golang/v6/pkg/demoinfocs/constants"
+	"github.com/markus-wa/demoinfocs-golang/v6/pkg/demoinfocs/events"
+	st "github.com/markus-wa/demoinfocs-golang/v6/pkg/demoinfocs/sendtables"
 )
 
 //go:generate ifacemaker -f game_state.go -s gameState -i GameState -p demoinfocs -D -y "GameState is an auto-generated interface for gameState." -c "DO NOT EDIT: Auto generated" -o game_state_interface.go

--- a/pkg/demoinfocs/game_state_interface.go
+++ b/pkg/demoinfocs/game_state_interface.go
@@ -3,8 +3,8 @@
 package demoinfocs
 
 import (
-	common "github.com/markus-wa/demoinfocs-golang/v5/pkg/demoinfocs/common"
-	st "github.com/markus-wa/demoinfocs-golang/v5/pkg/demoinfocs/sendtables"
+	common "github.com/markus-wa/demoinfocs-golang/v6/pkg/demoinfocs/common"
+	st "github.com/markus-wa/demoinfocs-golang/v6/pkg/demoinfocs/sendtables"
 )
 
 // GameState is an auto-generated interface for gameState.

--- a/pkg/demoinfocs/game_state_test.go
+++ b/pkg/demoinfocs/game_state_test.go
@@ -6,10 +6,10 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
-	common "github.com/markus-wa/demoinfocs-golang/v5/pkg/demoinfocs/common"
-	"github.com/markus-wa/demoinfocs-golang/v5/pkg/demoinfocs/constants"
-	st "github.com/markus-wa/demoinfocs-golang/v5/pkg/demoinfocs/sendtables"
-	stfake "github.com/markus-wa/demoinfocs-golang/v5/pkg/demoinfocs/sendtables/fake"
+	common "github.com/markus-wa/demoinfocs-golang/v6/pkg/demoinfocs/common"
+	"github.com/markus-wa/demoinfocs-golang/v6/pkg/demoinfocs/constants"
+	st "github.com/markus-wa/demoinfocs-golang/v6/pkg/demoinfocs/sendtables"
+	stfake "github.com/markus-wa/demoinfocs-golang/v6/pkg/demoinfocs/sendtables/fake"
 )
 
 func TestNewGameState(t *testing.T) {

--- a/pkg/demoinfocs/msg/generate.sh
+++ b/pkg/demoinfocs/msg/generate.sh
@@ -5,24 +5,24 @@
 
 protoc -Iproto \
        --go_out=. \
-       --go_opt=Mcs_usercmd.proto=github.com/markus-wa/demoinfocs-golang/v5/pkg/demoinfocs/msg \
-       --go_opt=Musercmd.proto=github.com/markus-wa/demoinfocs-golang/v5/pkg/demoinfocs/msg \
-       --go_opt=Mcstrike15_usermessages.proto=github.com/markus-wa/demoinfocs-golang/v5/pkg/demoinfocs/msg \
-       --go_opt=Mcstrike15_gcmessages.proto=github.com/markus-wa/demoinfocs-golang/v5/pkg/demoinfocs/msg \
-       --go_opt=Mengine_gcmessages.proto=github.com/markus-wa/demoinfocs-golang/v5/pkg/demoinfocs/msg \
-       --go_opt=Mnetmessages.proto=github.com/markus-wa/demoinfocs-golang/v5/pkg/demoinfocs/msg \
-       --go_opt=Msteammessages.proto=github.com/markus-wa/demoinfocs-golang/v5/pkg/demoinfocs/msg \
-       --go_opt=Mgcsdk_gcmessages.proto=github.com/markus-wa/demoinfocs-golang/v5/pkg/demoinfocs/msg \
-       --go_opt=Mnetworkbasetypes.proto=github.com/markus-wa/demoinfocs-golang/v5/pkg/demoinfocs/msg \
-       --go_opt=Mnetwork_connection.proto=github.com/markus-wa/demoinfocs-golang/v5/pkg/demoinfocs/msg \
-       --go_opt=Mdemo.proto=github.com/markus-wa/demoinfocs-golang/v5/pkg/demoinfocs/msg \
-       --go_opt=Mgameevents.proto=github.com/markus-wa/demoinfocs-golang/v5/pkg/demoinfocs/msg \
-       --go_opt=Musermessages.proto=github.com/markus-wa/demoinfocs-golang/v5/pkg/demoinfocs/msg \
-       --go_opt=Mcs_gameevents.proto=github.com/markus-wa/demoinfocs-golang/v5/pkg/demoinfocs/msg \
-       --go_opt=Mte.proto=github.com/markus-wa/demoinfocs-golang/v5/pkg/demoinfocs/msg \
-       --go_opt=Msource2_steam_stats.proto=github.com/markus-wa/demoinfocs-golang/v5/pkg/demoinfocs/msg \
-       --go_opt=Mvalveextensions.proto=github.com/markus-wa/demoinfocs-golang/v5/pkg/demoinfocs/msg \
-       --go_opt=module=github.com/markus-wa/demoinfocs-golang/v5/pkg/demoinfocs/msg \
+       --go_opt=Mcs_usercmd.proto=github.com/markus-wa/demoinfocs-golang/v6/pkg/demoinfocs/msg \
+       --go_opt=Musercmd.proto=github.com/markus-wa/demoinfocs-golang/v6/pkg/demoinfocs/msg \
+       --go_opt=Mcstrike15_usermessages.proto=github.com/markus-wa/demoinfocs-golang/v6/pkg/demoinfocs/msg \
+       --go_opt=Mcstrike15_gcmessages.proto=github.com/markus-wa/demoinfocs-golang/v6/pkg/demoinfocs/msg \
+       --go_opt=Mengine_gcmessages.proto=github.com/markus-wa/demoinfocs-golang/v6/pkg/demoinfocs/msg \
+       --go_opt=Mnetmessages.proto=github.com/markus-wa/demoinfocs-golang/v6/pkg/demoinfocs/msg \
+       --go_opt=Msteammessages.proto=github.com/markus-wa/demoinfocs-golang/v6/pkg/demoinfocs/msg \
+       --go_opt=Mgcsdk_gcmessages.proto=github.com/markus-wa/demoinfocs-golang/v6/pkg/demoinfocs/msg \
+       --go_opt=Mnetworkbasetypes.proto=github.com/markus-wa/demoinfocs-golang/v6/pkg/demoinfocs/msg \
+       --go_opt=Mnetwork_connection.proto=github.com/markus-wa/demoinfocs-golang/v6/pkg/demoinfocs/msg \
+       --go_opt=Mdemo.proto=github.com/markus-wa/demoinfocs-golang/v6/pkg/demoinfocs/msg \
+       --go_opt=Mgameevents.proto=github.com/markus-wa/demoinfocs-golang/v6/pkg/demoinfocs/msg \
+       --go_opt=Musermessages.proto=github.com/markus-wa/demoinfocs-golang/v6/pkg/demoinfocs/msg \
+       --go_opt=Mcs_gameevents.proto=github.com/markus-wa/demoinfocs-golang/v6/pkg/demoinfocs/msg \
+       --go_opt=Mte.proto=github.com/markus-wa/demoinfocs-golang/v6/pkg/demoinfocs/msg \
+       --go_opt=Msource2_steam_stats.proto=github.com/markus-wa/demoinfocs-golang/v6/pkg/demoinfocs/msg \
+       --go_opt=Mvalveextensions.proto=github.com/markus-wa/demoinfocs-golang/v6/pkg/demoinfocs/msg \
+       --go_opt=module=github.com/markus-wa/demoinfocs-golang/v6/pkg/demoinfocs/msg \
        cs_usercmd.proto \
        cstrike15_gcmessages.proto \
        cstrike15_usermessages.proto \

--- a/pkg/demoinfocs/net_messages.go
+++ b/pkg/demoinfocs/net_messages.go
@@ -5,9 +5,9 @@ import (
 
 	"github.com/markus-wa/go-unassert"
 
-	events "github.com/markus-wa/demoinfocs-golang/v5/pkg/demoinfocs/events"
-	"github.com/markus-wa/demoinfocs-golang/v5/pkg/demoinfocs/msg"
-	"github.com/markus-wa/demoinfocs-golang/v5/pkg/demoinfocs/sendtables"
+	events "github.com/markus-wa/demoinfocs-golang/v6/pkg/demoinfocs/events"
+	"github.com/markus-wa/demoinfocs-golang/v6/pkg/demoinfocs/msg"
+	"github.com/markus-wa/demoinfocs-golang/v6/pkg/demoinfocs/sendtables"
 )
 
 func (p *parser) onEntity(e sendtables.Entity, op sendtables.EntityOp) error {

--- a/pkg/demoinfocs/parser.go
+++ b/pkg/demoinfocs/parser.go
@@ -14,12 +14,12 @@ import (
 	"github.com/pkg/errors"
 	"google.golang.org/protobuf/proto"
 
-	bit "github.com/markus-wa/demoinfocs-golang/v5/internal/bitread"
-	"github.com/markus-wa/demoinfocs-golang/v5/pkg/demoinfocs/common"
-	"github.com/markus-wa/demoinfocs-golang/v5/pkg/demoinfocs/cstv"
-	"github.com/markus-wa/demoinfocs-golang/v5/pkg/demoinfocs/events"
-	"github.com/markus-wa/demoinfocs-golang/v5/pkg/demoinfocs/msg"
-	st "github.com/markus-wa/demoinfocs-golang/v5/pkg/demoinfocs/sendtables"
+	bit "github.com/markus-wa/demoinfocs-golang/v6/internal/bitread"
+	"github.com/markus-wa/demoinfocs-golang/v6/pkg/demoinfocs/common"
+	"github.com/markus-wa/demoinfocs-golang/v6/pkg/demoinfocs/cstv"
+	"github.com/markus-wa/demoinfocs-golang/v6/pkg/demoinfocs/events"
+	"github.com/markus-wa/demoinfocs-golang/v6/pkg/demoinfocs/msg"
+	st "github.com/markus-wa/demoinfocs-golang/v6/pkg/demoinfocs/sendtables"
 )
 
 //go:generate ifacemaker -f parser.go -f parsing.go -s parser -i Parser -p demoinfocs -D -y "Parser is an auto-generated interface for Parser, intended to be used when mockability is needed." -c "DO NOT EDIT: Auto generated" -o parser_interface.go

--- a/pkg/demoinfocs/parser_interface.go
+++ b/pkg/demoinfocs/parser_interface.go
@@ -5,7 +5,7 @@ package demoinfocs
 import (
 	"time"
 
-	st "github.com/markus-wa/demoinfocs-golang/v5/pkg/demoinfocs/sendtables"
+	st "github.com/markus-wa/demoinfocs-golang/v6/pkg/demoinfocs/sendtables"
 	dp "github.com/markus-wa/godispatch"
 )
 

--- a/pkg/demoinfocs/parsing.go
+++ b/pkg/demoinfocs/parsing.go
@@ -11,10 +11,10 @@ import (
 	"github.com/pkg/errors"
 	"google.golang.org/protobuf/proto"
 
-	"github.com/markus-wa/demoinfocs-golang/v5/pkg/demoinfocs/msg"
-	"github.com/markus-wa/demoinfocs-golang/v5/pkg/demoinfocs/sendtables/sendtablescs2"
+	"github.com/markus-wa/demoinfocs-golang/v6/pkg/demoinfocs/msg"
+	"github.com/markus-wa/demoinfocs-golang/v6/pkg/demoinfocs/sendtables/sendtablescs2"
 
-	"github.com/markus-wa/demoinfocs-golang/v5/pkg/demoinfocs/events"
+	"github.com/markus-wa/demoinfocs-golang/v6/pkg/demoinfocs/events"
 )
 
 const (

--- a/pkg/demoinfocs/participants_interface.go
+++ b/pkg/demoinfocs/participants_interface.go
@@ -3,7 +3,7 @@
 package demoinfocs
 
 import (
-	common "github.com/markus-wa/demoinfocs-golang/v5/pkg/demoinfocs/common"
+	common "github.com/markus-wa/demoinfocs-golang/v6/pkg/demoinfocs/common"
 )
 
 // Participants is an auto-generated interface for participants.

--- a/pkg/demoinfocs/s2_commands.go
+++ b/pkg/demoinfocs/s2_commands.go
@@ -10,9 +10,9 @@ import (
 	"github.com/pkg/errors"
 	"google.golang.org/protobuf/proto"
 
-	"github.com/markus-wa/demoinfocs-golang/v5/internal/bitread"
-	"github.com/markus-wa/demoinfocs-golang/v5/pkg/demoinfocs/events"
-	"github.com/markus-wa/demoinfocs-golang/v5/pkg/demoinfocs/msg"
+	"github.com/markus-wa/demoinfocs-golang/v6/internal/bitread"
+	"github.com/markus-wa/demoinfocs-golang/v6/pkg/demoinfocs/events"
+	"github.com/markus-wa/demoinfocs-golang/v6/pkg/demoinfocs/msg"
 )
 
 func (p *parser) handleSendTables(msg *msg.CDemoSendTables) {

--- a/pkg/demoinfocs/s2_usercmd_buttons.go
+++ b/pkg/demoinfocs/s2_usercmd_buttons.go
@@ -6,8 +6,8 @@ import (
 	"github.com/pkg/errors"
 	"google.golang.org/protobuf/encoding/protowire"
 
-	"github.com/markus-wa/demoinfocs-golang/v5/pkg/demoinfocs/events"
-	msg "github.com/markus-wa/demoinfocs-golang/v5/pkg/demoinfocs/msg"
+	"github.com/markus-wa/demoinfocs-golang/v6/pkg/demoinfocs/events"
+	msg "github.com/markus-wa/demoinfocs-golang/v6/pkg/demoinfocs/msg"
 )
 
 // userCmdButtonRing keeps the same command-number validation as the full

--- a/pkg/demoinfocs/s2_usercmd_delta.go
+++ b/pkg/demoinfocs/s2_usercmd_delta.go
@@ -1,7 +1,7 @@
 package demoinfocs
 
 import (
-	msg "github.com/markus-wa/demoinfocs-golang/v5/pkg/demoinfocs/msg"
+	msg "github.com/markus-wa/demoinfocs-golang/v6/pkg/demoinfocs/msg"
 	"github.com/pkg/errors"
 	"google.golang.org/protobuf/encoding/protowire"
 	"google.golang.org/protobuf/proto"

--- a/pkg/demoinfocs/s2_usercmd_delta_test.go
+++ b/pkg/demoinfocs/s2_usercmd_delta_test.go
@@ -3,7 +3,7 @@ package demoinfocs
 import (
 	"testing"
 
-	msg "github.com/markus-wa/demoinfocs-golang/v5/pkg/demoinfocs/msg"
+	msg "github.com/markus-wa/demoinfocs-golang/v6/pkg/demoinfocs/msg"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/protobuf/encoding/protowire"

--- a/pkg/demoinfocs/sendtables/fake/entity.go
+++ b/pkg/demoinfocs/sendtables/fake/entity.go
@@ -4,7 +4,7 @@ import (
 	"github.com/golang/geo/r3"
 	"github.com/stretchr/testify/mock"
 
-	st "github.com/markus-wa/demoinfocs-golang/v5/pkg/demoinfocs/sendtables"
+	st "github.com/markus-wa/demoinfocs-golang/v6/pkg/demoinfocs/sendtables"
 )
 
 // NewEntityWithProperty creates and returns an entity with a single mocked property.

--- a/pkg/demoinfocs/sendtables/fake/property.go
+++ b/pkg/demoinfocs/sendtables/fake/property.go
@@ -3,7 +3,7 @@ package fake
 import (
 	"github.com/stretchr/testify/mock"
 
-	st "github.com/markus-wa/demoinfocs-golang/v5/pkg/demoinfocs/sendtables"
+	st "github.com/markus-wa/demoinfocs-golang/v6/pkg/demoinfocs/sendtables"
 )
 
 var _ st.Property = new(Property)

--- a/pkg/demoinfocs/sendtables/sendtablescs2/class.go
+++ b/pkg/demoinfocs/sendtables/sendtablescs2/class.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"strings"
 
-	st "github.com/markus-wa/demoinfocs-golang/v5/pkg/demoinfocs/sendtables"
+	st "github.com/markus-wa/demoinfocs-golang/v6/pkg/demoinfocs/sendtables"
 )
 
 // fpNameTreeCache is kept as fallback for rare deep/large field paths.

--- a/pkg/demoinfocs/sendtables/sendtablescs2/entity.go
+++ b/pkg/demoinfocs/sendtables/sendtablescs2/entity.go
@@ -6,9 +6,9 @@ import (
 	"strings"
 
 	"github.com/golang/geo/r3"
-	"github.com/markus-wa/demoinfocs-golang/v5/pkg/demoinfocs/constants"
-	"github.com/markus-wa/demoinfocs-golang/v5/pkg/demoinfocs/msg"
-	st "github.com/markus-wa/demoinfocs-golang/v5/pkg/demoinfocs/sendtables"
+	"github.com/markus-wa/demoinfocs-golang/v6/pkg/demoinfocs/constants"
+	"github.com/markus-wa/demoinfocs-golang/v6/pkg/demoinfocs/msg"
+	st "github.com/markus-wa/demoinfocs-golang/v6/pkg/demoinfocs/sendtables"
 )
 
 // Entity represents a single game entity in the replay

--- a/pkg/demoinfocs/sendtables/sendtablescs2/field.go
+++ b/pkg/demoinfocs/sendtables/sendtablescs2/field.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"strconv"
 
-	"github.com/markus-wa/demoinfocs-golang/v5/pkg/demoinfocs/msg"
+	"github.com/markus-wa/demoinfocs-golang/v6/pkg/demoinfocs/msg"
 )
 
 const (

--- a/pkg/demoinfocs/sendtables/sendtablescs2/parser.go
+++ b/pkg/demoinfocs/sendtables/sendtablescs2/parser.go
@@ -5,9 +5,9 @@ import (
 	"math"
 	"strings"
 
-	bit "github.com/markus-wa/demoinfocs-golang/v5/internal/bitread"
-	"github.com/markus-wa/demoinfocs-golang/v5/pkg/demoinfocs/msg"
-	st "github.com/markus-wa/demoinfocs-golang/v5/pkg/demoinfocs/sendtables"
+	bit "github.com/markus-wa/demoinfocs-golang/v6/internal/bitread"
+	"github.com/markus-wa/demoinfocs-golang/v6/pkg/demoinfocs/msg"
+	st "github.com/markus-wa/demoinfocs-golang/v6/pkg/demoinfocs/sendtables"
 	"google.golang.org/protobuf/proto"
 )
 

--- a/pkg/demoinfocs/sendtables/sendtablescs2/poly_test.go
+++ b/pkg/demoinfocs/sendtables/sendtablescs2/poly_test.go
@@ -8,8 +8,8 @@ import (
 	"github.com/stretchr/testify/require"
 	"google.golang.org/protobuf/proto"
 
-	"github.com/markus-wa/demoinfocs-golang/v5/pkg/demoinfocs/msg"
-	st "github.com/markus-wa/demoinfocs-golang/v5/pkg/demoinfocs/sendtables"
+	"github.com/markus-wa/demoinfocs-golang/v6/pkg/demoinfocs/msg"
+	st "github.com/markus-wa/demoinfocs-golang/v6/pkg/demoinfocs/sendtables"
 )
 
 // polyTestSchema builds a small polymorphic schema:

--- a/pkg/demoinfocs/stringtables.go
+++ b/pkg/demoinfocs/stringtables.go
@@ -12,10 +12,10 @@ import (
 	"github.com/pkg/errors"
 	"google.golang.org/protobuf/proto"
 
-	bit "github.com/markus-wa/demoinfocs-golang/v5/internal/bitread"
-	common "github.com/markus-wa/demoinfocs-golang/v5/pkg/demoinfocs/common"
-	events "github.com/markus-wa/demoinfocs-golang/v5/pkg/demoinfocs/events"
-	"github.com/markus-wa/demoinfocs-golang/v5/pkg/demoinfocs/msg"
+	bit "github.com/markus-wa/demoinfocs-golang/v6/internal/bitread"
+	common "github.com/markus-wa/demoinfocs-golang/v6/pkg/demoinfocs/common"
+	events "github.com/markus-wa/demoinfocs-golang/v6/pkg/demoinfocs/events"
+	"github.com/markus-wa/demoinfocs-golang/v6/pkg/demoinfocs/msg"
 )
 
 const (


### PR DESCRIPTION
## Description

Bumps the module path from `github.com/markus-wa/demoinfocs-golang/v5` to `github.com/markus-wa/demoinfocs-golang/v6` in preparation for the `v6.0.0-alpha.0` release, following the `v4 -> v5` transition (df0da13).

Go modules with major version >= 2 must encode the major version in the module path, making this the defining breaking change of v6.

## What changed

- `go.mod`: `module .../v6`
- All internal imports across `pkg/` (incl. tests & fakes)
- `README.md`: go-get instructions, pkg.go.dev links, quickstart example, ldflags example
- `examples/`: imports & READMEs
- `.golangci.yml`: `gci` import prefix
- `.github/workflows/ci.yml`: CSDA `go mod edit -replace` target
- `pkg/demoinfocs/msg/generate.sh`: protoc `--go_opt=module` mappings

Purely mechanical: 70 files, 200 insertions / 200 deletions - every occurrence of `demoinfocs-golang/v5` -> `demoinfocs-golang/v6`.

## Breaking Changes

- Import paths change from `github.com/markus-wa/demoinfocs-golang/v5/...` to `github.com/markus-wa/demoinfocs-golang/v6/...`
  - `sed -i 's/demoinfocs-golang\/v5/demoinfocs-golang\/v6/'  **/*.go` may be useful to upgrade, use at your own risk

## Notes

- The `test-csda` CI job now replaces `.../v6` in CSDA's go.mod, but cs-demo-analyzer still requires `/v5` - until CSDA bumps to the v6 path, that job resolves demoinfocs from the module proxy instead of this checkout (it won't fail, but it won't exercise local changes either). May want to coordinate with @akiver or disable the job until then.
- The `v5` maintenance line continues on the [v5 branch](https://github.com/markus-wa/demoinfocs-golang/tree/v5), cut at `v5.2.0` - before the Go 1.27 requirement (#681), the usercmd rework (#669) and the behavioral changes (#663).

## Validation

- `go build ./...` ✔
- `go vet ./...` ✔
- `go test ./pkg/...` ✔ (full suite, from a clean-checkout state)
- `go test -run '^$' ./...` ✔ (compiles all tests, `scripts/build.sh` equivalent)
