### PR TITLE
ci: add OSV-Scanner dependency vulnerability scanning workflow

### DIFF
--- a/.github/workflows/osv-scanner.yml
+++ b/.github/workflows/osv-scanner.yml
@@ -1,0 +1,24 @@
+name: OSV-Scanner
+
+on:
+  pull_request:
+    branches: [master]
+  push:
+    branches: [master]
+  schedule:
+    - cron: "30 12 * * 1"
+
+permissions:
+  # Required to upload SARIF file to CodeQL. See: https://github.com/github/codeql-action/issues/2117
+  actions: read
+  # Require writing security events to upload SARIF file to security tab
+  security-events: write
+  # Only need to read contents
+  contents: read
+
+jobs:
+  scan-pr:
+    uses: "google/osv-scanner-action/.github/workflows/osv-scanner-reusable-pr.yml@v2.5.1"
+
+  scan-scheduled:
+    uses: "google/osv-scanner-action/.github/workflows/osv-scanner-reusable.yml@v2.5.1"

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ A blazing fast, feature complete and production ready Go library for parsing and
 [![codecov](https://img.shields.io/codecov/c/github/markus-wa/demoinfocs-golang?style=flat-square)](https://codecov.io/gh/markus-wa/demoinfocs-golang)
 [![License](https://img.shields.io/badge/license-MIT-blue.svg?style=flat-square)](LICENSE.md)
 [![FOSSA Status](https://app.fossa.io/api/projects/git%2Bgithub.com%2Fmarkus-wa%2Fdemoinfocs-golang.svg?type=shield)](https://app.fossa.io/projects/git%2Bgithub.com%2Fmarkus-wa%2Fdemoinfocs-golang?ref=badge_shield)
-[![Snyk Scan](https://img.shields.io/badge/security%20scan-snyk-blueviolet?style=flat-square)](https://app.snyk.io/org/markus-wa/project/cbd87cca-a903-4553-b677-42f3bb086655)
+[![OSV-Scanner](https://img.shields.io/github/actions/workflow/status/markus-wa/demoinfocs-golang/osv-scanner.yml?branch=master&label=osv-scanner&style=flat-square)](https://github.com/markus-wa/demoinfocs-golang/actions/workflows/osv-scanner.yml)
 
 ## Discussions / Chat
 


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/osv-scanner.yml` using the official [google/osv-scanner-action](https://github.com/google/osv-scanner-action) reusable workflows (`v2.5.1`)
- **PR scan**: on every PR against `master`, diffs vulnerabilities between base and head — fails if the PR introduces new known vulnerabilities
- **Scheduled scan**: weekly (Mon 12:30 UTC) + on push to `master`, full scan of `go.mod`/`go.sum` reported to Security → Code scanning
- Results also uploaded as SARIF artifacts; inner actions are SHA-pinned upstream

## Test plan
- [x] `actionlint` passes on the new workflow (pre-existing `protobuf.yml` shellcheck infos unrelated)
- [ ] Workflow triggers on this PR (`scan-pr` job) — check the Actions tab
- [ ] First scheduled/push run appears under Security → Code scanning

## Notes
- Default scan args recursively scan the repo; `go.mod` is natively supported. Submodule (`test/cs-demos`) checkout is disabled, so large demo files are not downloaded.
- If the current dependency tree has known vulns, the scheduled scan will fail by design (`fail-on-vuln: true` default) — triage then.