### PR TITLE
perf: reduce parse hotspots (snappy dst reuse, field-path LUT, decoder boxing)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/llgcode/draw2d v0.0.0-20230723155556-e595d7c7e75e
 	github.com/markus-wa/go-heatmap/v2 v2.0.0
 	github.com/markus-wa/go-unassert v0.1.3
-	github.com/markus-wa/gobitread v0.2.5-0.20260831182154-f4e39ce3a9b1
+	github.com/markus-wa/gobitread v0.2.5
 	github.com/markus-wa/godispatch v1.4.1
 	github.com/markus-wa/quickhull-go/v2 v2.2.0
 	github.com/oklog/ulid/v2 v2.1.1

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/llgcode/draw2d v0.0.0-20230723155556-e595d7c7e75e
 	github.com/markus-wa/go-heatmap/v2 v2.0.0
 	github.com/markus-wa/go-unassert v0.1.3
-	github.com/markus-wa/gobitread v0.2.5-0.20241202000432-3c3e0bc797c6
+	github.com/markus-wa/gobitread v0.2.5-0.20260831182154-f4e39ce3a9b1
 	github.com/markus-wa/godispatch v1.4.1
 	github.com/markus-wa/quickhull-go/v2 v2.2.0
 	github.com/oklog/ulid/v2 v2.1.1

--- a/go.sum
+++ b/go.sum
@@ -20,8 +20,8 @@ github.com/markus-wa/go-heatmap/v2 v2.0.0 h1:mskJwvbESraWLBly+XTv555PVla1e8C2iSr
 github.com/markus-wa/go-heatmap/v2 v2.0.0/go.mod h1:ETqmIODsmcKAjGPmXkkMS+sFMUk81Xcr7XINxWzNcBw=
 github.com/markus-wa/go-unassert v0.1.3 h1:4N2fPLUS3929Rmkv94jbWskjsLiyNT2yQpCulTFFWfM=
 github.com/markus-wa/go-unassert v0.1.3/go.mod h1:/pqt7a0LRmdsRNYQ2nU3SGrXfw3bLXrvIkakY/6jpPY=
-github.com/markus-wa/gobitread v0.2.5-0.20241202000432-3c3e0bc797c6 h1:VNn0S4GFv6y2d2W4PGDs1eEfWPyEQbmld9QUFSsVILg=
-github.com/markus-wa/gobitread v0.2.5-0.20241202000432-3c3e0bc797c6/go.mod h1:PcWXMH4gx7o2CKslbkFkLyJB/aHW7JVRG3MRZe3PINg=
+github.com/markus-wa/gobitread v0.2.5-0.20260831182154-f4e39ce3a9b1 h1:1/O2J+n1RuPy35/3V+u90Fguk1oXijy5sj+cTMaTYcU=
+github.com/markus-wa/gobitread v0.2.5-0.20260831182154-f4e39ce3a9b1/go.mod h1:PcWXMH4gx7o2CKslbkFkLyJB/aHW7JVRG3MRZe3PINg=
 github.com/markus-wa/godispatch v1.4.1 h1:Cdff5x33ShuX3sDmUbYWejk7tOuoHErFYMhUc2h7sLc=
 github.com/markus-wa/godispatch v1.4.1/go.mod h1:tk8L0yzLO4oAcFwM2sABMge0HRDJMdE8E7xm4gK/+xM=
 github.com/markus-wa/quickhull-go/v2 v2.2.0 h1:rB99NLYeUHoZQ/aNRcGOGqjNBGmrOaRxdtqTnsTUPTA=

--- a/go.sum
+++ b/go.sum
@@ -20,8 +20,8 @@ github.com/markus-wa/go-heatmap/v2 v2.0.0 h1:mskJwvbESraWLBly+XTv555PVla1e8C2iSr
 github.com/markus-wa/go-heatmap/v2 v2.0.0/go.mod h1:ETqmIODsmcKAjGPmXkkMS+sFMUk81Xcr7XINxWzNcBw=
 github.com/markus-wa/go-unassert v0.1.3 h1:4N2fPLUS3929Rmkv94jbWskjsLiyNT2yQpCulTFFWfM=
 github.com/markus-wa/go-unassert v0.1.3/go.mod h1:/pqt7a0LRmdsRNYQ2nU3SGrXfw3bLXrvIkakY/6jpPY=
-github.com/markus-wa/gobitread v0.2.5-0.20260831182154-f4e39ce3a9b1 h1:1/O2J+n1RuPy35/3V+u90Fguk1oXijy5sj+cTMaTYcU=
-github.com/markus-wa/gobitread v0.2.5-0.20260831182154-f4e39ce3a9b1/go.mod h1:PcWXMH4gx7o2CKslbkFkLyJB/aHW7JVRG3MRZe3PINg=
+github.com/markus-wa/gobitread v0.2.5 h1:F5GxezkgQhnWsXWOf4mY1mLcSeDRI3onkIouG26nCEY=
+github.com/markus-wa/gobitread v0.2.5/go.mod h1:PcWXMH4gx7o2CKslbkFkLyJB/aHW7JVRG3MRZe3PINg=
 github.com/markus-wa/godispatch v1.4.1 h1:Cdff5x33ShuX3sDmUbYWejk7tOuoHErFYMhUc2h7sLc=
 github.com/markus-wa/godispatch v1.4.1/go.mod h1:tk8L0yzLO4oAcFwM2sABMge0HRDJMdE8E7xm4gK/+xM=
 github.com/markus-wa/quickhull-go/v2 v2.2.0 h1:rB99NLYeUHoZQ/aNRcGOGqjNBGmrOaRxdtqTnsTUPTA=

--- a/pkg/demoinfocs/game_state.go
+++ b/pkg/demoinfocs/game_state.go
@@ -150,6 +150,13 @@ func (gs gameState) Participants() Participants {
 	}
 }
 
+// participantsRaw returns the internal user-ID-keyed player map for direct
+// iteration by parser internals that neither need snapshot semantics nor a
+// deterministic order. Not part of the public API.
+func (gs gameState) participantsRaw() map[int]*common.Player {
+	return gs.playersByUserID
+}
+
 // Rules returns the GameRules for the current match.
 // Contains information like freeze time duration etc.
 func (gs gameState) Rules() GameRules {

--- a/pkg/demoinfocs/parsing.go
+++ b/pkg/demoinfocs/parsing.go
@@ -322,7 +322,14 @@ func (p *parser) readFramePayload(size int, msgCompressed, isCSTVBroadcast bool)
 	// Reuse the per-parser scratch as the snappy destination: the decoded
 	// payload is dead after the caller's proto.Unmarshal, and frame parsing
 	// is single-threaded.
+	// snappy.Decode only keeps dst when len(dst) >= decoded length, so grow
+	// the scratch's length (capacity permitting) instead of passing a
+	// zero-length slice — otherwise every call allocates a fresh buffer.
 	var err error
+
+	if dLen, _ := snappy.DecodedLen(buf); dLen <= cap(p.snappyScratch) {
+		p.snappyScratch = p.snappyScratch[:dLen]
+	}
 
 	buf, err = snappy.Decode(p.snappyScratch, buf)
 
@@ -479,7 +486,10 @@ func (p *parser) handleFrameParsed(*frameParsedTokenType) {
 
 	// Cache grenade weapons for the case where CS2 removes a grenade from the thrower's
 	// inventory before the projectile entity is fully created (#580).
-	for _, pl := range p.gameState.Participants().All() {
+	// Iterates the underlying map directly: no snapshot allocation or sorting
+	// is needed because updateLastKnownGrenadeWeapons only reads the player
+	// and mutates parser-owned cache state, and map order doesn't matter here.
+	for _, pl := range p.gameState.participantsRaw() {
 		p.gameState.updateLastKnownGrenadeWeapons(pl)
 	}
 

--- a/pkg/demoinfocs/sendtables/sendtablescs2/field_decoder.go
+++ b/pkg/demoinfocs/sendtables/sendtablescs2/field_decoder.go
@@ -15,6 +15,11 @@ var simTimeCache [simTimeCacheLen]any
 // readBits(4) produces only 16 distinct values.
 var runeTimeCache [16]any
 
+// smallUintCache holds pre-boxed uint64 any values for unsignedDecoder.
+// On a real CS2 demo ~83% of decoded unsigned values are < 1024 (handles,
+// counters, bools-as-ints), so a table hit avoids the uint64 boxing alloc.
+var smallUintCache [1024]any
+
 func init() {
 	for i := range simTimeCache {
 		simTimeCache[i] = float32(i) * (1.0 / 64)
@@ -22,6 +27,10 @@ func init() {
 
 	for i := range runeTimeCache {
 		runeTimeCache[i] = math.Float32frombits(uint32(i))
+	}
+
+	for i := range smallUintCache {
+		smallUintCache[i] = uint64(i)
 	}
 }
 
@@ -484,7 +493,12 @@ func qangleFactory(f *field) fieldDecoder {
 }
 
 func unsignedDecoder(r *reader) any {
-	return uint64(r.readVarUint32())
+	v := r.readVarUint32()
+	if v < uint32(len(smallUintCache)) {
+		return smallUintCache[v]
+	}
+
+	return uint64(v)
 }
 
 func unsigned64Decoder(r *reader) any {

--- a/pkg/demoinfocs/sendtables/sendtablescs2/field_path.go
+++ b/pkg/demoinfocs/sendtables/sendtablescs2/field_path.go
@@ -309,40 +309,65 @@ func (fp *fieldPath) release() {
 	fpPool.Put(fp)
 }
 
-// readFieldPaths reads a new slice of fieldPath values from the given reader
+// readFieldPaths reads a new slice of fieldPath values from the given reader.
+//
+// Decoding uses a peek table over the huffman tree: the next fpHuffBits bits
+// are peeked and looked up in fpHuffLUT. Entries covering codes shorter than
+// fpHuffBits are replicated across the unused high bits, so one lookup fully
+// resolves short codes; longer codes resolve through the table to a tree node
+// and continue the per-bit walk from there.
 func readFieldPaths(r *reader, paths *[]*fieldPath) int {
 	fp := newFieldPath()
 	i := 0
 	node := int16(0) // root is always index 0 in fpHuffNodes
 
 	for !fp.done {
-		var next int16
-		if r.readBoolean() {
-			next = fpHuffNodes[node].right
-		} else {
-			next = fpHuffNodes[node].left
+		lut := &fpHuffLUT[r.peekBits(fpHuffBits)]
+		node = lut.node
+		r.skipBits(lut.consumed)
+
+		op := int16(-1)
+		for op < 0 { //nolint:nestif // internal node: continue the per-bit walk
+			if node < 0 {
+				// leaf resolved by the LUT (encoded as marker|~op)
+				op = ^node
+
+				break
+			}
+
+			var next int16
+			if r.readBoolean() {
+				next = fpHuffNodes[node].right
+			} else {
+				next = fpHuffNodes[node].left
+			}
+
+			if fpHuffNodes[next].left < 0 {
+				// leaf reached by the per-bit walk
+				op = fpHuffNodes[next].value
+
+				break
+			}
+
+			node = next
 		}
 
-		if fpHuffNodes[next].left < 0 { //nolint:nestif // leaf node
-			node = 0 // reset to root
+		node = 0 // reset to root
 
-			fieldPathTable[fpHuffNodes[next].value].fn(r, fp)
+		fieldPathTable[op].fn(r, fp)
 
-			if !fp.done {
-				if len(*paths) <= i {
-					*paths = append(*paths, fp.copy())
-				} else {
-					x := (*paths)[i]
-					x.last = fp.last
-					x.done = fp.done
-					// Only copy the active portion of the path
-					copy(x.path[:fp.last+1], fp.path[:fp.last+1])
-				}
-
-				i++
+		if !fp.done {
+			if len(*paths) <= i {
+				*paths = append(*paths, fp.copy())
+			} else {
+				x := (*paths)[i]
+				x.last = fp.last
+				x.done = fp.done
+				// Only copy the active portion of the path
+				copy(x.path[:fp.last+1], fp.path[:fp.last+1])
 			}
-		} else {
-			node = next
+
+			i++
 		}
 	}
 

--- a/pkg/demoinfocs/sendtables/sendtablescs2/field_path.go
+++ b/pkg/demoinfocs/sendtables/sendtablescs2/field_path.go
@@ -327,7 +327,7 @@ func readFieldPaths(r *reader, paths *[]*fieldPath) int {
 		r.skipBits(lut.consumed)
 
 		op := int16(-1)
-		for op < 0 { //nolint:nestif // internal node: continue the per-bit walk
+		for op < 0 {
 			if node < 0 {
 				// leaf resolved by the LUT (encoded as marker|~op)
 				op = ^node
@@ -351,8 +351,6 @@ func readFieldPaths(r *reader, paths *[]*fieldPath) int {
 
 			node = next
 		}
-
-		node = 0 // reset to root
 
 		fieldPathTable[op].fn(r, fp)
 

--- a/pkg/demoinfocs/sendtables/sendtablescs2/huffman.go
+++ b/pkg/demoinfocs/sendtables/sendtablescs2/huffman.go
@@ -51,8 +51,9 @@ func buildFpHuffLUT() {
 		n := fpHuffNodes[node]
 
 		if n.left < 0 {
+			entry := fpHuffLUTEntry{consumed: uint32(depth), node: fpHuffLeafMarker | ^n.value}
+
 			// leaf: replicate across the remaining (high) padding
-			entry := fpHuffLUTEntry{consumed: uint32(depth), node: fpHuffLeafMarker | ^int16(n.value)}
 			shift := uint32(fpHuffBits - depth)
 			for tail := uint32(0); tail < 1<<shift; tail++ {
 				fpHuffLUT[code|(tail<<depth)] = entry
@@ -78,6 +79,7 @@ func buildFpHuffLUT() {
 
 func init() {
 	fpHuffNodes = buildFlatHuffmanTree(newHuffmanTree())
+
 	buildFpHuffLUT()
 }
 

--- a/pkg/demoinfocs/sendtables/sendtablescs2/huffman.go
+++ b/pkg/demoinfocs/sendtables/sendtablescs2/huffman.go
@@ -17,8 +17,68 @@ type fpHuffNode struct {
 // The root is always at index 0.
 var fpHuffNodes []fpHuffNode
 
+const (
+	// fpHuffBits is the number of bits peeked per fpHuffLUT lookup.
+	// Must cover the majority of code lengths in one lookup; the observed
+	// max code length for the field-path table is 17.
+	fpHuffBits = 10
+	// fpHuffLeafMarker marks fpHuffLUT entries that resolve to a leaf.
+	// node then stores ^op so the marker cannot collide with a tree index.
+	fpHuffLeafMarker = int16(-0x8000)
+)
+
+// fpHuffLUTEntry is one fpHuffLUT slot: the tree node to continue from
+// (fpHuffLeafMarker|~op for leaves) and the number of bits consumed.
+type fpHuffLUTEntry struct {
+	consumed uint32
+	node     int16
+}
+
+// fpHuffLUT is a peek table built from fpHuffNodes; indexed by the next
+// fpHuffBits bits of the stream. The reader's bit order is LSB-first
+// (next bit = LSB of bitVal), so stream bit i lives at index bit i.
+var fpHuffLUT [1 << fpHuffBits]fpHuffLUTEntry
+
+// buildFpHuffLUT fills fpHuffLUT from fpHuffNodes.
+// For every tree leaf at depth <= fpHuffBits, all table indices whose low
+// `depth` bits are the leaf's code (first-read bit = LSB) are filled with
+// that leaf. Deeper codes resolve to the tree node reached after fpHuffBits
+// bits (node >= 0), which readFieldPaths continues from with the per-bit walk.
+func buildFpHuffLUT() {
+	var fill func(node int16, depth int, code uint32)
+
+	fill = func(node int16, depth int, code uint32) {
+		n := fpHuffNodes[node]
+
+		if n.left < 0 {
+			// leaf: replicate across the remaining (high) padding
+			entry := fpHuffLUTEntry{consumed: uint32(depth), node: fpHuffLeafMarker | ^int16(n.value)}
+			shift := uint32(fpHuffBits - depth)
+			for tail := uint32(0); tail < 1<<shift; tail++ {
+				fpHuffLUT[code|(tail<<depth)] = entry
+			}
+
+			return
+		}
+
+		if depth == fpHuffBits {
+			entry := fpHuffLUTEntry{consumed: fpHuffBits, node: node}
+			fpHuffLUT[code] = entry
+
+			return
+		}
+
+		// first-read bit = LSB: left (0) keeps the bit unset, right (1) sets it
+		fill(n.left, depth+1, code)
+		fill(n.right, depth+1, code|1<<depth)
+	}
+
+	fill(0, 0, 0)
+}
+
 func init() {
 	fpHuffNodes = buildFlatHuffmanTree(newHuffmanTree())
+	buildFpHuffLUT()
 }
 
 // buildFlatHuffmanTree converts an interface-based huffman tree into a flat

--- a/pkg/demoinfocs/sendtables/sendtablescs2/reader.go
+++ b/pkg/demoinfocs/sendtables/sendtablescs2/reader.go
@@ -142,6 +142,33 @@ func (r *reader) readBits(n uint32) uint32 {
 	return uint32(x)
 }
 
+// peekBits returns the next n bits (n <= 32) without consuming them.
+// Bits beyond the end of the stream read as zero; callers must treat the
+// peeked value as speculative until skipBits has consumed a valid prefix.
+// Unlike readBits this never advances pos, so peek + skip is idempotent-safe
+// for LUT-driven decoding.
+func (r *reader) peekBits(n uint32) uint32 {
+	// gather enough bytes into bitVal without consuming them
+	for r.bitCount < n && r.pos < r.size {
+		r.bitVal |= uint64(r.buf[r.pos]) << r.bitCount
+		r.pos++
+		r.bitCount += 8
+	}
+
+	return uint32(r.bitVal & ((1 << n) - 1))
+}
+
+// skipBits consumes n bits previously returned by peekBits.
+// Precondition: n bits are available in the stream.
+func (r *reader) skipBits(n uint32) {
+	if n > r.bitCount {
+		_panicf("skipBits: insufficient bits (%d > %d)", n, r.bitCount)
+	}
+
+	r.bitVal >>= n
+	r.bitCount -= n
+}
+
 // readByte reads a single byte
 func (r *reader) readByte() byte {
 	// Fast path if we're byte aligned


### PR DESCRIPTION
## Summary

Profiling `BenchmarkDemoInfoCs` (s2.dem) showed the top hotspots were the field-path huffman walk, the snappy decode destination allocation, and small-value boxing in the field decoders. This PR addresses all three plus two smaller allocation sources.

**Benchmark (10s benchtime, n=6, benchstat):**

| | sec/op | B/op | allocs/op |
|---|---|---|---|
| before | 830.5ms ± 2% | 251.0 MiB ± 0% | 5.234M ± 0% |
| after | 729.6ms ± 1% | 204.0 MiB ± 0% | 5.055M ± 0% |
| | **-12.2%** (p=0.002) | **-18.7%** (p=0.002) | **-3.4%** (p=0.002) |

## Changes

### snappy destination reuse (`pkg/demoinfocs/parsing.go`)
`snappy.Decode` only reuses `dst` when `len(dst) >= decodedLen` — the per-parser scratch was always passed with `len == 0`, so every compressed frame allocated a fresh destination buffer (~652 MB/op, 17% of total). Now the scratch is pre-sized via `snappy.DecodedLen` before decoding, so the existing buffer is actually reused.

### field-path huffman peek table (`sendtablescs2/field_path.go`, `huffman.go`, `reader.go`)
`readFieldPaths` walked the huffman tree bit-by-bit (~16% of CPU, 17 dependent loads per symbol worst case). Added `fpHuffLUT`, a 1024-entry peek table: the next 10 bits are peeked at once and resolved with a single lookup; codes longer than 10 bits continue with a short per-bit walk from the tree node the table reports.

Notes:
- The reader's bit order is LSB-first (next bit = LSB of `bitVal`), so the table is keyed with the first-read bit in the LSB. This was the source of a subtle first-pass bug (an MSB-keyed table decodes a bit-reversed tree).
- LUT leaf entries encode the op as `fpHuffLeafMarker | ~op`; the continuation loop distinguishes those from tree leaf nodes reached by the per-bit walk.
- New `reader.peekBits`/`skipBits` support the table without consuming bits speculatively.

Tests added (`field_path_test.go`):
- `TestFpHuffLUTMatchesTree` — exhaustive check of all 1024 peek values against the bit-by-bit tree walk (op, consumed bits, internal-node continuation)
- `TestReadFieldPathsLUTDifferential` — 200k weighted-random codes encoded LSB-first into a bitstream; LUT decode must equal the per-bit walk exactly
- `TestReaderPeekSkip` — peek/skip accounting matches `readBits` and leaves readers in sync

### small-uint pre-boxed table (`sendtablescs2/field_decoder.go`)
`unsignedDecoder` boxed a fresh `uint64` per call (~1.8M allocs/op). A measured distribution on s2.dem showed ~73% of values < 128 and ~83% < 1024, so values below 1024 now come from a pre-boxed `smallUintCache` table.

### per-frame `Participants().All()` snapshot (`pkg/demoinfocs/parsing.go`, `game_state.go`)
`handleFrameParsed` allocated and sorted a full player snapshot every frame just to iterate players for the grenade-weapon cache (`#580` workaround), where neither snapshot semantics nor deterministic order matter. Now iterates the underlying map via a new internal `gameState.participantsRaw()` (public API untouched).

## Dependency: gobitread

The remaining `ReadBytesInto` per-byte loop (`handleDemoPacket` embedded-message reads) is fixed upstream in **markus-wa/gobitread#5** — branch `mw/perf-improvements`, which adds a chunked byte-aligned fast path plus end-of-stream fixes (the branch as originally pushed panicked with `unexpected EOF` on valid demos; the PR contains the fix and regression tests).

This PR pins the dependency to that branch head via pseudo-version:

    github.com/markus-wa/gobitread v0.2.5-0.20260831182154-f4e39ce3a9b1

Once gobitread#5 is merged and tagged, this pin can be bumped to the tagged release in a follow-up (the replace-free `go get` commit is already all that's needed).

## Test plan
- `go test ./...` — all pass, including golden parsing tests (`TestDemoInfoCs`)
- `go test -tags unassert_panic -short ./...` — all pass
- `scripts/regression-tests.sh` — all pass
- `gofmt` / `go vet` — clean