### PR TITLE
fix(events): resolve nil Entity/Owner on grenade WeaponInstance (#580)

### DIFF
--- a/pkg/demoinfocs/common/equipment.go
+++ b/pkg/demoinfocs/common/equipment.go
@@ -312,9 +312,13 @@ const (
 // Equipment is a weapon / piece of equipment belonging to a player.
 // This also includes the skin and some additional data.
 type Equipment struct {
-	Type   EquipmentType // The type of weapon which the equipment instantiates.
-	Entity st.Entity     // The game entity instance
-	Owner  *Player       // The player carrying the equipment, not necessarily the buyer.
+	Type EquipmentType // The type of weapon which the equipment instantiates.
+	// The game entity instance.
+	// For the WeaponInstance of a thrown grenade this may be an entity that was just
+	// destroyed: CS2 removes the weapon from the thrower's inventory before the projectile
+	// entity is fully created, in which case the last known entity is used.
+	Entity st.Entity
+	Owner  *Player // The player carrying the equipment, not necessarily the buyer.
 	// Holds the original string of the weapon / equipment.
 	// E.g. the raw weapon name as provided by game events like 'knife_karambit' or 'ak47'.
 	// For entity-bound equipment that hasn't been seen in a game event it's empty.

--- a/pkg/demoinfocs/datatables.go
+++ b/pkg/demoinfocs/datatables.go
@@ -624,6 +624,11 @@ func (p *parser) bindPlayerWeapons(pawnEntity st.Entity, pl *common.Player) {
 		}
 
 		pl.Inventory = inventory
+
+		// Track grenades for the fallback in bindGrenadeProjectiles (#580).
+		// Not deleted when a grenade disappears from the inventory - see
+		// updateLastKnownGrenadeWeapons.
+		p.gameState.updateLastKnownGrenadeWeapons(pl)
 	}
 
 	pawnEntity.Property(playerWeaponPrefixS2).OnUpdate(func(pv st.PropertyValue) {
@@ -775,8 +780,27 @@ func (p *parser) bindGrenadeProjectiles(entity st.Entity) {
 			}
 		}
 
+		// CS2 removes the grenade from the thrower's inventory before the projectile entity is
+		// fully created - usually when the last grenade of the type is thrown (#580). In that
+		// case getPlayerWeapon() can't find the weapon in the inventory and returns a new one
+		// without an entity, so fall back to the last-known weapon of that type.
+		wepInstance := getPlayerWeapon(proj.Thrower, wep, "", p.nextUniqueID())
+		if wepInstance.Entity == nil && proj.Thrower != nil {
+			if lastKnownWep := p.gameState.lastKnownGrenadeWeapon(proj.Thrower, wepInstance.Type); lastKnownWep != nil {
+				wepInstance = lastKnownWep
+			}
+		}
+
 		// copy the weapon so it doesn't get overwritten by a new entity in parser.weapons
-		wepCopy := *(getPlayerWeapon(proj.Thrower, wep, "", p.nextUniqueID()))
+		wepCopy := *wepInstance
+		wepCopy.OriginalString = ""
+
+		// the inventory weapon's owner may be unknown if it was never updated since the
+		// parser started (e.g. mid-round GOTV start) - the thrower is always known here though
+		if proj.Thrower != nil {
+			wepCopy.Owner = proj.Thrower
+		}
+
 		proj.WeaponInstance = &wepCopy
 
 		unassert.NotNilf(proj.WeaponInstance, "couldn't find grenade instance for player")

--- a/pkg/demoinfocs/demoinfocs_test.go
+++ b/pkg/demoinfocs/demoinfocs_test.go
@@ -428,6 +428,47 @@ func TestDemoSetS2(t *testing.T) {
 	testDemoSet(t, demSetPathS2)
 }
 
+// TestGrenadeProjectileWeaponInstance asserts that the WeaponInstance of thrown grenades
+// resolves to a weapon with an entity and the thrower as owner.
+//
+// CS2 removes the grenade from the thrower's inventory before the projectile entity is
+// fully created - usually when the last grenade of the type is thrown - so a plain
+// inventory lookup returns a weapon without an entity and owner.
+// See https://github.com/markus-wa/demoinfocs-golang/issues/580
+//
+// pov.dem is used because the issue triggers regularly on it
+// (~13% of grenade throws resolved to a weapon without an entity before the fix).
+func TestGrenadeProjectileWeaponInstance(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping test due to -short flag")
+	}
+
+	t.Parallel()
+
+	f, err := os.Open(s2POVDemPath)
+	assert.NoError(t, err, "error opening demo %q", s2POVDemPath)
+
+	defer mustClose(t, f)
+
+	p := demoinfocs.NewParser(f)
+
+	throwsChecked := 0
+
+	p.RegisterEventHandler(func(e events.GrenadeProjectileThrow) {
+		throwsChecked++
+
+		wep := e.Projectile.WeaponInstance
+		if assert.NotNil(t, wep, "WeaponInstance is nil for a thrown grenade") {
+			assert.NotNil(t, wep.Entity, "WeaponInstance.Entity is nil for a thrown grenade")
+			assert.NotNil(t, wep.Owner, "WeaponInstance.Owner is nil for a thrown grenade")
+			assert.Same(t, e.Projectile.Thrower, wep.Owner, "WeaponInstance.Owner is not the thrower")
+		}
+	})
+
+	assert.NoError(t, p.ParseToEnd())
+	assert.Positive(t, throwsChecked, "no grenade throws found in %q, the test needs a demo with grenade throws", s2POVDemPath)
+}
+
 // TestPolymorphicGameModeRules asserts that the polymorphic m_pGameModeRules
 // pointer on the game-rules entity is tracked per entity and that its
 // activation state is readable through the poly-aware name resolution.

--- a/pkg/demoinfocs/game_state.go
+++ b/pkg/demoinfocs/game_state.go
@@ -43,6 +43,7 @@ type gameState struct {
 	currentDefuser               *common.Player                                                  // Player currently defusing the bomb, if any
 	currentPlanter               *common.Player                                                  // Player currently planting the bomb, if any
 	thrownGrenades               map[*common.Player]map[common.EquipmentType][]*common.Equipment // Information about every player's thrown grenades (from the moment they are thrown to the moment their effect is ended)
+	lastKnownGrenadeWeapons      map[*common.Player]map[common.EquipmentType]*common.Equipment   // Last-known grenade weapon per player & type, see updateLastKnownGrenadeWeapons
 	rules                        gameRules
 	demoInfo                     demoInfoProvider
 	lastRoundStartEvent          *events.RoundStart             // Used to dispatch this event after a possible MatchStartedChanged event
@@ -244,6 +245,36 @@ func (gs gameState) EntityByHandle(handle uint64) st.Entity {
 	return gs.entities[entityIDFromHandle(handle)]
 }
 
+// updateLastKnownGrenadeWeapons caches the grenade-type weapons currently in the player's inventory.
+//
+// CS2 removes a grenade from the thrower's inventory before the projectile entity is fully
+// created - usually when the last grenade of the type is thrown. The cache allows resolving
+// the weapon instance for a thrown grenade even after that removal (#580).
+//
+// Entries are only ever overwritten, never deleted: a weapon disappearing from the inventory
+// is exactly the case this cache exists for.
+func (gs *gameState) updateLastKnownGrenadeWeapons(pl *common.Player) {
+	for _, wep := range pl.Inventory {
+		if wep.Class() != common.EqClassGrenade {
+			continue
+		}
+
+		perType, ok := gs.lastKnownGrenadeWeapons[pl]
+		if !ok {
+			perType = make(map[common.EquipmentType]*common.Equipment)
+			gs.lastKnownGrenadeWeapons[pl] = perType
+		}
+
+		perType[wep.Type] = wep
+	}
+}
+
+// lastKnownGrenadeWeapon returns the last weapon of the given grenade type that was seen
+// in the player's inventory, or nil if none was seen.
+func (gs *gameState) lastKnownGrenadeWeapon(pl *common.Player, wepType common.EquipmentType) *common.Equipment {
+	return gs.lastKnownGrenadeWeapons[pl][wepType]
+}
+
 func newGameState(demoInfo demoInfoProvider) *gameState {
 	gs := &gameState{
 		playerControllerEntities: make(map[int]st.Entity),
@@ -257,6 +288,7 @@ func newGameState(demoInfo demoInfoProvider) *gameState {
 		hostages:                 make(map[int]*common.Hostage),
 		entities:                 make(map[int]st.Entity),
 		thrownGrenades:           make(map[*common.Player]map[common.EquipmentType][]*common.Equipment),
+		lastKnownGrenadeWeapons:  make(map[*common.Player]map[common.EquipmentType]*common.Equipment),
 		flyingFlashbangs:         make([]*FlyingFlashbang, 0),
 		lastFlash: lastFlash{
 			projectileByPlayer: make(map[*common.Player]*common.GrenadeProjectile),

--- a/pkg/demoinfocs/parsing.go
+++ b/pkg/demoinfocs/parsing.go
@@ -477,6 +477,12 @@ func (p *parser) handleFrameParsed(*frameParsedTokenType) {
 
 	p.processFrameGameEvents()
 
+	// Cache grenade weapons for the case where CS2 removes a grenade from the thrower's
+	// inventory before the projectile entity is fully created (#580).
+	for _, pl := range p.gameState.Participants().All() {
+		p.gameState.updateLastKnownGrenadeWeapons(pl)
+	}
+
 	p.currentFrame++
 	p.eventDispatcher.Dispatch(events.FrameDone{})
 }


### PR DESCRIPTION
## Root cause

CS2 removes a grenade from the thrower's inventory (and destroys the weapon entity) **before the projectile entity is fully created** — usually when the last grenade of the type is thrown, plus some slot-update ordering races when several grenades of a type are thrown in quick succession.

In `bindGrenadeProjectiles()` the `OnCreateFinished` handler resolves the weapon via `getPlayerWeapon()`, which scans the thrower's inventory. On a miss it falls through to a new `Equipment` with `Entity == nil` and `Owner == nil` — so `WeaponInstance.Entity`/`.Owner` were nil on `GrenadeProjectileThrow` and the mimicked `WeaponFire` events (the two events named in the issue).

Retest findings across 17 local 2026-era demos (~6,700 throws) plus the test set:
- nil `Entity` on 9–42% of throws per demo (v5.2.0 **and** current master — not fixed by the unknown-model fallback from `d8440de`, `unknownType=0` everywhere)
- failures are dominated by last-nade-of-type throws per (player, round, type), plus ~13% mid-sequence slot-churn races
- `proj.Thrower` always resolved; no molotov/incendiary mixups
- the projectile entity itself carries no weapon handle (only `m_hOwnerEntity`/`m_hThrower` = the player), so there is no authoritative source to resolve from — a last-known cache is the best available

## Fix

- Fall back to the **last-known weapon of that type** seen in the thrower's inventory when the inventory lookup misses (`gameState.lastKnownGrenadeWeapons`)
- The cache is populated on inventory rebuilds (`bindPlayerWeapons`) and every `FrameDone` (covers mid-parse starts); entries are only overwritten, never deleted
- Always set `WeaponInstance.Owner` to the thrower (the inventory weapon's owner may be stale/nil when it was never updated since the parse started)
- Document that `Equipment.Entity` for a thrown grenade may point to a just-destroyed entity
- `UniqueID2` semantics are unchanged (still identifies the weapon entity / "stash" — #361 / #601 are a separate matter)

## Verification

Retest harness across 17 demos + the test set (before → after, nil Entity / nil Owner):

| demo | throws | before | after |
|---|---|---|---|
| pov.dem (test set, POV) | 904 | 114 / 118 | **0 / 0** |
| s2 test set (5 demos w/ throws) | 922 | 4 / 7 | **0 / 0** |
| mouz-vs-vitality-m3-inferno | 441 | 38 / 72 | **0 / 0** |
| nrg-vs-aurora-m1-inferno | 374 | 56 / 96 | **0 / 0** |
| nrg-vs-aurora-m2-nuke | 316 | 106 / 112 | **0 / 0** |
| G2 vs Vitality (inferno, 2026) | 484 | 164 / 165 | **0 / 0** |
| Falcons vs 3DMAX (dust2, 2026) | 523 | 44 / 74 | **1 / 1**\* |
| 11 further 2026 demos | 3,696 | 1,256 / 1,481 | **0 / 0** |

\* single residual: a smoke projectile created at tick 1 (parse start) whose `m_hOwnerEntity` handle doesn't resolve to any player — with an unknown thrower there is nothing to resolve the weapon from (same class as the unknown-player limitation, #162)

Also: regression test `TestGrenadeProjectileWeaponInstance` on `pov.dem` (fails on master, passes with the fix), full test suite + race detector clean, golangci-lint clean.

## Side-findings (out of scope, worth knowing)

- the existing `unassert.NotNilf(proj.WeaponInstance.Owner, ...)` in `bindGrenadeProjectiles` can never fire: a typed nil `*Player` boxed into `interface{}` is `!= nil` — that's why CI stayed green with `-tags unassert_panic` despite pov.dem triggering 118 nil-Owner throws
- the new test-set walkthrough confirmed `TestDemoSetS2` was already exercising the bug via pov.dem without noticing

Fixes #580