### PR TITLE
ci: add least-privilege permissions to workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,11 @@ jobs:
   ci:
     runs-on: ubuntu-latest
 
+    # reviewdog github-check reporter requires check-run write access
+    permissions:
+      contents: read
+      checks: write
+
     env:
       REVIEWDOG_REPORTER: github-check
       REVIEWDOG_GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -66,6 +71,9 @@ jobs:
 
   test-csda: # Run tests of CS Demo Analyzer
     runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
 
     steps:
       - name: Checkout demoinfocs-golang repo

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -9,6 +9,11 @@ on:
   schedule:
     - cron: '0 1 * * 4'
 
+permissions:
+  contents: read
+  # Required to upload SARIF results to the security tab
+  security-events: write
+
 jobs:
   analyze:
     name: Analyze

--- a/.github/workflows/mirror.yml
+++ b/.github/workflows/mirror.yml
@@ -4,6 +4,10 @@ on:
     branches:
       - master
 
+permissions:
+  # Mirroring uses SSH_PRIVATE_KEY, not GITHUB_TOKEN
+  contents: read
+
 jobs:
   build:
     name: Mirror to GitLab

--- a/.github/workflows/protobuf.yml
+++ b/.github/workflows/protobuf.yml
@@ -3,6 +3,11 @@ on:
   workflow_dispatch: {}
   schedule:
     - cron: '0 0 * * *'
+
+permissions:
+  # Pull Requests are created with the CUSTOM_GITHUB_TOKEN (PAT), not GITHUB_TOKEN
+  contents: read
+
 jobs:
   protobuf:
     name: Update Protobufs


### PR DESCRIPTION
Fixes the 5 open CodeQL code-scanning alerts (`actions/missing-workflow-permissions`, medium severity).

GitHub Actions workflows currently run with the default broad `GITHUB_TOKEN` permissions. This adds explicit least-privilege `permissions:` blocks:

| Workflow | Permissions | Rationale |
|---|---|---|
| `ci.yml` (`ci` job) | `contents: read`, `checks: write` | reviewdog `github-check` reporter creates check runs |
| `ci.yml` (`test-csda` job) | `contents: read` | checkout + tests only |
| `codeql-analysis.yml` | `contents: read`, `security-events: write` | SARIF upload to Security tab |
| `protobuf.yml` | `contents: read` | PRs are created with `CUSTOM_GITHUB_TOKEN` (PAT), not `GITHUB_TOKEN` |
| `mirror.yml` | `contents: read` | mirroring uses `SSH_PRIVATE_KEY`, not `GITHUB_TOKEN` |

## Test plan
- [ ] CI passes on this PR (validates the `ci` job permissions, incl. reviewdog check-run creation)
- [ ] After merge: Code scanning alerts for `actions/missing-workflow-permissions` close on the next scheduled CodeQL run