### PR TITLE
fix: return false from Silenced() when m_bSilencerOn is missing

### DIFF
--- a/pkg/demoinfocs/common/equipment.go
+++ b/pkg/demoinfocs/common/equipment.go
@@ -449,7 +449,11 @@ func (e *Equipment) Silenced() bool {
 		return false
 	}
 
+	// Entities whose class does not declare m_bSilencerOn (e.g. equipment items) get a nil property.
 	prop := e.Entity.Property("m_bSilencerOn")
+	if prop == nil {
+		return false
+	}
 
 	return prop.Value().BoolVal()
 }

--- a/pkg/demoinfocs/common/equipment_test.go
+++ b/pkg/demoinfocs/common/equipment_test.go
@@ -187,6 +187,23 @@ func TestEquipment_Silenced_On_Off(t *testing.T) {
 	assert.Equal(t, false, wep.Silenced(), "Weapon should not be silenced after the property value has been set to 0.")
 }
 
+func TestEquipment_Silenced_PropertyMissing(t *testing.T) {
+	wep := &Equipment{
+		Type:   EqDefuseKit,
+		Entity: entityWithProperties(nil),
+	}
+
+	assert.False(t, wep.Silenced())
+}
+
+func TestEquipment_Silenced_EntityNil(t *testing.T) {
+	wep := &Equipment{
+		Type: EqAK47,
+	}
+
+	assert.False(t, wep.Silenced())
+}
+
 func TestEquipmentAlternative(t *testing.T) {
 	assert.Equal(t, EqUSP, EquipmentAlternative(EqP2000))
 	assert.Equal(t, EqCZ, EquipmentAlternative(EqP250))


### PR DESCRIPTION
## Problem

`(*common.Equipment).Silenced()` panics with a nil pointer dereference instead of returning `false` when the weapon entity's class does not declare `m_bSilencerOn`.

```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x30]
common.(*Equipment).Silenced(...)
	pkg/demoinfocs/common/equipment.go:454
```

This is reachable from ordinary demo parsing. Equipment items -- defuse kit, kevlar, helmet, NVG -- get a real `Entity` attached at `pkg/demoinfocs/datatables.go:982` via `common.EquipmentIndexMapping`, and their entity class has no `m_bSilencerOn` field, so any consumer that reaches `Silenced()` on one of them crashes rather than getting `false`.

## Cause

`pkg/demoinfocs/sendtables/sendtablescs2/entity.go:240` states the contract: `// Property returns the named property of the entity, or nil if not found.` The implementation returns a bare `nil` on three not-found paths. Since `st.Property` is an interface, calling `.Value()` on that nil panics.

`Silenced()` is the only `Property` caller in the repo that does not check:

- `pkg/demoinfocs/common/equipment.go:418` -- sibling `AmmoReserve()`: `if prop != nil && prop.Value().Any != nil {`
- `pkg/demoinfocs/common/inferno.go:81` -- `if prop := entity.Property(...); prop != nil {`
- `pkg/demoinfocs/datatables.go:893` -- `if bounceProp := entity.Property("m_nBounces"); bounceProp != nil {`
- the library's own `PropertyValue` (`entity.go:289`) and `PropertyValueMust` (`entity.go:301`) both nil-check

It also looks like a half-finished sweep: commit f0b5a7e "fix error if reserve-amo is nil (POV demos)" added exactly this guard, but only to `AmmoReserve()`. `Silenced()` was added in 5b10e5e and never revisited. `AmmoReserve` and `ZoomLevel` each have an `_EntityNil` test; `Silenced` had neither a nil-entity nor a missing-property test.

## Verification

- `go test -count=1 ./...` with the LFS demo fixtures pulled: every package green, zero FAIL lines.
- The repo's own `scripts/unit-tests.sh` (`go test -tags unassert_panic -short ./...`): all packages ok.
- Reverting the source change makes `TestEquipment_Silenced_PropertyMissing` fail with the SIGSEGV above.
- Over-correcting the other way (returning `false` unconditionally instead of reading the property) instead fails `TestEquipment_Silenced_On_Off`, while both new tests pass. The two failure sets are disjoint, so the tests pin both sides.
- `gofmt -l ./pkg ./internal ./examples` empty, `go vet ./...` clean, `golangci-lint` v2.13.2 (the version pinned at `.github/workflows/ci.yml:38`) reports 0 issues for `./pkg/demoinfocs/common/...`.

The new tests use the existing `entityWithProperties` helper from `pkg/demoinfocs/common/common_test.go`, whose catch-all `entity.On("Property", mock.Anything).Return(nil)` matches the real contract; the public mock at `pkg/demoinfocs/sendtables/fake/entity.go:51-61` behaves the same way.

## Prior art

Searched open and closed issues and PRs for `Silenced`, `m_bSilencerOn`, `silencer panic` and `nil pointer Property`. The nil-pointer reports (#654, #650, #638, #501, #458, #161, #121, #114, #99, #94, #38) are all closed and none touches `Silenced()`.

---

Disclosure: this change was prepared with AI assistance. I verified the panic, the history and every gate locally, and will handle review feedback myself.
